### PR TITLE
Add channel CRUD operations

### DIFF
--- a/app/api/api_v1/routers/channels.py
+++ b/app/api/api_v1/routers/channels.py
@@ -1,34 +1,57 @@
+"""API routes for :class:`~app.models.channel.Channel`."""
+
 from typing import List
-from fastapi import APIRouter, HTTPException
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api.deps import get_db
 from app.schemas import ChannelCreate, ChannelUpdate, Channel
 
 router = APIRouter()
 
 # Your endpoints and handlers go here
 
-@router.post("/channels/", response_model=Channel)
-async def create_channel(channel: ChannelCreate):
-    # Logic to create a new channel
-    pass
+@router.post("/channels/", response_model=Channel, status_code=status.HTTP_201_CREATED)
+async def create_channel(
+    channel: ChannelCreate, db: Session = Depends(get_db)
+):
+    """Create a new channel."""
+    try:
+        return crud.channel.create(db, obj_in=channel)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 @router.get("/channels/", response_model=List[Channel])
-async def get_channels():
-    # Logic to get all channels
-    pass
+async def get_channels(db: Session = Depends(get_db)):
+    """Return all channels."""
+    return crud.channel.get_multi(db)
 
 @router.get("/channels/{channel_id}", response_model=Channel)
-async def get_channel(channel_id: int):
-    # Logic to get a specific channel by ID
-    pass
+async def get_channel(channel_id: int, db: Session = Depends(get_db)):
+    """Return a channel by ID."""
+    channel = crud.channel.get(db, channel_id)
+    if not channel:
+        raise HTTPException(status_code=404, detail="Channel not found")
+    return channel
 
 @router.put("/channels/{channel_id}", response_model=Channel)
-async def update_channel(channel_id: int, channel: ChannelUpdate):
-    # Logic to update an existing channel
-    pass
+async def update_channel(
+    channel_id: int, channel: ChannelUpdate, db: Session = Depends(get_db)
+):
+    """Update a channel."""
+    db_channel = crud.channel.get(db, channel_id)
+    if not db_channel:
+        raise HTTPException(status_code=404, detail="Channel not found")
+    return crud.channel.update(db, db_obj=db_channel, obj_in=channel)
 
-@router.delete("/channels/{channel_id}")
-async def delete_channel(channel_id: int):
-    # Logic to delete a channel
-    pass
+@router.delete("/channels/{channel_id}", response_model=Channel)
+async def delete_channel(channel_id: int, db: Session = Depends(get_db)):
+    """Delete a channel."""
+    channel = crud.channel.remove(db, channel_id)
+    if not channel:
+        raise HTTPException(status_code=404, detail="Channel not found")
+    return channel
 
 

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -5,4 +5,4 @@ from .bot import (
     update_bot,
 )
 
-from . import bot, connector
+from . import bot, connector, channel

--- a/app/crud/channel.py
+++ b/app/crud/channel.py
@@ -1,11 +1,45 @@
+"""CRUD operations for :class:`~app.models.channel.Channel`."""
+
+from typing import List, Optional
+
 from sqlalchemy.orm import Session
-from . import models
 
-def get_channel_by_id(db: Session, channel_id: int):
-    return db.query(models.Channel).filter(models.Channel.id == channel_id).first()
+from app.models.channel import Channel as ChannelModel
+from app.schemas.channel import ChannelCreate, ChannelUpdate
 
-def create_channel(db: Session, channel: models.Channel):
-    db.add(channel)
+
+def get(db: Session, channel_id: int) -> Optional[ChannelModel]:
+    """Return a channel by its ID."""
+    return db.query(ChannelModel).filter(ChannelModel.id == channel_id).first()
+
+
+def get_multi(db: Session, skip: int = 0, limit: int = 100) -> List[ChannelModel]:
+    """Return multiple channels."""
+    return db.query(ChannelModel).offset(skip).limit(limit).all()
+
+
+def create(db: Session, obj_in: ChannelCreate) -> ChannelModel:
+    """Create a new channel."""
+    db_obj = ChannelModel(name=obj_in.name)
+    db.add(db_obj)
     db.commit()
-    db.refresh(channel)
-    return channel
+    db.refresh(db_obj)
+    return db_obj
+
+
+def update(db: Session, db_obj: ChannelModel, obj_in: ChannelUpdate) -> ChannelModel:
+    """Update an existing channel."""
+    for field, value in obj_in.dict(exclude_unset=True).items():
+        setattr(db_obj, field, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def remove(db: Session, channel_id: int) -> Optional[ChannelModel]:
+    """Delete a channel and return the deleted instance."""
+    obj = get(db, channel_id)
+    if obj:
+        db.delete(obj)
+        db.commit()
+    return obj

--- a/tests/test_channels_api.py
+++ b/tests/test_channels_api.py
@@ -1,0 +1,40 @@
+import json
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_channel_crud(db: Session):
+    # Create channel
+    response = client.post("/api/v1/channels/", json={"name": "test", "connector_id": 1})
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "test"
+    channel_id = data["id"]
+
+    # Get channel
+    response = client.get(f"/api/v1/channels/{channel_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == channel_id
+
+    # Update channel
+    response = client.put(f"/api/v1/channels/{channel_id}", json={"name": "updated", "connector_id": 1})
+    assert response.status_code == 200
+    assert response.json()["name"] == "updated"
+
+    # List channels
+    response = client.get("/api/v1/channels/")
+    assert response.status_code == 200
+    assert any(ch["id"] == channel_id for ch in response.json())
+
+    # Delete channel
+    response = client.delete(f"/api/v1/channels/{channel_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == channel_id
+
+    # Verify deletion
+    response = client.get(f"/api/v1/channels/{channel_id}")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- flesh out `crud.channel` with standard CRUD helpers
- implement full REST endpoints in `channels.py`
- expose `crud.channel` in package init
- add API tests for channel endpoints

## Testing
- `flake8`
- `pytest -q` *(fails: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard')*