### PR TITLE
Add REST callback connector

### DIFF
--- a/app/api/api_v1/routers/connectors/__init__.py
+++ b/app/api/api_v1/routers/connectors/__init__.py
@@ -5,6 +5,7 @@ from .teams import router as teams_router
 from .google_chat import router as google_chat_router
 from .discord import router as discord_router
 from .webhook import router as webhook_router
+from .rest_callback import router as rest_callback_router
 
 router = APIRouter()
 
@@ -14,4 +15,5 @@ router.include_router(teams_router, prefix="/microsoft_teams", tags=["Microsoft 
 router.include_router(google_chat_router, prefix="/google_chat", tags=["Google Chat"])
 router.include_router(discord_router, prefix="/discord", tags=["Discord"])
 router.include_router(webhook_router, prefix="/webhook", tags=["Webhook"])
+router.include_router(rest_callback_router, prefix="/rest_callback", tags=["REST Callback"])
 

--- a/app/api/api_v1/routers/connectors/rest_callback.py
+++ b/app/api/api_v1/routers/connectors/rest_callback.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, Request
+from app.connectors.rest_callback_connector import RestCallbackConnector
+from app.core.config import get_settings, Settings
+
+router = APIRouter()
+
+
+def get_rest_callback_connector(settings: Settings = Depends(get_settings)) -> RestCallbackConnector:
+    return RestCallbackConnector(
+        inbound_url=settings.rest_callback_inbound_url,
+        outbound_url=settings.rest_callback_outbound_url,
+    )
+
+
+@router.post("/webhooks/rest_callback")
+async def process_rest_callback_update(
+    request: Request,
+    rest_connector: RestCallbackConnector = Depends(get_rest_callback_connector),
+):
+    payload = await request.json()
+    await rest_connector.process_incoming(payload)
+    return {"detail": "Update processed"}

--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -12,6 +12,7 @@ from .discord_connector import DiscordConnector
 from .teams_connector import TeamsConnector
 from .telegram_connector import TelegramConnector
 from .webhook_connector import WebhookConnector
+from .rest_callback_connector import RestCallbackConnector
 from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
 from .signal_connector import SignalConnector
@@ -39,4 +40,8 @@ def init_connectors(app: FastAPI, settings: Settings):
         user_id=settings.matrix_user_id,
         access_token=settings.matrix_access_token,
         room_id=settings.matrix_room_id,
+    )
+    app.state.rest_callback_connector = RestCallbackConnector(
+        inbound_url=settings.rest_callback_inbound_url,
+        outbound_url=settings.rest_callback_outbound_url,
     )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -25,6 +25,7 @@ from .webhook_connector import WebhookConnector
 from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
 from .signal_connector import SignalConnector
+from .rest_callback_connector import RestCallbackConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -38,6 +39,7 @@ connector_classes: Dict[str, type] = {
     "whatsapp": WhatsAppConnector,
     "matrix": MatrixConnector,
     "signal": SignalConnector,
+    "rest_callback": RestCallbackConnector,
 }
 
 

--- a/app/connectors/rest_callback_connector.py
+++ b/app/connectors/rest_callback_connector.py
@@ -1,0 +1,31 @@
+import httpx
+from typing import Any, Dict
+
+from .base_connector import BaseConnector
+
+
+class RestCallbackConnector(BaseConnector):
+    """Connector handling REST callbacks for inbound and outbound messages."""
+
+    id = "rest_callback"
+    name = "REST Callback"
+
+    def __init__(self, inbound_url: str, outbound_url: str, config=None):
+        super().__init__(config)
+        self.inbound_url = inbound_url
+        self.outbound_url = outbound_url
+
+    async def send_message(self, message: Dict[str, Any]) -> str:
+        """Send an outbound callback message via HTTP POST."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(self.outbound_url, json=message)
+            response.raise_for_status()
+            return response.text
+
+    async def listen_and_process(self):
+        """Placeholder for listening for inbound callbacks."""
+        pass
+
+    async def process_incoming(self, message: Dict[str, Any]):
+        """Process an inbound callback message."""
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -38,6 +38,8 @@ class Settings(BaseSettings):
     matrix_user_id: str
     matrix_access_token: str
     matrix_room_id: str
+    rest_callback_inbound_url: str
+    rest_callback_outbound_url: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -30,6 +30,8 @@ matrix_homeserver: "your_matrix_homeserver"
 matrix_user_id: "your_matrix_user_id"
 matrix_access_token: "your_matrix_access_token"
 matrix_room_id: "your_matrix_room_id"
+rest_callback_inbound_url: "your_rest_callback_inbound_url"
+rest_callback_outbound_url: "your_rest_callback_outbound_url"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -16,6 +16,7 @@ The following connectors are soon to be supported:
 7. [Webhook](./connectors/webhook.md)
 8. [Matrix](./connectors/matrix.md)
 9. [WhatsApp](./connectors/whatsapp.md)
+10. [REST Callback](./connectors/restcallback.md)
 
 
 ## Usage

--- a/docs/connectors/restcallback.md
+++ b/docs/connectors/restcallback.md
@@ -1,0 +1,25 @@
+# REST Callback Connector
+
+The REST Callback connector allows Norman to communicate with external services using HTTP callbacks. It supports sending outbound requests and processing inbound callbacks.
+
+## Requirements
+
+- An HTTP endpoint capable of receiving JSON payloads
+
+## Configuration
+
+Add the callback URLs to your `config.yaml` file:
+
+```yaml
+rest_callback_inbound_url: "https://your-app.example.com/inbound"
+rest_callback_outbound_url: "https://external-service.example.com/callback"
+```
+
+## Usage
+
+When enabled, Norman will POST outbound messages to the configured outbound URL. Incoming HTTP callbacks can be sent to Norman's `/api/v1/connectors/rest_callback/webhooks/rest_callback` endpoint.
+
+## Troubleshooting
+
+1. Ensure the URLs are reachable from the Norman server.
+2. Check HTTP response codes in the logs for any errors.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -19,6 +19,7 @@ if 'slack_sdk' not in sys.modules:
 from app.connectors.connector_utils import get_connector, get_connectors_data
 from app.connectors.slack_connector import SlackConnector
 from app.connectors.signal_connector import SignalConnector
+from app.connectors.rest_callback_connector import RestCallbackConnector
 from app.core.test_settings import TestSettings
 
 
@@ -32,6 +33,12 @@ def test_get_connector_returns_signal(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     connector = get_connector('signal')
     assert isinstance(connector, SignalConnector)
+
+
+def test_get_connector_returns_rest_callback(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('rest_callback')
+    assert isinstance(connector, RestCallbackConnector)
 
 
 def test_get_connectors_data_missing_config(monkeypatch):


### PR DESCRIPTION
## Summary
- implement `RestCallbackConnector` for HTTP callbacks
- expose REST callback webhook endpoint
- register the new connector
- document configuration and usage
- ensure settings include new URLs
- test new connector via `get_connector`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ac4f501988333bb284345082bb446