### PR TITLE
Fix imports in tests package

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,7 @@
-from .connectors import test_irc, test_slack, test_telegram, test_teams, test_discord, test_google_chat
+"""Expose available test modules for discovery."""
+
+# Only import tests that actually exist to avoid ImportError during test
+# collection. Currently the connectors package only includes IRC and Slack
+# tests.
+from .connectors import test_irc, test_slack
 from . import test_routers, test_actions, test_filters


### PR DESCRIPTION
## Summary
- simplify `tests/__init__.py` imports to only include existing test modules

## Testing
- `pytest -q` *(fails: ValueError: 'not' is not a valid parameter name)*