### PR TITLE
Add main() entrypoint for uvicorn

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,11 @@ app.mount("/static", StaticFiles(directory=os.path.join(current_dir, "app/static
 # Include app_routes
 app.include_router(app_routes)
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run the FastAPI application using Uvicorn."""
     uvicorn.run(app, host=settings.host, port=settings.port, debug=settings.debug)
+
+
+if __name__ == "__main__":
+    main()
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "norman = norman.app:main",
+            "norman = main:main",
         ],
     },
 )


### PR DESCRIPTION
## Summary
- create a `main` function that runs uvicorn
- call `main()` in the module guard
- update `setup.py` console script entry point

## Testing
- `pytest -q` *(fails: ForwardRef._evaluate() missing 1 required keyword-only argument)*