### PR TITLE
Add Codecov token to CI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           files: coverage.xml
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- provide Codecov token for coverage upload

## Testing
- `pytest -q`