### PR TITLE
Fix fixtures and config imports in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from app.core.test_settings import TestSettings
 test_settings = TestSettings()
 
 @pytest.fixture(scope="module")
-def test_client():
+def test_app():
     init_connectors(app, test_settings)
     with TestClient(app) as client:
         yield client

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -7,7 +7,7 @@ from app.core.config import settings
 from app.schemas.action import ActionCreate
 from app.tests.utils.utils import random_lower_string
 
-def test_create_action(client: TestClient, db: Session) -> None:
+def test_create_action(test_app: TestClient, db: Session) -> None:
     prompt = random_lower_string()
     execution_order = 1
     action_in = ActionCreate(prompt=prompt, execution_order=execution_order)
@@ -15,7 +15,7 @@ def test_create_action(client: TestClient, db: Session) -> None:
     assert action.prompt == prompt
     assert action.execution_order == execution_order
 
-def test_get_action(client: TestClient, db: Session) -> None:
+def test_get_action(test_app: TestClient, db: Session) -> None:
     prompt = random_lower_string()
     execution_order = 1
     action_in = ActionCreate(prompt=prompt, execution_order=execution_order)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,16 +4,16 @@ import pytest
 from app.schemas import Token
 
 
-def test_authenticate_user(test_client):
+def test_authenticate_user(test_app):
     # Test invalid email or password
-    response = test_client.post(
+    response = test_app.post(
         "/token",
         data={"username": "invalid@example.com", "password": "invalid_password"},
     )
     assert response.status_code == 400
 
     # Test successful authentication
-    response = test_client.post(
+    response = test_app.post(
         "/token",
         data={"username": "test@example.com", "password": "test_password"},
     )
@@ -23,19 +23,19 @@ def test_authenticate_user(test_client):
     assert token["token_type"] == "bearer"
 
 
-def test_protected_route(test_client):
+def test_protected_route(test_app):
     # Test access without a token
-    response = test_client.get("/some_protected_route")
+    response = test_app.get("/some_protected_route")
     assert response.status_code == 401
 
     # Test access with a valid token
-    response = test_client.post(
+    response = test_app.post(
         "/token",
         data={"username": "test@example.com", "password": "test_password"},
     )
     token = response.json()["access_token"]
 
-    response = test_client.get(
+    response = test_app.get(
         "/some_protected_route", headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == 200

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -7,7 +7,7 @@ from app.core.config import settings
 from app.schemas.bot import BotCreate
 from app.tests.utils.utils import random_lower_string
 
-def test_create_bot(client: TestClient, db: Session) -> None:
+def test_create_bot(test_app: TestClient, db: Session) -> None:
     gpt_model = "gpt-4"
     name = random_lower_string()
     bot_in = BotCreate(gpt_model=gpt_model, name=name)
@@ -15,7 +15,7 @@ def test_create_bot(client: TestClient, db: Session) -> None:
     assert bot.gpt_model == gpt_model
     assert bot.name == name
 
-def test_get_bot(client: TestClient, db: Session) -> None:
+def test_get_bot(test_app: TestClient, db: Session) -> None:
     gpt_model = "gpt-4"
     name = random_lower_string()
     bot_in = BotCreate(gpt_model=gpt_model, name=name)

--- a/tests/test_channel_filters.py
+++ b/tests/test_channel_filters.py
@@ -7,7 +7,7 @@ from app.core.config import settings
 from app.schemas.channel_filter import FilterCreate
 from app.tests.utils.utils import random_lower_string
 
-def test_create_channel_filter(client: TestClient, db: Session) -> None:
+def test_create_channel_filter(test_app: TestClient, db: Session) -> None:
     regex = r"helpdesk"
     description = random_lower_string()
     channel_filter_in = FilterCreate(regex=regex, description=description)
@@ -15,7 +15,7 @@ def test_create_channel_filter(client: TestClient, db: Session) -> None:
     assert channel_filter.regex == regex
     assert channel_filter.description == description
 
-def test_get_channel_filter(client: TestClient, db: Session) -> None:
+def test_get_channel_filter(test_app: TestClient, db: Session) -> None:
     regex = r"helpdesk"
     description = random_lower_string()
     channel_filter_in = FilterCreate(regex=regex, description=description)

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -7,7 +7,7 @@ from app.core.config import settings
 from app.schemas.connector import ConnectorCreate
 from app.tests.utils.utils import random_lower_string
 
-def test_create_connector(client: TestClient, db: Session) -> None:
+def test_create_connector(test_app: TestClient, db: Session) -> None:
     connector_type = "irc"
     name = random_lower_string()
     connector_in = ConnectorCreate(connector_type=connector_type, name=name)
@@ -15,7 +15,7 @@ def test_create_connector(client: TestClient, db: Session) -> None:
     assert connector.connector_type == connector_type
     assert connector.name == name
 
-def test_get_connector(client: TestClient, db: Session) -> None:
+def test_get_connector(test_app: TestClient, db: Session) -> None:
     connector_type = "irc"
     name = random_lower_string()
     connector_in = ConnectorCreate(connector_type=connector_type, name=name)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,5 @@
 # test/test_settings.py
-from .config import Settings
+from app.core.config import Settings
 
 
 class TestSettings(Settings):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -7,14 +7,14 @@ from app.core.config import settings
 from app.schemas.user import UserCreate
 from app.tests.utils.utils import random_email, random_lower_string
 
-def test_create_user(client: TestClient, db: Session) -> None:
+def test_create_user(test_app: TestClient, db: Session) -> None:
     email = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=email, password=password)
     user = crud.user.create(db, obj_in=user_in)
     assert user.email == email
 
-def test_get_user(client: TestClient, db: Session) -> None:
+def test_get_user(test_app: TestClient, db: Session) -> None:
     email = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=email, password=password)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -18,7 +18,7 @@ from app.endpoints import (
 )
 
 
-def test_webhook_process(test_client):
+def test_webhook_process(test_app):
     # Create a bot
     bot = BotCreate(name="TestBot")
     created_bot = create_bot(bot)


### PR DESCRIPTION
## Summary
- rename fixture to `test_app`
- update all tests to use `test_app`
- import `Settings` from `app.core.config`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*