### PR TITLE
Fix connectors schema

### DIFF
--- a/app/models/connectors.py
+++ b/app/models/connectors.py
@@ -7,7 +7,7 @@ class Connector(Base):
     __tablename__ = "connectors"
 
     id = Column(Integer, primary_key=True, index=True)
-    description = Column(String)
+    name = Column(String)
     connector_type = Column(String, index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/app/schemas/connector.py
+++ b/app/schemas/connector.py
@@ -2,7 +2,7 @@ from typing import List, Dict, Any
 from pydantic import BaseModel
 
 class ConnectorBase(BaseModel):
-    description: str
+    name: str
     config: Dict[str, Any]
     connector_type: str
 

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -10,7 +10,7 @@ from app.tests.utils.utils import random_lower_string
 def test_create_connector(test_app: TestClient, db: Session) -> None:
     connector_type = "irc"
     name = random_lower_string()
-    connector_in = ConnectorCreate(connector_type=connector_type, name=name)
+    connector_in = ConnectorCreate(connector_type=connector_type, name=name, config={})
     connector = crud.connector.create(db, obj_in=connector_in)
     assert connector.connector_type == connector_type
     assert connector.name == name
@@ -18,7 +18,7 @@ def test_create_connector(test_app: TestClient, db: Session) -> None:
 def test_get_connector(test_app: TestClient, db: Session) -> None:
     connector_type = "irc"
     name = random_lower_string()
-    connector_in = ConnectorCreate(connector_type=connector_type, name=name)
+    connector_in = ConnectorCreate(connector_type=connector_type, name=name, config={})
     connector = crud.connector.create(db, obj_in=connector_in)
     connector_2 = crud.connector.get(db, connector.id)
     assert connector_2


### PR DESCRIPTION
## Summary
- align `Connector` schema and model on `name` attribute
- update tests to use new schema

## Testing
- `pytest -q` *(fails: ImportError from pydantic with Python 3.12)*