### PR TITLE
Implement SMTP connector

### DIFF
--- a/app/connectors/TODO.md
+++ b/app/connectors/TODO.md
@@ -4,11 +4,11 @@ This file tracks connectors that we would like to implement in the future.
 
 - [ ] MQTT
 - [ ] Steam Chat
-- [ ] Twitch Chat
+- [x] Twitch Chat
 - [ ] XMPP
 - [ ] Bluesky
 - [ ] Mastodon
-- [ ] SMTP
+- [x] SMTP
 - [ ] SMS (e.g., Twilio)
 - [ ] Facebook Messenger
 - [ ] LinkedIn Messaging

--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -17,6 +17,7 @@ from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
 from .signal_connector import SignalConnector
 from .twitch_connector import TwitchConnector
+from .smtp_connector import SMTPConnector
 
 from .connector_utils import get_connector
 
@@ -51,4 +52,12 @@ def init_connectors(app: FastAPI, settings: Settings):
     )
     app.state.rest_callback_connector = RESTCallbackConnector(
         callback_url=settings.rest_callback_url
+    )
+    app.state.smtp_connector = SMTPConnector(
+        host=settings.smtp_host,
+        port=settings.smtp_port,
+        username=settings.smtp_username,
+        password=settings.smtp_password,
+        from_address=settings.smtp_from_address,
+        to_address=settings.smtp_to_address,
     )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -27,6 +27,7 @@ from .whatsapp_connector import WhatsAppConnector
 from .matrix_connector import MatrixConnector
 from .signal_connector import SignalConnector
 from .twitch_connector import TwitchConnector
+from .smtp_connector import SMTPConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -42,6 +43,7 @@ connector_classes: Dict[str, type] = {
     "matrix": MatrixConnector,
     "signal": SignalConnector,
     "twitch": TwitchConnector,
+    "smtp": SMTPConnector,
 }
 
 

--- a/app/connectors/irc_connector.py
+++ b/app/connectors/irc_connector.py
@@ -1,4 +1,7 @@
 import socket
+import ssl
+from typing import List, Optional
+
 from .base_connector import BaseConnector
 
 
@@ -7,29 +10,61 @@ class IRCConnector(BaseConnector):
     name = 'IRC'
     id = 'irc'
 
-    def __init__(self, config):
+    def __init__(
+        self,
+        server: str,
+        port: int = 6667,
+        nickname: str = "norman",
+        username: Optional[str] = None,
+        realname: Optional[str] = None,
+        password: Optional[str] = None,
+        channels: Optional[List[str]] = None,
+        use_ssl: bool = False,
+        config: Optional[dict] = None,
+    ):
         super().__init__(config)
-        self.socket = None
+        self.server = server
+        self.port = port
+        self.nickname = nickname
+        self.username = username or nickname
+        self.realname = realname or nickname
+        self.password = password
+        self.channels = channels or []
+        self.use_ssl = use_ssl
+        self.socket: Optional[socket.socket] = None
 
     def connect(self):
-        # TODO: update all these configs
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.socket.connect((self.config["server"], self.config["port"]))
-        self.socket.send(f"NICK {self.config['nickname']}\r\n".encode("utf-8"))
-        self.socket.send(f"USER {self.config['username']} 0 * :{self.config['realname']}\r\n".encode("utf-8"))
+        self.socket = socket.create_connection((self.server, self.port))
+        if self.use_ssl:
+            context = ssl.create_default_context()
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            self.socket = context.wrap_socket(self.socket, server_hostname=self.server)
+        if self.password:
+            self.socket.sendall(f"PASS {self.password}\r\n".encode("utf-8"))
+        self.socket.sendall(f"NICK {self.nickname}\r\n".encode("utf-8"))
+        self.socket.sendall(
+            f"USER {self.username} 0 * :{self.realname}\r\n".encode("utf-8")
+        )
+        for channel in self.channels:
+            self.socket.sendall(f"JOIN {channel}\r\n".encode("utf-8"))
 
     def disconnect(self):
-        self.socket.send(b"QUIT\r\n")
-        self.socket.close()
+        if self.socket:
+            try:
+                self.socket.sendall(b"QUIT\r\n")
+            finally:
+                self.socket.close()
+                self.socket = None
 
     def send_message(self, channel, message):
-        self.socket.send(f"PRIVMSG {channel} :{message}\r\n".encode("utf-8"))
+        if self.socket:
+            self.socket.sendall(f"PRIVMSG {channel} :{message}\r\n".encode("utf-8"))
 
     def receive_message(self):
         while True:
             data = self.socket.recv(1024).decode("utf-8")
             if data.startswith("PING"):
-                self.socket.send(f"PONG {data.split()[1]}\r\n".encode("utf-8"))
+                self.socket.sendall(f"PONG {data.split()[1]}\r\n".encode("utf-8"))
             else:
                 return data
 

--- a/app/connectors/smtp_connector.py
+++ b/app/connectors/smtp_connector.py
@@ -1,0 +1,67 @@
+import smtplib
+from email.message import EmailMessage
+from typing import Optional
+
+from .base_connector import BaseConnector
+
+
+class SMTPConnector(BaseConnector):
+    """Connector for sending emails via SMTP."""
+
+    id = "smtp"
+    name = "SMTP"
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 587,
+        username: str = "",
+        password: str = "",
+        from_address: str = "",
+        to_address: str = "",
+        use_tls: bool = True,
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.from_address = from_address
+        self.to_address = to_address
+        self.use_tls = use_tls
+        self.server: Optional[smtplib.SMTP] = None
+
+    def connect(self) -> None:
+        self.server = smtplib.SMTP(self.host, self.port)
+        if self.use_tls:
+            self.server.starttls()
+        if self.username:
+            self.server.login(self.username, self.password)
+
+    def disconnect(self) -> None:
+        if self.server:
+            try:
+                self.server.quit()
+            finally:
+                self.server = None
+
+    async def send_message(self, message: str) -> None:
+        if not self.server:
+            self.connect()
+        msg = EmailMessage()
+        msg["From"] = self.from_address
+        msg["To"] = self.to_address
+        msg["Subject"] = "Norman Notification"
+        msg.set_content(message)
+        self.server.send_message(msg)
+
+    async def listen_and_process(self):
+        """SMTP connector does not support incoming messages."""
+        return None
+
+    async def process_incoming(self, message):
+        return message
+
+    def is_connected(self) -> bool:
+        return self.server is not None

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -44,6 +44,12 @@ class Settings(BaseSettings):
     twitch_server: str
     twitch_port: int
     rest_callback_url: str
+    smtp_host: str
+    smtp_port: int
+    smtp_username: str
+    smtp_password: str
+    smtp_from_address: str
+    smtp_to_address: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -36,6 +36,12 @@ twitch_channel: "your_twitch_channel"
 twitch_server: "irc.chat.twitch.tv"
 twitch_port: 6667
 rest_callback_url: "your_rest_callback_url"
+smtp_host: "your_smtp_host"
+smtp_port: 587
+smtp_username: "your_smtp_username"
+smtp_password: "your_smtp_password"
+smtp_from_address: "your_from@example.com"
+smtp_to_address: "your_to@example.com"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -18,6 +18,7 @@ The following connectors are soon to be supported:
 9. [WhatsApp](./connectors/whatsapp.md)
 10. [Twitch](./connectors/twitch.md)
 11. [REST Callback](./connectors/rest_callback.md)
+12. [SMTP](./connectors/smtp.md)
 
 
 ## Usage

--- a/docs/connectors/smtp.md
+++ b/docs/connectors/smtp.md
@@ -1,0 +1,30 @@
+# SMTP Connector
+
+The SMTP connector allows Norman to send email notifications via a standard SMTP server.
+
+## Requirements
+
+- Access to an SMTP server
+- Credentials for authentication if required
+
+## Configuration
+
+Add the following fields to your `config.yaml`:
+
+```yaml
+smtp_host: "smtp.example.com"
+smtp_port: 587
+smtp_username: "your_username"
+smtp_password: "your_password"
+smtp_from_address: "bot@example.com"
+smtp_to_address: "destination@example.com"
+```
+
+## Usage
+
+When enabled, Norman can send messages through the configured SMTP server. Incoming messages are not supported for this connector.
+
+## Troubleshooting
+
+1. Verify the SMTP credentials and host information are correct.
+2. Ensure the network allows outbound connections to the SMTP server.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -20,6 +20,7 @@ from app.connectors.connector_utils import get_connector, get_connectors_data
 from app.connectors.slack_connector import SlackConnector
 from app.connectors.signal_connector import SignalConnector
 from app.connectors.rest_callback_connector import RESTCallbackConnector
+from app.connectors.smtp_connector import SMTPConnector
 from app.core.test_settings import TestSettings
 
 
@@ -39,6 +40,12 @@ def test_get_connector_returns_rest_callback(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     connector = get_connector('rest_callback')
     assert isinstance(connector, RESTCallbackConnector)
+
+
+def test_get_connector_returns_smtp(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('smtp')
+    assert isinstance(connector, SMTPConnector)
 
 
 def test_get_connectors_data_missing_config(monkeypatch):


### PR DESCRIPTION
## Summary
- add a simple SMTP connector
- configure settings for SMTP
- update IRC connector to support additional params
- register SMTP connector and document it
- mark completed TODO items and extend tests
- **fix TLS configuration in IRC connector**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ad6b2a5708333a9a5ce55774e62fa