### PR TITLE
Fix ForwardRef handling by version

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,13 +2,20 @@
 
 from typing import ForwardRef, Any, cast
 import inspect
+import sys
 import pydantic.typing as _pydantic_typing
 
 # Pydantic 1.x doesn't support Python 3.12's updated ForwardRef._evaluate
 sig = inspect.signature(ForwardRef._evaluate)
-if 'recursive_guard' in sig.parameters:
+py_ver = sys.version_info
+if py_ver >= (3, 12) and 'recursive_guard' in sig.parameters:
     def _evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         return cast(Any, type_)._evaluate(globalns, localns, None, recursive_guard=set())
+
+    _pydantic_typing.evaluate_forwardref = _evaluate_forwardref
+elif py_ver < (3, 12) and 'recursive_guard' not in sig.parameters:
+    def _evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
+        return cast(Any, type_)._evaluate(globalns, localns, None)
 
     _pydantic_typing.evaluate_forwardref = _evaluate_forwardref
 


### PR DESCRIPTION
## Summary
- patch `_evaluate_forwardref` based on `sys.version_info`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ab8bfc4e48333abd718944c45f01d