### PR TITLE
Add config initialization to connectors

### DIFF
--- a/app/connectors/base_connector.py
+++ b/app/connectors/base_connector.py
@@ -3,6 +3,15 @@ from abc import ABC, abstractmethod
 
 
 class BaseConnector(ABC):
+
+    def __init__(self, config=None):
+        """Initialize the connector with optional configuration.
+
+        Args:
+            config (dict | None): Optional configuration dictionary.  If not
+                provided, an empty dict is used.
+        """
+        self.config = config or {}
     @abstractmethod
     async def send_message(self, message):
         """Send a message using the connector.

--- a/app/connectors/discord_connector.py
+++ b/app/connectors/discord_connector.py
@@ -6,7 +6,8 @@ class DiscordConnector(BaseConnector):
     id = 'discord'
     name = 'Discord'
 
-    def __init__(self, token: str, channel_id: str):
+    def __init__(self, token: str, channel_id: str, config=None):
+        super().__init__(config)
         self.token = token
         self.channel_id = channel_id
 

--- a/app/connectors/google_chat_connector.py
+++ b/app/connectors/google_chat_connector.py
@@ -6,7 +6,8 @@ class GoogleChatConnector(BaseConnector):
     id = 'google_chat'
     name = 'Google Chat'
 
-    def __init__(self, service_account_key_path: str, space: str):
+    def __init__(self, service_account_key_path: str, space: str, config=None):
+        super().__init__(config)
         self.service_account_key_path = service_account_key_path
         self.space = space
 

--- a/app/connectors/slack_connector.py
+++ b/app/connectors/slack_connector.py
@@ -8,7 +8,8 @@ class SlackConnector(BaseConnector):
     id = 'slack'
     name = 'Slack'
 
-    def __init__(self, token: str, channel_id: str):
+    def __init__(self, token: str, channel_id: str, config=None):
+        super().__init__(config)
         self.token = token
         self.channel_id = channel_id
         self.client = WebClient(token=self.token)

--- a/app/connectors/teams_connector.py
+++ b/app/connectors/teams_connector.py
@@ -6,7 +6,8 @@ class TeamsConnector(BaseConnector):
     id = 'teams'
     name = 'Teams'
 
-    def __init__(self, app_id, app_password, tenant_id, bot_endpoint):
+    def __init__(self, app_id, app_password, tenant_id, bot_endpoint, config=None):
+        super().__init__(config)
         self.app_id = app_id
         self.app_password = app_password
         self.tenant_id = tenant_id

--- a/app/connectors/telegram_connector.py
+++ b/app/connectors/telegram_connector.py
@@ -7,7 +7,8 @@ class TelegramConnector(BaseConnector):
     id = 'telegram'
     name = 'Telegram'
 
-    def __init__(self, token: str, chat_id: str):
+    def __init__(self, token: str, chat_id: str, config=None):
+        super().__init__(config)
         self.token = token
         self.chat_id = chat_id
 


### PR DESCRIPTION
## Summary
- allow `BaseConnector` to store optional config
- initialize connector config in Slack, Discord, Google Chat, Teams, and Telegram connectors

## Testing
- `pytest -q` *(fails: ImportError while loading conftest due to missing dependencies)*