### PR TITLE
Add CRUD helpers for actions

### DIFF
--- a/app/crud/action.py
+++ b/app/crud/action.py
@@ -1,11 +1,52 @@
+"""CRUD helpers for :class:`~app.models.action.Action`."""
+
+from typing import Optional
+
 from sqlalchemy.orm import Session
-from . import models
 
-def get_action_by_id(db: Session, action_id: int):
-    return db.query(models.Action).filter(models.Action.id == action_id).first()
+from app.models.action import Action as ActionModel
+from app.schemas.action import ActionCreate, ActionUpdate
 
-def create_action(db: Session, action: models.Action):
-    db.add(action)
+
+def get(db: Session, action_id: int) -> Optional[ActionModel]:
+    """Return an action by its ID."""
+
+    return db.query(ActionModel).filter(ActionModel.id == action_id).first()
+
+
+def create(db: Session, obj_in: ActionCreate) -> ActionModel:
+    """Create a new action."""
+
+    db_obj = ActionModel(
+        channel_filter_id=obj_in.channel_filter_id,
+        prompt=obj_in.prompt,
+        reply_to=obj_in.reply_channel_id,
+        execution_order=obj_in.execution_order,
+    )
+    db.add(db_obj)
     db.commit()
-    db.refresh(action)
-    return action
+    db.refresh(db_obj)
+    return db_obj
+
+
+def update(db: Session, db_obj: ActionModel, obj_in: ActionUpdate) -> ActionModel:
+    """Update an existing action."""
+
+    update_data = obj_in.dict(exclude_unset=True)
+    if "reply_channel_id" in update_data:
+        db_obj.reply_to = update_data.pop("reply_channel_id")
+    for field, value in update_data.items():
+        setattr(db_obj, field, value)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def remove(db: Session, action_id: int) -> Optional[ActionModel]:
+    """Delete an action and return the deleted instance."""
+
+    obj = get(db, action_id)
+    if obj:
+        db.delete(obj)
+        db.commit()
+    return obj

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -4,13 +4,18 @@ from sqlalchemy.orm import Session
 
 from app import crud, models
 from app.core.config import settings
-from app.schemas.action import ActionCreate
+from app.schemas.action import ActionCreate, ActionUpdate
 from app.tests.utils.utils import random_lower_string
 
 def test_create_action(test_app: TestClient, db: Session) -> None:
     prompt = random_lower_string()
     execution_order = 1
-    action_in = ActionCreate(prompt=prompt, execution_order=execution_order)
+    action_in = ActionCreate(
+        channel_filter_id=1,
+        prompt=prompt,
+        reply_channel_id=1,
+        execution_order=execution_order,
+    )
     action = crud.action.create(db, obj_in=action_in)
     assert action.prompt == prompt
     assert action.execution_order == execution_order
@@ -18,10 +23,49 @@ def test_create_action(test_app: TestClient, db: Session) -> None:
 def test_get_action(test_app: TestClient, db: Session) -> None:
     prompt = random_lower_string()
     execution_order = 1
-    action_in = ActionCreate(prompt=prompt, execution_order=execution_order)
+    action_in = ActionCreate(
+        channel_filter_id=1,
+        prompt=prompt,
+        reply_channel_id=1,
+        execution_order=execution_order,
+    )
     action = crud.action.create(db, obj_in=action_in)
     action_2 = crud.action.get(db, action.id)
     assert action_2
     assert action.prompt == action_2.prompt
     assert action.execution_order == action_2.execution_order
     assert action.id == action_2.id
+
+
+def test_update_action(test_app: TestClient, db: Session) -> None:
+    prompt = random_lower_string()
+    action_in = ActionCreate(
+        channel_filter_id=1,
+        prompt=prompt,
+        reply_channel_id=1,
+        execution_order=1,
+    )
+    action = crud.action.create(db, obj_in=action_in)
+    new_prompt = random_lower_string()
+    action_up = ActionUpdate(
+        channel_filter_id=1,
+        prompt=new_prompt,
+        reply_channel_id=1,
+        execution_order=2,
+    )
+    updated = crud.action.update(db, db_obj=action, obj_in=action_up)
+    assert updated.prompt == new_prompt
+    assert updated.execution_order == 2
+
+
+def test_remove_action(test_app: TestClient, db: Session) -> None:
+    action_in = ActionCreate(
+        channel_filter_id=1,
+        prompt=random_lower_string(),
+        reply_channel_id=1,
+        execution_order=1,
+    )
+    action = crud.action.create(db, obj_in=action_in)
+    removed = crud.action.remove(db, action.id)
+    assert removed.id == action.id
+    assert crud.action.get(db, action.id) is None


### PR DESCRIPTION
## Summary
- implement create, get, update and remove in `app/crud/action.py`
- extend tests for action CRUD operations

## Testing
- `pytest tests/test_actions.py::test_create_action -q` *(fails: ImportError while loading conftest)*