### PR TITLE
Fix connector router init args

### DIFF
--- a/app/api/api_v1/routers/connectors/discord.py
+++ b/app/api/api_v1/routers/connectors/discord.py
@@ -5,7 +5,12 @@ from app.core.config import get_settings, Settings
 router = APIRouter()
 
 def get_discord_connector(settings: Settings = Depends(get_settings)) -> DiscordConnector:
-    return DiscordConnector(token=settings.discord_token)
+    """Instantiate :class:`DiscordConnector` using ``Settings`` values."""
+
+    return DiscordConnector(
+        token=settings.discord_token,
+        channel_id=settings.discord_channel_id,
+    )
 
 @router.post("/webhooks/discord")
 async def process_discord_update(request: Request, discord_connector: DiscordConnector = Depends(get_discord_connector)):

--- a/app/api/api_v1/routers/connectors/google_chat.py
+++ b/app/api/api_v1/routers/connectors/google_chat.py
@@ -5,7 +5,12 @@ from app.core.config import get_settings, Settings
 router = APIRouter()
 
 def get_google_chat_connector(settings: Settings = Depends(get_settings)) -> GoogleChatConnector:
-    return GoogleChatConnector(credentials=settings.google_chat_credentials)
+    """Instantiate :class:`GoogleChatConnector` using ``Settings`` values."""
+
+    return GoogleChatConnector(
+        service_account_key_path=settings.google_chat_service_account_key_path,
+        space=settings.google_chat_space,
+    )
 
 @router.post("/webhooks/google_chat")
 async def process_google_chat_update(request: Request, google_chat_connector: GoogleChatConnector = Depends(get_google_chat_connector)):

--- a/app/api/api_v1/routers/connectors/teams.py
+++ b/app/api/api_v1/routers/connectors/teams.py
@@ -5,7 +5,14 @@ from app.core.config import get_settings, Settings
 router = APIRouter()
 
 def get_teams_connector(settings: Settings = Depends(get_settings)) -> TeamsConnector:
-    return TeamsConnector(client_id=settings.teams_client_id, client_secret=settings.teams_client_secret, tenant_id=settings.teams_tenant_id)
+    """Instantiate :class:`TeamsConnector` using ``Settings`` values."""
+
+    return TeamsConnector(
+        app_id=settings.teams_app_id,
+        app_password=settings.teams_app_password,
+        tenant_id=settings.teams_tenant_id,
+        bot_endpoint=settings.teams_bot_endpoint,
+    )
 
 @router.post("/webhooks/teams")
 async def process_teams_update(request: Request, teams_connector: TeamsConnector = Depends(get_teams_connector)):

--- a/app/api/api_v1/routers/connectors/webhook.py
+++ b/app/api/api_v1/routers/connectors/webhook.py
@@ -1,10 +1,13 @@
 from fastapi import APIRouter, Depends, Request
 from app.connectors.webhook_connector import WebhookConnector
+from app.core.config import get_settings, Settings
 
 router = APIRouter()
 
-def get_webhook_connector() -> WebhookConnector:
-    return WebhookConnector()
+def get_webhook_connector(settings: Settings = Depends(get_settings)) -> WebhookConnector:
+    """Instantiate :class:`WebhookConnector` using ``Settings`` values."""
+
+    return WebhookConnector(webhook_url=settings.webhook_webhook_url)
 
 @router.post("/webhooks/webhook")
 async def process_webhook_update(request: Request, webhook_connector: WebhookConnector = Depends(get_webhook_connector)):

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
     teams_tenant_id: str
     teams_bot_endpoint: str
     webhook_secret: str
+    webhook_webhook_url: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -20,6 +20,7 @@ teams_app_password: "your_teams_app_password"
 teams_tenant_id: "your_teams_tenant_id"
 teams_bot_endpoint: "your_teams_bot_endpoint"
 webhook_secret: "your_webhook_secret"
+webhook_webhook_url: "https://example.com/webhook"
 
 openai_api_key: 
 

--- a/tests/test_connector_router_creation.py
+++ b/tests/test_connector_router_creation.py
@@ -1,0 +1,26 @@
+"""Tests for connector routers to ensure connectors instantiate without errors."""
+
+from fastapi.testclient import TestClient
+
+
+def _post_and_check(client: TestClient, url: str) -> None:
+    """Helper to post empty payload to ``url`` and assert a successful response."""
+
+    response = client.post(url, json={})
+    assert response.status_code == 200
+    assert response.json() == {"detail": "Update processed"}
+
+
+def test_connector_routes_create(test_app: TestClient) -> None:
+    base = "/api/v1/connectors"
+    endpoints = [
+        f"{base}/telegram/webhooks/telegram",
+        f"{base}/discord/webhooks/discord",
+        f"{base}/google_chat/webhooks/google_chat",
+        f"{base}/microsoft_teams/webhooks/teams",
+        f"{base}/webhook/webhooks/webhook",
+    ]
+
+    for url in endpoints:
+        _post_and_check(test_app, url)
+


### PR DESCRIPTION
## Summary
- hook up connectors router dependencies to Settings
- allow WebhookConnector URL config
- test that connector routers instantiate

## Testing
- `pytest -q` *(fails: ForwardRef._evaluate() missing recursive_guard)*