### PR TITLE
Add tests for connector utilities

### DIFF
--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -1,0 +1,35 @@
+import sys
+import types
+
+# Provide a minimal slack_sdk stub if the real package isn't installed
+if 'slack_sdk' not in sys.modules:
+    slack_sdk = types.ModuleType('slack_sdk')
+
+    class DummyClient:
+        def __init__(self, token=None):
+            self.token = token
+        def auth_test(self):
+            return {'ok': True}
+    slack_sdk.WebClient = DummyClient
+    errors_mod = types.ModuleType('slack_sdk.errors')
+    slack_sdk.errors = errors_mod
+    sys.modules['slack_sdk'] = slack_sdk
+    sys.modules['slack_sdk.errors'] = errors_mod
+
+from app.connectors.connector_utils import get_connector, get_connectors_data
+from app.connectors.slack_connector import SlackConnector
+from app.core.test_settings import TestSettings
+
+
+def test_get_connector_returns_slack(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('slack')
+    assert isinstance(connector, SlackConnector)
+
+
+def test_get_connectors_data_missing_config(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    data = get_connectors_data()
+    assert all(item['status'] == 'missing_config' for item in data)
+    slack_data = next(item for item in data if item['id'] == 'slack')
+    assert slack_data['status'] == 'missing_config'


### PR DESCRIPTION
## Summary
- test `get_connector` to ensure Slack connector is returned
- verify `get_connectors_data` marks all connectors missing when using placeholder values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ab8ca53d083339e99365c01944c08