### PR TITLE
Fix TODOs: add admin username config and restrict bots

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     # initial admin
     initial_admin_email: str = "admin@example.com"
     initial_admin_password: str = "password123"
+    initial_admin_username: str = "admin"
 
     # Connectors
     telegram_token: str
@@ -89,6 +90,17 @@ class Settings(BaseSettings):
             return v
         assert v != "admin@example.com", (
             "You must set an admin email in the config.yaml!"
+        )
+        return v
+
+    @validator("initial_admin_username", pre=True)
+    def validate_admin_username(cls, v):
+        """Validate admin username unless running under pytest."""
+        import sys
+        if "pytest" in sys.modules:
+            return v
+        assert v != "admin", (
+            "You must set an admin username in the config.yaml!"
         )
         return v
 

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -41,9 +41,15 @@ def is_admin_user_exists(db: Session) -> bool:
     admin_user = db.query(models.User).filter(models.User.is_superuser == True).first()
     return admin_user is not None
 
-def create_admin_user(db: Session, email: str, password: str):
+def create_admin_user(db: Session, email: str, password: str, username: str) -> models.User:
+    """Create the initial administrator user."""
     hashed_password = get_password_hash(password)
-    user = models.User(email=email, password=hashed_password, is_superuser=True, username='admin') # todo: add to config
+    user = models.User(
+        email=email,
+        password=hashed_password,
+        is_superuser=True,
+        username=username,
+    )
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/app/initial_setup.py
+++ b/app/initial_setup.py
@@ -8,5 +8,10 @@ def create_initial_admin_user():
 
     db = SessionLocal()
     if not is_admin_user_exists(db):
-        create_admin_user(db, settings.initial_admin_email, settings.initial_admin_password)
+        create_admin_user(
+            db,
+            settings.initial_admin_email,
+            settings.initial_admin_password,
+            settings.initial_admin_username,
+        )
     db.close()

--- a/app/views.py
+++ b/app/views.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.models.bot import Bot as BotModel
 from app.schemas.bot import Bot
-from app.api.deps import get_db
+from app.api.deps import get_db, get_current_user
 
 from app.connectors.connector_utils import get_connector, get_connectors_data
 
@@ -42,9 +42,9 @@ async def login(request: Request):
 async def logout(request: Request):
     return templates.TemplateResponse("logout.html", {"request": request})
 
-async def get_bots(db):
-    # TODO: restrict by user
-    return db.query(BotModel).all()
+async def get_bots(db: Session, current_user=Depends(get_current_user)):
+    """Return bots owned by the current authenticated user."""
+    return db.query(BotModel).filter(BotModel.user_id == current_user.id).all()
 
 async def process_message(request: Request):
     data = await request.json()

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -1,6 +1,7 @@
 secret_key: "super_secret_key_change_me"
 initial_admin_password: "change_me_too"
 initial_admin_email: "admin@example.com"
+initial_admin_username: "admin"
 app_name: "norman"
 debug: true
 api_version: "v1"


### PR DESCRIPTION
## Summary
- add `initial_admin_username` to default config
- validate `initial_admin_username` in settings
- allow passing username when creating the initial admin user
- use new username setting during startup
- restrict `get_bots` view by current user

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ad6be37888333a4cad5436124968a