### PR TITLE
Add Twitch chat connector

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -15,6 +15,7 @@ from .webhook_connector import WebhookConnector
 from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
 from .signal_connector import SignalConnector
+from .twitch_connector import TwitchConnector
 
 from .connector_utils import get_connector
 
@@ -39,4 +40,11 @@ def init_connectors(app: FastAPI, settings: Settings):
         user_id=settings.matrix_user_id,
         access_token=settings.matrix_access_token,
         room_id=settings.matrix_room_id,
+    )
+    app.state.twitch_connector = TwitchConnector(
+        token=settings.twitch_token,
+        nickname=settings.twitch_nickname,
+        channel=settings.twitch_channel,
+        server=settings.twitch_server,
+        port=settings.twitch_port,
     )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -25,6 +25,7 @@ from .webhook_connector import WebhookConnector
 from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
 from .signal_connector import SignalConnector
+from .twitch_connector import TwitchConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -38,6 +39,7 @@ connector_classes: Dict[str, type] = {
     "whatsapp": WhatsAppConnector,
     "matrix": MatrixConnector,
     "signal": SignalConnector,
+    "twitch": TwitchConnector,
 }
 
 

--- a/app/connectors/twitch_connector.py
+++ b/app/connectors/twitch_connector.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import socket
+from typing import Optional
+
+from .base_connector import BaseConnector
+
+
+class TwitchConnector(BaseConnector):
+    """Connector for interacting with Twitch chat via IRC."""
+
+    id = "twitch"
+    name = "Twitch"
+
+    def __init__(
+        self,
+        token: str,
+        nickname: str,
+        channel: str,
+        server: str = "irc.chat.twitch.tv",
+        port: int = 6667,
+        config: Optional[dict] = None,
+    ):
+        super().__init__(config)
+        self.token = token
+        self.nickname = nickname
+        self.channel = channel
+        self.server = server
+        self.port = port
+        self.socket: Optional[socket.socket] = None
+
+    def connect(self) -> None:
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.connect((self.server, self.port))
+        # Twitch requires the token to be prefixed with "oauth:"
+        self.socket.sendall(f"PASS {self.token}\r\n".encode("utf-8"))
+        self.socket.sendall(f"NICK {self.nickname}\r\n".encode("utf-8"))
+        self.socket.sendall(f"JOIN #{self.channel}\r\n".encode("utf-8"))
+
+    def disconnect(self) -> None:
+        if self.socket:
+            try:
+                self.socket.sendall(b"QUIT\r\n")
+            finally:
+                self.socket.close()
+                self.socket = None
+
+    def send_message(self, message: str) -> None:
+        if not self.socket:
+            raise RuntimeError("TwitchConnector is not connected")
+        self.socket.sendall(
+            f"PRIVMSG #{self.channel} :{message}\r\n".encode("utf-8")
+        )
+
+    def receive_message(self) -> str:
+        if not self.socket:
+            raise RuntimeError("TwitchConnector is not connected")
+        data = self.socket.recv(2048).decode("utf-8")
+        if data.startswith("PING"):
+            self.socket.sendall(f"PONG {data.split()[1]}\r\n".encode("utf-8"))
+            return ""
+        return data
+
+    def listen_and_process(self):
+        if not self.socket:
+            self.connect()
+        messages = []
+        data = self.receive_message()
+        if data:
+            processed = self.process_incoming({"raw": data})
+            if processed:
+                messages.append(processed)
+        return messages
+
+    def process_incoming(self, message: dict) -> dict:
+        return message
+
+    def is_connected(self) -> bool:
+        return self.socket is not None

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -38,6 +38,11 @@ class Settings(BaseSettings):
     matrix_user_id: str
     matrix_access_token: str
     matrix_room_id: str
+    twitch_token: str
+    twitch_nickname: str
+    twitch_channel: str
+    twitch_server: str
+    twitch_port: int
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -30,6 +30,11 @@ matrix_homeserver: "your_matrix_homeserver"
 matrix_user_id: "your_matrix_user_id"
 matrix_access_token: "your_matrix_access_token"
 matrix_room_id: "your_matrix_room_id"
+twitch_token: "your_twitch_token"
+twitch_nickname: "your_twitch_nickname"
+twitch_channel: "your_twitch_channel"
+twitch_server: "irc.chat.twitch.tv"
+twitch_port: 6667
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -16,6 +16,7 @@ The following connectors are soon to be supported:
 7. [Webhook](./connectors/webhook.md)
 8. [Matrix](./connectors/matrix.md)
 9. [WhatsApp](./connectors/whatsapp.md)
+10. [Twitch](./connectors/twitch.md)
 
 
 ## Usage
@@ -49,10 +50,9 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Microsoft Teams Connector](./connectors/teams.md)
 - [Google Chat Connector](./connectors/googlechat.md)
 - [Telegram Connector](./connectors/telegram.md)
-- [Matrix Connector](#)
-- [WhatsApp Connector](#)
 - [Signal Connector](./connectors/signal.md)
 - [Matrix Connector](./connectors/matrix.md)
 - [WhatsApp Connector](./connectors/whatsapp.md)
+- [Twitch Connector](./connectors/twitch.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/twitch.md
+++ b/docs/connectors/twitch.md
@@ -1,0 +1,31 @@
+# Twitch Connector
+
+The Twitch connector allows Norman to interact with Twitch chat channels over IRC.
+This connector requires a Twitch IRC token and the channel you want the bot to
+join.
+
+## Requirements
+
+- A Twitch account
+- An OAuth token for IRC (usually begins with `oauth:`). You can generate one at
+  <https://twitchapps.com/tmi/>.
+
+## Configuration
+
+Add the following configuration to your `config.yaml` file:
+
+```yaml
+connectors:
+  - type: "twitch"
+    token: "oauth:your-token"
+    nickname: "your-twitch-username"
+    channel: "your-channel"
+```
+
+Replace the values with your actual credentials and the channel name (without the
+`#` prefix).
+
+## Usage
+
+Once configured, Norman will connect to the specified Twitch chat channel and can
+send and receive messages just like any other connector.


### PR DESCRIPTION
## Summary
- add TwitchConnector implementation
- register Twitch connector in init and utilities
- configure Twitch settings
- document Twitch connector setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ac4d338cc8333a136846a1815fd51