### PR TITLE
Fix encryption settings usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ cp config.yaml.dist config.yaml
 
 5. Edit `config.yaml` to configure the application, connectors, and API keys.
 
-6. Run the `generate_key.sh` script to set a secret key for your application:
+6. Run the `generate_key.sh` script to set a secret key, along with the
+   `encryption_key` and `encryption_salt` values for your application:
 
 ```
 chmod +x generate_key.sh

--- a/app/core/encryption.py
+++ b/app/core/encryption.py
@@ -8,8 +8,8 @@ from app.core.config import get_settings
 class EncryptionManager:
     def __init__(self):
         settings = get_settings()
-        key = settings.ENCRYPTION_KEY
-        salt = settings.ENCRYPTION_SALT
+        key = settings.encryption_key
+        salt = settings.encryption_salt
         if key is None or salt is None:
             raise ValueError('No encryption key or salt provided in config.')
         self.key = key.encode()

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -34,3 +34,5 @@ port: 8000
 # how long before a session should close from the web ui
 access_token_expire_minutes: 1440
 algorithm: HS256
+encryption_key: "your_encryption_key"
+encryption_salt: "your_encryption_salt"


### PR DESCRIPTION
## Summary
- read `encryption_key` and `encryption_salt` from settings
- add placeholders for encryption keys in `config.yaml.dist`
- document `encryption_key` and `encryption_salt` in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*