### PR TITLE
Implement connectors router CRUD

### DIFF
--- a/app/api/api_v1/routers/connectors.py
+++ b/app/api/api_v1/routers/connectors.py
@@ -1,31 +1,52 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
 from typing import List
+
+from app import crud
 from app.schemas import ConnectorCreate, ConnectorUpdate, Connector
+from app.api.deps import get_db
 
 router = APIRouter()
 
-@router.post("/connectors/", response_model=Connector)
-async def create_connector(connector: ConnectorCreate):
-    # Logic to create a new connector
-    pass
+@router.post("/connectors/", response_model=Connector, status_code=201)
+async def create_connector(
+    connector: ConnectorCreate, db: Session = Depends(get_db)
+):
+    try:
+        return crud.connector.create(db, obj_in=connector)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 @router.get("/connectors/", response_model=List[Connector])
-async def get_connectors():
-    # Logic to get all connectors
-    pass
+async def get_connectors(db: Session = Depends(get_db)):
+    connectors = crud.connector.get_multi(db)
+    return connectors
 
 @router.get("/connectors/{connector_id}", response_model=Connector)
-async def get_connector(connector_id: int):
-    # Logic to get a specific connector by ID
-    pass
+async def get_connector(connector_id: int, db: Session = Depends(get_db)):
+    connector = crud.connector.get(db, connector_id)
+    if not connector:
+        raise HTTPException(status_code=404, detail="Connector not found")
+    return connector
 
 @router.put("/connectors/{connector_id}", response_model=Connector)
-async def update_connector(connector_id: int, connector: ConnectorUpdate):
-    # Logic to update an existing connector
-    pass
+async def update_connector(
+    connector_id: int,
+    connector: ConnectorUpdate,
+    db: Session = Depends(get_db),
+):
+    db_connector = crud.connector.get(db, connector_id)
+    if not db_connector:
+        raise HTTPException(status_code=404, detail="Connector not found")
+    try:
+        return crud.connector.update(db, db_obj=db_connector, obj_in=connector)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
-@router.delete("/connectors/{connector_id}")
-async def delete_connector(connector_id: int):
-    # Logic to delete a connector
-    pass
+@router.delete("/connectors/{connector_id}", response_model=Connector)
+async def delete_connector(connector_id: int, db: Session = Depends(get_db)):
+    connector = crud.connector.remove(db, connector_id)
+    if not connector:
+        raise HTTPException(status_code=404, detail="Connector not found")
+    return connector
 

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -4,3 +4,5 @@ from .bot import (
     delete_bot,
     update_bot,
 )
+
+from . import bot, connector

--- a/app/crud/connector.py
+++ b/app/crud/connector.py
@@ -1,0 +1,37 @@
+from typing import List, Optional
+from sqlalchemy.orm import Session
+
+from app.models.connectors import Connector as ConnectorModel
+from app.schemas.connector import ConnectorCreate, ConnectorUpdate
+
+
+def get(db: Session, connector_id: int) -> Optional[ConnectorModel]:
+    return db.query(ConnectorModel).filter(ConnectorModel.id == connector_id).first()
+
+
+def get_multi(db: Session, skip: int = 0, limit: int = 100) -> List[ConnectorModel]:
+    return db.query(ConnectorModel).offset(skip).limit(limit).all()
+
+
+def create(db: Session, obj_in: ConnectorCreate) -> ConnectorModel:
+    db_obj = ConnectorModel(**obj_in.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def update(db: Session, db_obj: ConnectorModel, obj_in: ConnectorUpdate) -> ConnectorModel:
+    for field, value in obj_in.dict(exclude_unset=True).items():
+        setattr(db_obj, field, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def remove(db: Session, connector_id: int) -> Optional[ConnectorModel]:
+    obj = get(db, connector_id)
+    if obj:
+        db.delete(obj)
+        db.commit()
+    return obj


### PR DESCRIPTION
## Summary
- add CRUD helper for connectors
- expose new module via `app.crud`
- flesh out `/connectors` API routes with error handling

## Testing
- `python -m py_compile app/api/api_v1/routers/connectors.py app/crud/connector.py app/crud/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*