### PR TITLE
Fix TODOs in routes

### DIFF
--- a/app/crud/message.py
+++ b/app/crud/message.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
+from typing import Optional
 from app.models import Message
 from typing import List
 
@@ -13,8 +14,21 @@ def create_message(db: Session, bot_id: int, text: str, source: str) -> Message:
 def get_message_by_id(db: Session, message_id: int) -> Message:
     return db.query(Message).filter(Message.id == message_id).first()
 
-def get_messages_by_bot_id(db: Session, bot_id: int) -> List[Message]:
-    return db.query(Message).filter(Message.bot_id == bot_id).all()
+def get_messages_by_bot_id(
+    db: Session,
+    bot_id: int,
+    *,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+) -> List[Message]:
+    """Return messages for a bot with optional pagination."""
+
+    query = db.query(Message).filter(Message.bot_id == bot_id).order_by(Message.created_at)
+    if offset is not None:
+        query = query.offset(offset)
+    if limit is not None:
+        query = query.limit(limit)
+    return query.all()
 
 def delete_message(db: Session, message_id: int) -> None:
     message = get_message_by_id(db, message_id)


### PR DESCRIPTION
## Summary
- add optional limit/offset to `get_messages_endpoint`
- count tokens and restrict by `default_prompt_tokens`
- allow setting `history_limit` when generating bot responses
- return interaction headers if available
- support limit/offset pagination in `get_messages_by_bot_id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683acac9068c83339689f2f72ba3b848