### PR TITLE
Add coverage badge and reporting

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -29,5 +29,13 @@ jobs:
       - name: Run pylint
         run: pylint --rcfile=.pylintrc $(git ls-files '*.py') || true
 
-      - name: Run tests
-        run: pytest -vv
+      - name: Run tests with coverage
+        run: |
+          coverage run -m pytest -vv
+          coverage xml
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ config.yaml
 
 # ignore user databases
 db/*.db
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Norman
 
+[![Codecov](https://codecov.io/gh/KristopherKubicki/norman/branch/main/graph/badge.svg)](https://codecov.io/gh/KristopherKubicki/norman)
+
 Norman is an open-source chatbot that leverages OpenAI's GPT models to assist and automate communication on various chat platforms like Slack and IRC. The project is built with FastAPI, SQLite, and SQLAlchemy, and is designed to be easily extensible with additional connectors.
 
 ![krstopher_abstract_readme_header_graphic_for_a_chatbot_software_a578ebda-8121-4195-ba94-7c5128049da3 (1)](https://user-images.githubusercontent.com/478212/235266088-7f69c1bd-e3db-4b80-b8ff-64c5785f55b7.png)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 # Development and testing dependencies
 pytest==6.2.5
 pytest-asyncio==0.16.0
+coverage==7.4.4


### PR DESCRIPTION
## Summary
- enable coverage generation in CI and upload results to Codecov
- ignore generated coverage.xml file
- track coverage dependency in `requirements-dev.txt`
- display Codecov badge in README

## Testing
- `pytest -q`