### PR TITLE
Fix Base import in connectors model

### DIFF
--- a/app/models/connectors.py
+++ b/app/models/connectors.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime, JSON
 from sqlalchemy.sql import func
-from app.database import Base
+from app.db.base import Base
 
 
 class Connector(Base):


### PR DESCRIPTION
## Summary
- import Base from `app.db.base` in `connectors` model

## Testing
- `pytest -q` *(fails: ForwardRef._evaluate() missing argument due to Python version/Pydantic compatibility)*