### PR TITLE
Add Slack router and tests

### DIFF
--- a/app/api/api_v1/routers/connectors/__init__.py
+++ b/app/api/api_v1/routers/connectors/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from .telegram import router as telegram_router
-#from .slack import router as slack_router
+from .slack import router as slack_router
 from .teams import router as teams_router
 from .google_chat import router as google_chat_router
 from .discord import router as discord_router
@@ -9,7 +9,7 @@ from .webhook import router as webhook_router
 router = APIRouter()
 
 router.include_router(telegram_router, prefix="/telegram", tags=["Telegram"])
-#router.include_router(slack_router, prefix="/slack", tags=["Slack"])
+router.include_router(slack_router, prefix="/slack", tags=["Slack"])
 router.include_router(teams_router, prefix="/microsoft_teams", tags=["Microsoft Teams"])
 router.include_router(google_chat_router, prefix="/google_chat", tags=["Google Chat"])
 router.include_router(discord_router, prefix="/discord", tags=["Discord"])

--- a/app/api/api_v1/routers/connectors/slack.py
+++ b/app/api/api_v1/routers/connectors/slack.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends, Request
+from app.connectors.slack_connector import SlackConnector
+from app.core.config import get_settings, Settings
+
+router = APIRouter()
+
+
+def get_slack_connector(settings: Settings = Depends(get_settings)) -> SlackConnector:
+    return SlackConnector(token=settings.slack_token, channel_id=settings.slack_channel_id)
+
+
+@router.post("/webhooks/slack")
+async def process_slack_update(request: Request, slack_connector: SlackConnector = Depends(get_slack_connector)):
+    payload = await request.json()
+    slack_connector.process_incoming(payload)
+    return {"detail": "Update processed"}

--- a/tests/test_slack_router.py
+++ b/tests/test_slack_router.py
@@ -1,0 +1,31 @@
+import sys
+import types
+
+# Provide a minimal slack_sdk stub if the real package isn't installed
+if 'slack_sdk' not in sys.modules:
+    slack_sdk = types.ModuleType('slack_sdk')
+
+    class SlackApiError(Exception):
+        def __init__(self, message=None, response=None):
+            super().__init__(message)
+            self.response = response
+
+    class DummyClient:
+        def __init__(self, token=None):
+            self.token = token
+
+    slack_sdk.WebClient = DummyClient
+    errors_mod = types.ModuleType('slack_sdk.errors')
+    errors_mod.SlackApiError = SlackApiError
+    slack_sdk.errors = errors_mod
+    sys.modules['slack_sdk'] = slack_sdk
+    sys.modules['slack_sdk.errors'] = errors_mod
+
+from app.api.api_v1.routers.connectors.slack import get_slack_connector
+from app.core.test_settings import TestSettings
+
+
+def test_get_slack_connector_uses_settings():
+    connector = get_slack_connector(TestSettings)
+    assert connector.token == TestSettings.slack_token
+    assert connector.channel_id == TestSettings.slack_channel_id


### PR DESCRIPTION
## Summary
- implement Slack connector router
- register Slack router
- test Slack router dependency uses settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ac14c1f3c83338c0c29190df970c6