### PR TITLE
Add Matrix and WhatsApp connector skeletons

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -12,6 +12,8 @@ from .discord_connector import DiscordConnector
 from .teams_connector import TeamsConnector
 from .telegram_connector import TelegramConnector
 from .webhook_connector import WebhookConnector
+from .whatsapp_connector import WhatsAppConnector
+from .matrix_connector import MatrixConnector
 
 from .connector_utils import get_connector
 
@@ -21,3 +23,15 @@ def init_connectors(app: FastAPI, settings: Settings):
     app.state.google_chat_connector = GoogleChatConnector(service_account_key_path=settings.google_chat_service_account_key_path, space=settings.google_chat_space)
     app.state.discord_connector = DiscordConnector(token=settings.discord_token, channel_id=settings.discord_channel_id)
     app.state.teams_connector = TeamsConnector(app_id=settings.teams_app_id, app_password=settings.teams_app_password, tenant_id=settings.teams_tenant_id, bot_endpoint=settings.teams_bot_endpoint)
+    app.state.whatsapp_connector = WhatsAppConnector(
+        account_sid=settings.whatsapp_account_sid,
+        auth_token=settings.whatsapp_auth_token,
+        from_number=settings.whatsapp_from_number,
+        to_number=settings.whatsapp_to_number,
+    )
+    app.state.matrix_connector = MatrixConnector(
+        homeserver=settings.matrix_homeserver,
+        user_id=settings.matrix_user_id,
+        access_token=settings.matrix_access_token,
+        room_id=settings.matrix_room_id,
+    )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -22,6 +22,8 @@ from .slack_connector import SlackConnector
 from .teams_connector import TeamsConnector
 from .telegram_connector import TelegramConnector
 from .webhook_connector import WebhookConnector
+from .whatsapp_connector import WhatsAppConnector
+from .matrix_connector import MatrixConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -32,6 +34,8 @@ connector_classes: Dict[str, type] = {
     "teams": TeamsConnector,
     "telegram": TelegramConnector,
     "webhook": WebhookConnector,
+    "whatsapp": WhatsAppConnector,
+    "matrix": MatrixConnector,
 }
 
 

--- a/app/connectors/matrix_connector.py
+++ b/app/connectors/matrix_connector.py
@@ -1,0 +1,28 @@
+from .base_connector import BaseConnector
+
+class MatrixConnector(BaseConnector):
+    """Connector for interacting with Matrix chat networks."""
+
+    id = 'matrix'
+    name = 'Matrix'
+
+    def __init__(self, homeserver: str, user_id: str, access_token: str, room_id: str, config=None):
+        super().__init__(config)
+        self.homeserver = homeserver
+        self.user_id = user_id
+        self.access_token = access_token
+        self.room_id = room_id
+
+    async def send_message(self, message):
+        # Code to send a message using the Matrix API
+        pass
+
+    async def listen_and_process(self):
+        # Code to listen for incoming messages from Matrix
+        # and call process_incoming for each message
+        pass
+
+    async def process_incoming(self, message):
+        # Code to process the incoming message, including applying filters
+        # and calling the appropriate action(s)
+        pass

--- a/app/connectors/whatsapp_connector.py
+++ b/app/connectors/whatsapp_connector.py
@@ -1,0 +1,28 @@
+from .base_connector import BaseConnector
+
+class WhatsAppConnector(BaseConnector):
+    """Connector for sending and receiving WhatsApp messages via Twilio."""
+
+    id = 'whatsapp'
+    name = 'WhatsApp'
+
+    def __init__(self, account_sid: str, auth_token: str, from_number: str, to_number: str, config=None):
+        super().__init__(config)
+        self.account_sid = account_sid
+        self.auth_token = auth_token
+        self.from_number = from_number
+        self.to_number = to_number
+
+    async def send_message(self, message):
+        # Code to send a message using the Twilio API
+        pass
+
+    async def listen_and_process(self):
+        # Code to listen for incoming messages from WhatsApp
+        # and call process_incoming for each message
+        pass
+
+    async def process_incoming(self, message):
+        # Code to process the incoming message, including applying filters
+        # and calling the appropriate action(s)
+        pass

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -28,6 +28,14 @@ class Settings(BaseSettings):
     teams_tenant_id: str
     teams_bot_endpoint: str
     webhook_secret: str
+    whatsapp_account_sid: str
+    whatsapp_auth_token: str
+    whatsapp_from_number: str
+    whatsapp_to_number: str
+    matrix_homeserver: str
+    matrix_user_id: str
+    matrix_access_token: str
+    matrix_room_id: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -20,8 +20,16 @@ teams_app_password: "your_teams_app_password"
 teams_tenant_id: "your_teams_tenant_id"
 teams_bot_endpoint: "your_teams_bot_endpoint"
 webhook_secret: "your_webhook_secret"
+whatsapp_account_sid: "your_whatsapp_account_sid"
+whatsapp_auth_token: "your_whatsapp_auth_token"
+whatsapp_from_number: "your_whatsapp_from_number"
+whatsapp_to_number: "your_whatsapp_to_number"
+matrix_homeserver: "your_matrix_homeserver"
+matrix_user_id: "your_matrix_user_id"
+matrix_access_token: "your_matrix_access_token"
+matrix_room_id: "your_matrix_room_id"
 
-openai_api_key: 
+openai_api_key:
 
 # Database
 database_url: "sqlite:///./db/norman.db"

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -13,6 +13,8 @@ The following connectors are soon to be supported:
 5. **Google Chat**
 6. **Telegram**
 7. **Webhook**
+8. **Matrix**
+9. **WhatsApp**
 
 ## Usage
 
@@ -46,5 +48,7 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Google Chat Connector](./connectors/googlechat.md)
 - [Telegram Connector](./connectors/telegram.md)
 - [Webhook Connector](./connectors/webhook.md)
+- [Matrix Connector](#)
+- [WhatsApp Connector](#)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.


### PR DESCRIPTION
## Summary
- add new `WhatsAppConnector` and `MatrixConnector` classes
- register new connectors and wire them into initialization
- expose configuration settings for the connectors
- update docs with Matrix and WhatsApp connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683abb4d497c8333adc11fc2ec5c1ccc