### PR TITLE
Inject settings into webhook router

### DIFF
--- a/app/api/api_v1/routers/connectors/webhook.py
+++ b/app/api/api_v1/routers/connectors/webhook.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter, Depends, Request
 from app.connectors.webhook_connector import WebhookConnector
+from app.core.config import get_settings, Settings
 
 router = APIRouter()
 
-def get_webhook_connector() -> WebhookConnector:
-    return WebhookConnector()
+def get_webhook_connector(settings: Settings = Depends(get_settings)) -> WebhookConnector:
+    return WebhookConnector(settings.webhook_secret)
 
 @router.post("/webhooks/webhook")
 async def process_webhook_update(request: Request, webhook_connector: WebhookConnector = Depends(get_webhook_connector)):

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -1,0 +1,7 @@
+from app.api.api_v1.routers.connectors.webhook import get_webhook_connector
+from app.core.test_settings import TestSettings
+
+
+def test_get_webhook_connector_uses_settings():
+    connector = get_webhook_connector(TestSettings)
+    assert connector.webhook_url == TestSettings.webhook_secret


### PR DESCRIPTION
## Summary
- inject `Settings` dependency for webhook router
- use the webhook secret from the app settings when constructing `WebhookConnector`
- add a simple unit test covering the new behaviour

## Testing
- `pytest -q` *(fails: ForwardRef._evaluate() missing 1 required keyword-only argument)*