### PR TITLE
Add BlueSky connector skeleton

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -14,6 +14,7 @@ from .telegram_connector import TelegramConnector
 from .webhook_connector import WebhookConnector
 from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
+from .bluesky_connector import BlueSkyConnector
 
 from .connector_utils import get_connector
 
@@ -34,4 +35,8 @@ def init_connectors(app: FastAPI, settings: Settings):
         user_id=settings.matrix_user_id,
         access_token=settings.matrix_access_token,
         room_id=settings.matrix_room_id,
+    )
+    app.state.bluesky_connector = BlueSkyConnector(
+        token=settings.bluesky_token,
+        channel_id=settings.bluesky_channel_id,
     )

--- a/app/connectors/bluesky_connector.py
+++ b/app/connectors/bluesky_connector.py
@@ -1,0 +1,26 @@
+from .base_connector import BaseConnector
+
+class BlueSkyConnector(BaseConnector):
+    """Connector skeleton for the BlueSky platform."""
+
+    id = 'bluesky'
+    name = 'BlueSky'
+
+    def __init__(self, token: str, channel_id: str, config=None):
+        super().__init__(config)
+        self.token = token
+        self.channel_id = channel_id
+
+    async def send_message(self, message):
+        # Code to send a message using the BlueSky API
+        pass
+
+    async def listen_and_process(self):
+        # Code to listen for incoming messages from BlueSky
+        # and call process_incoming for each message
+        pass
+
+    async def process_incoming(self, message):
+        # Code to process the incoming message, including applying filters
+        # and calling the appropriate action(s)
+        pass

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -24,6 +24,7 @@ from .telegram_connector import TelegramConnector
 from .webhook_connector import WebhookConnector
 from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
+from .bluesky_connector import BlueSkyConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -36,6 +37,7 @@ connector_classes: Dict[str, type] = {
     "webhook": WebhookConnector,
     "whatsapp": WhatsAppConnector,
     "matrix": MatrixConnector,
+    "bluesky": BlueSkyConnector,
 }
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -36,6 +36,8 @@ class Settings(BaseSettings):
     matrix_user_id: str
     matrix_access_token: str
     matrix_room_id: str
+    bluesky_token: str
+    bluesky_channel_id: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -28,6 +28,8 @@ matrix_homeserver: "your_matrix_homeserver"
 matrix_user_id: "your_matrix_user_id"
 matrix_access_token: "your_matrix_access_token"
 matrix_room_id: "your_matrix_room_id"
+bluesky_token: "your_bluesky_token"
+bluesky_channel_id: "your_bluesky_channel_id"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -15,6 +15,7 @@ The following connectors are soon to be supported:
 7. **Webhook**
 8. **Matrix**
 9. **WhatsApp**
+10. **BlueSky**
 
 ## Usage
 
@@ -50,5 +51,6 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Webhook Connector](./connectors/webhook.md)
 - [Matrix Connector](#)
 - [WhatsApp Connector](#)
+- [BlueSky Connector](./connectors/bluesky.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/bluesky.md
+++ b/docs/connectors/bluesky.md
@@ -1,0 +1,25 @@
+# BlueSky Connector
+
+The BlueSky connector enables Norman to interact with the hypothetical BlueSky platform. This file outlines the minimal configuration required to enable the connector.
+
+## Requirements
+
+- A BlueSky account with API access
+- The token and channel identifier where the bot will operate
+
+## Configuration
+
+Add the following configuration to your `config.yaml` file:
+
+```yaml
+connectors:
+  - type: "bluesky"
+    token: "your-bluesky-token"
+    channel: "your-bluesky-channel-id"
+```
+
+Replace the values with your actual BlueSky credentials.
+
+## Usage
+
+Once configured, Norman will be able to send and receive messages via BlueSky using the connector. Implementation details are left to the developer.


### PR DESCRIPTION
## Summary
- rename placeholder Bluesku connector to **BlueSky**
- wire up BlueSky initialization in the app
- expose new configuration options
- update documentation for BlueSky connector

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ac20684b88333b3cc0811ba5b6364