### PR TITLE
Update test settings to preload config

### DIFF
--- a/app/core/test_settings.py
+++ b/app/core/test_settings.py
@@ -1,7 +1,11 @@
 # app/core/test_settings.py
-from .config import Settings
+from .config import Settings, load_config
 
 
 class TestSettings(Settings):
-    database_url: str = "sqlite:///./db/test.db"
+    class Config(Settings.Config):
+        env_prefix = ""
+
+test_defaults = load_config()
+TestSettings = Settings(**{**test_defaults, "database_url": "sqlite:///./db/test.db"})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from app.connectors import init_connectors
 from app.core.test_settings import TestSettings
 from app.api.deps import get_db
 
-test_settings = TestSettings()
+test_settings = TestSettings
 
 @pytest.fixture(scope="module")
 def test_app():


### PR DESCRIPTION
## Summary
- preload defaults in `TestSettings` using `load_config`
- adjust tests to use the `TestSettings` instance

## Testing
- `pytest -q` *(fails: ForwardRef._evaluate missing 'recursive_guard')*