### PR TITLE
Add REST callback connector

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -12,6 +12,7 @@ from .discord_connector import DiscordConnector
 from .teams_connector import TeamsConnector
 from .telegram_connector import TelegramConnector
 from .webhook_connector import WebhookConnector
+from .rest_callback_connector import RESTCallbackConnector
 from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
 from .signal_connector import SignalConnector
@@ -47,4 +48,7 @@ def init_connectors(app: FastAPI, settings: Settings):
         channel=settings.twitch_channel,
         server=settings.twitch_server,
         port=settings.twitch_port,
+    )
+    app.state.rest_callback_connector = RESTCallbackConnector(
+        callback_url=settings.rest_callback_url
     )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -22,6 +22,7 @@ from .slack_connector import SlackConnector
 from .teams_connector import TeamsConnector
 from .telegram_connector import TelegramConnector
 from .webhook_connector import WebhookConnector
+from .rest_callback_connector import RESTCallbackConnector
 from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
 from .signal_connector import SignalConnector
@@ -36,6 +37,7 @@ connector_classes: Dict[str, type] = {
     "teams": TeamsConnector,
     "telegram": TelegramConnector,
     "webhook": WebhookConnector,
+    "rest_callback": RESTCallbackConnector,
     "whatsapp": WhatsAppConnector,
     "matrix": MatrixConnector,
     "signal": SignalConnector,

--- a/app/connectors/rest_callback_connector.py
+++ b/app/connectors/rest_callback_connector.py
@@ -1,0 +1,35 @@
+import httpx
+from typing import Any, Dict, Optional
+
+from .base_connector import BaseConnector
+
+
+class RESTCallbackConnector(BaseConnector):
+    """Connector that forwards messages to a REST endpoint."""
+
+    id = "rest_callback"
+    name = "REST Callback"
+
+    def __init__(self, callback_url: str, config=None) -> None:
+        super().__init__(config)
+        self.callback_url = callback_url
+
+    async def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        """Send a message to the configured callback URL."""
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(self.callback_url, json=message)
+                response.raise_for_status()
+                return response.text
+            except httpx.HTTPError as exc:
+                print(f"Error sending message to {self.callback_url}: {exc}")
+                return None
+
+    async def listen_and_process(self):
+        """This connector does not support incoming messages."""
+        pass
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        """Forward an incoming message to the callback URL."""
+        await self.send_message(message)
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
     twitch_channel: str
     twitch_server: str
     twitch_port: int
+    rest_callback_url: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -35,6 +35,7 @@ twitch_nickname: "your_twitch_nickname"
 twitch_channel: "your_twitch_channel"
 twitch_server: "irc.chat.twitch.tv"
 twitch_port: 6667
+rest_callback_url: "your_rest_callback_url"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -17,6 +17,7 @@ The following connectors are soon to be supported:
 8. [Matrix](./connectors/matrix.md)
 9. [WhatsApp](./connectors/whatsapp.md)
 10. [Twitch](./connectors/twitch.md)
+11. [REST Callback](./connectors/rest_callback.md)
 
 
 ## Usage

--- a/docs/connectors/rest_callback.md
+++ b/docs/connectors/rest_callback.md
@@ -1,0 +1,27 @@
+# REST Callback Connector
+
+The REST Callback connector allows Norman to forward messages to an arbitrary REST endpoint. It is useful for integrating with external services that expose a simple HTTP interface.
+
+## Requirements
+
+- An HTTP endpoint that accepts JSON payloads
+
+## Configuration
+
+Add the callback URL to your `config.yaml` file:
+
+```yaml
+rest_callback_url: "https://example.com/callback"
+```
+
+`rest_callback_url` should contain the full URL that will receive the POST requests.
+
+## Usage
+
+When enabled, Norman will send POST requests with the message data to the configured endpoint whenever this connector is used.
+
+## Troubleshooting
+
+1. Ensure the callback URL is reachable from the Norman server.
+2. Check HTTP response codes in the logs for any errors.
+3. Verify any authentication or secrets required by your callback service.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -19,6 +19,7 @@ if 'slack_sdk' not in sys.modules:
 from app.connectors.connector_utils import get_connector, get_connectors_data
 from app.connectors.slack_connector import SlackConnector
 from app.connectors.signal_connector import SignalConnector
+from app.connectors.rest_callback_connector import RESTCallbackConnector
 from app.core.test_settings import TestSettings
 
 
@@ -32,6 +33,12 @@ def test_get_connector_returns_signal(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     connector = get_connector('signal')
     assert isinstance(connector, SignalConnector)
+
+
+def test_get_connector_returns_rest_callback(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('rest_callback')
+    assert isinstance(connector, RESTCallbackConnector)
 
 
 def test_get_connectors_data_missing_config(monkeypatch):


### PR DESCRIPTION
## Summary
- implement `RESTCallbackConnector` for HTTP callbacks
- expose connector in connector registry and initialization
- document configuration and usage
- update default config and settings
- add basic tests for connector utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ac8be2a648333934e4bdcf3142870