### PR TITLE
Fix database URL references

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
 
-engine = create_engine(settings.DATABASE_URL)
+engine = create_engine(settings.database_url)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/app/core/test_settings.py
+++ b/app/core/test_settings.py
@@ -3,5 +3,5 @@ from .config import Settings
 
 
 class TestSettings(Settings):
-    DATABASE_URL: str = "sqlite:///./db/test.db"
+    database_url: str = "sqlite:///./db/test.db"
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,5 +3,5 @@ from .config import Settings
 
 
 class TestSettings(Settings):
-    DATABASE_URL: str = "sqlite:///./db/test.db"
+    database_url: str = "sqlite:///./db/test.db"
 


### PR DESCRIPTION
## Summary
- use `settings.database_url` in core database helpers
- align test configuration to use lower-case `database_url`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*