### PR TITLE
Add db fixture to tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.connectors import init_connectors
 from app.core.test_settings import TestSettings
+from app.api.deps import get_db
 
 test_settings = TestSettings()
 
@@ -12,4 +13,10 @@ def test_app():
     init_connectors(app, test_settings)
     with TestClient(app) as client:
         yield client
+
+
+@pytest.fixture(scope="function")
+def db():
+    with get_db() as session:
+        yield session
 


### PR DESCRIPTION
## Summary
- ensure tests can access a database session by adding a `db` fixture

## Testing
- `pytest -q` *(fails: ImportError due to pydantic incompatibility)*