### PR TITLE
Add docs for remaining connectors

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -6,15 +6,15 @@ Connectors are the way Norman interacts with different chat platforms. They hand
 
 The following connectors are soon to be supported:
 
-1. **IRC**
-2. **Slack**
-3. **Discord**
-4. **Microsoft Teams**
-5. **Google Chat**
-6. **Telegram**
-7. **Webhook**
-8. **Matrix**
-9. **WhatsApp**
+1. [IRC](./connectors/irc.md)
+2. [Slack](./connectors/slack.md)
+3. [Discord](./connectors/discord.md)
+4. [Microsoft Teams](./connectors/teams.md)
+5. [Google Chat](./connectors/googlechat.md)
+6. [Telegram](./connectors/telegram.md)
+7. [Webhook](./connectors/webhook.md)
+8. [Matrix](./connectors/matrix.md)
+9. [WhatsApp](./connectors/whatsapp.md)
 
 ## Usage
 
@@ -48,7 +48,7 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Google Chat Connector](./connectors/googlechat.md)
 - [Telegram Connector](./connectors/telegram.md)
 - [Webhook Connector](./connectors/webhook.md)
-- [Matrix Connector](#)
-- [WhatsApp Connector](#)
+- [Matrix Connector](./connectors/matrix.md)
+- [WhatsApp Connector](./connectors/whatsapp.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/googlechat.md
+++ b/docs/connectors/googlechat.md
@@ -1,0 +1,37 @@
+# Google Chat Connector
+
+The Google Chat connector allows Norman to send messages to Google Chat spaces. This document describes how to set up and configure the connector.
+
+## Requirements
+
+- A Google Cloud project with the Google Chat API enabled
+- A service account with access to the desired space
+- A service account key JSON file
+- The ID of the Google Chat space you want to use
+
+## Configuration
+
+1. Create or select a service account in your Google Cloud project and enable the Google Chat API.
+2. Download the service account key JSON file and note its path.
+3. Add the service account to the target Google Chat space.
+4. Update your `config.yaml` with the following keys:
+
+```yaml
+google_chat_service_account_key_path: "/path/to/service_account.json"
+google_chat_space: "spaces/AAAAExample"
+```
+
+The fields are:
+
+- `google_chat_service_account_key_path`: Path to the service account key file.
+- `google_chat_space`: Identifier of the Google Chat space.
+
+## Usage
+
+After configuration, Norman will connect to the specified space and can send and receive messages via Google Chat.
+
+## Troubleshooting
+
+1. Ensure the service account key path is correct and readable.
+2. Confirm the service account has permission to post in the Google Chat space.
+3. Check the Norman logs for any authentication or API errors.

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -1,0 +1,37 @@
+# Matrix Connector
+
+The Matrix connector enables Norman to communicate within Matrix rooms.
+
+## Requirements
+
+- Access to a Matrix homeserver
+- A Matrix user account and access token
+- The ID of the Matrix room where Norman should operate
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+matrix_homeserver: "https://matrix.example.com"
+matrix_user_id: "@bot:example.com"
+matrix_access_token: "your_matrix_access_token"
+matrix_room_id: "!yourRoom:example.com"
+```
+
+The fields are:
+
+- `matrix_homeserver`: URL of the Matrix homeserver
+- `matrix_user_id`: User ID for the bot account
+- `matrix_access_token`: Access token for the bot account
+- `matrix_room_id`: ID of the Matrix room to join
+
+## Usage
+
+Once configured, Norman will join the specified room and can send and receive messages via Matrix.
+
+## Troubleshooting
+
+1. Verify that the homeserver URL and credentials are correct.
+2. Ensure the bot account has access to the room.
+3. Check the logs for authentication errors if messages fail to appear.

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -1,0 +1,35 @@
+# Telegram Connector
+
+The Telegram connector enables Norman to interact with Telegram chats and groups.
+
+## Requirements
+
+- A Telegram account
+- A bot token obtained from [@BotFather](https://t.me/BotFather)
+- The chat ID of the target chat or group
+
+## Configuration
+
+1. Use @BotFather to create a new bot and obtain its token.
+2. Add the bot to the chat or group you want Norman to use and note the chat ID.
+3. Update your `config.yaml` with the following keys:
+
+```yaml
+telegram_token: "your_telegram_token"
+telegram_chat_id: "your_telegram_chat_id"
+```
+
+The fields are:
+
+- `telegram_token`: The token provided by BotFather.
+- `telegram_chat_id`: The chat or group ID where messages will be sent.
+
+## Usage
+
+Once configured, Norman will send messages to the specified chat and process incoming updates from Telegram.
+
+## Troubleshooting
+
+1. Verify that the bot token is correct.
+2. Ensure the chat ID is accurate and that the bot has permission to post in the chat.
+3. Check Norman's logs if messages fail to send or if updates are not received.

--- a/docs/connectors/webhook.md
+++ b/docs/connectors/webhook.md
@@ -1,0 +1,27 @@
+# Webhook Connector
+
+The Webhook connector forwards messages from Norman to an arbitrary HTTP endpoint.
+
+## Requirements
+
+- An HTTP endpoint capable of receiving JSON payloads
+
+## Configuration
+
+Add the webhook URL to your `config.yaml` file:
+
+```yaml
+webhook_secret: "https://your-webhook-url.example.com/"
+```
+
+`webhook_secret` should contain the full URL of the endpoint that will receive the messages.
+
+## Usage
+
+When enabled, Norman will send POST requests with message data to the configured webhook URL.
+
+## Troubleshooting
+
+1. Ensure the webhook URL is reachable from the Norman server.
+2. Check HTTP response codes in the logs for any errors.
+3. Verify any authentication or secrets required by your webhook service.

--- a/docs/connectors/whatsapp.md
+++ b/docs/connectors/whatsapp.md
@@ -1,0 +1,37 @@
+# WhatsApp Connector
+
+The WhatsApp connector uses Twilio to send and receive WhatsApp messages.
+
+## Requirements
+
+- A Twilio account with WhatsApp support
+- Your Twilio Account SID and Auth Token
+- A WhatsApp-enabled `from` number and a destination `to` number
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+whatsapp_account_sid: "your_whatsapp_account_sid"
+whatsapp_auth_token: "your_whatsapp_auth_token"
+whatsapp_from_number: "whatsapp:+1234567890"
+whatsapp_to_number: "whatsapp:+0987654321"
+```
+
+The fields are:
+
+- `whatsapp_account_sid`: Your Twilio account SID
+- `whatsapp_auth_token`: Your Twilio Auth Token
+- `whatsapp_from_number`: The WhatsApp-enabled number sending messages
+- `whatsapp_to_number`: The destination number for messages
+
+## Usage
+
+After configuration, Norman can send messages via Twilio to WhatsApp and process incoming messages.
+
+## Troubleshooting
+
+1. Confirm the Twilio credentials are correct.
+2. Ensure the `from` and `to` numbers are authorized in your Twilio account.
+3. Review Twilio logs for delivery errors if messages fail to send.


### PR DESCRIPTION
## Summary
- document Google Chat, Telegram, Webhook, Matrix and WhatsApp connectors
- link new pages from `docs/connectors.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ac13f9a8c8333bb71ab3952263882