### PR TITLE
Add custom exceptions

### DIFF
--- a/app/TODO.md
+++ b/app/TODO.md
@@ -4,7 +4,7 @@ This document outlines the remaining tasks to complete and improve the Norman pr
 
 ## Core
 
-- [ ] Add additional exception classes in `app/core/exceptions.py` to handle specific error scenarios.
+- [x] Add additional exception classes in `app/core/exceptions.py` to handle specific error scenarios.
 - [ ] Improve logging configuration and log messages in `app/core/logging.py`.
 - [x] Review and optimize the configuration loading in `app/core/config.py`.
 

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -38,3 +38,23 @@ class BotError(NormanError):
     Raised when there's an issue with a bot or bot-related operation.
     """
     pass
+
+
+class DatabaseError(NormanError):
+    """Raised when a database operation fails."""
+    pass
+
+
+class APIError(NormanError):
+    """Raised when an unexpected API error occurs."""
+    pass
+
+
+class AuthenticationError(NormanError):
+    """Raised when authentication fails."""
+    pass
+
+
+class AuthorizationError(NormanError):
+    """Raised when a user is not authorized to perform an action."""
+    pass

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,4 +4,4 @@
 # collection. Currently the connectors package only includes IRC and Slack
 # tests.
 from .connectors import test_irc, test_slack
-from . import test_routers, test_actions, test_filters
+from . import test_routers, test_actions, test_filters, test_exceptions

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,20 @@
+import pytest
+from app.core import exceptions
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        exceptions.ConfigurationError,
+        exceptions.ChannelError,
+        exceptions.FilterError,
+        exceptions.ConnectorError,
+        exceptions.BotError,
+        exceptions.DatabaseError,
+        exceptions.APIError,
+        exceptions.AuthenticationError,
+        exceptions.AuthorizationError,
+    ],
+)
+def test_subclass_of_norman_error(exc):
+    assert issubclass(exc, exceptions.NormanError)


### PR DESCRIPTION
## Summary
- add DatabaseError, APIError, AuthenticationError, and AuthorizationError classes
- mark exceptions task done in TODO
- verify all custom exceptions inherit from NormanError

## Testing
- `pytest -q` *(fails: ValueError during Pydantic model generation)*