### PR TITLE
Add MQTT and Mastodon connectors

### DIFF
--- a/app/connectors/TODO.md
+++ b/app/connectors/TODO.md
@@ -2,12 +2,12 @@
 
 This file tracks connectors that we would like to implement in the future.
 
-- [ ] MQTT
+ - [x] MQTT
 - [ ] Steam Chat
 - [x] Twitch Chat
 - [ ] XMPP
 - [ ] Bluesky
-- [ ] Mastodon
+ - [x] Mastodon
 - [x] SMTP
 - [ ] SMS (e.g., Twilio)
 - [ ] Facebook Messenger

--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -19,6 +19,8 @@ from .signal_connector import SignalConnector
 from .twitch_connector import TwitchConnector
 from .mcp_connector import MCPConnector
 from .smtp_connector import SMTPConnector
+from .mqtt_connector import MQTTConnector
+from .mastodon_connector import MastodonConnector
 
 from .connector_utils import get_connector
 
@@ -53,6 +55,19 @@ def init_connectors(app: FastAPI, settings: Settings):
     )
     app.state.rest_callback_connector = RESTCallbackConnector(
         callback_url=settings.rest_callback_url
+    )
+
+    app.state.mqtt_connector = MQTTConnector(
+        host=settings.mqtt_host,
+        port=settings.mqtt_port,
+        topic=settings.mqtt_topic,
+        username=settings.mqtt_username,
+        password=settings.mqtt_password,
+    )
+
+    app.state.mastodon_connector = MastodonConnector(
+        base_url=settings.mastodon_base_url,
+        access_token=settings.mastodon_access_token,
     )
 
     app.state.mcp_connector = MCPConnector(

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -29,6 +29,8 @@ from .signal_connector import SignalConnector
 from .twitch_connector import TwitchConnector
 from .mcp_connector import MCPConnector
 from .smtp_connector import SMTPConnector
+from .mqtt_connector import MQTTConnector
+from .mastodon_connector import MastodonConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -46,6 +48,8 @@ connector_classes: Dict[str, type] = {
     "twitch": TwitchConnector,
     "mcp": MCPConnector,
     "smtp": SMTPConnector,
+    "mqtt": MQTTConnector,
+    "mastodon": MastodonConnector,
 }
 
 

--- a/app/connectors/mastodon_connector.py
+++ b/app/connectors/mastodon_connector.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict, Optional
+
+import requests
+
+from .base_connector import BaseConnector
+
+
+class MastodonConnector(BaseConnector):
+    """Connector for posting messages to a Mastodon server."""
+
+    id = "mastodon"
+    name = "Mastodon"
+
+    def __init__(self, base_url: str, access_token: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.base_url = base_url.rstrip('/')
+        self.access_token = access_token
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.access_token}"}
+
+    def send_message(self, text: str) -> Optional[str]:
+        url = f"{self.base_url}/api/v1/statuses"
+        try:
+            resp = requests.post(url, headers=self._headers(), data={"status": text})
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending message to Mastodon: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Streaming not implemented."""
+        pass
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/connectors/mqtt_connector.py
+++ b/app/connectors/mqtt_connector.py
@@ -1,0 +1,65 @@
+import asyncio
+from typing import Optional
+
+try:
+    import paho.mqtt.client as mqtt
+except ImportError:  # pragma: no cover - library may not be installed for tests
+    mqtt = None
+
+from .base_connector import BaseConnector
+
+
+class MQTTConnector(BaseConnector):
+    """Simple connector for MQTT brokers."""
+
+    id = "mqtt"
+    name = "MQTT"
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 1883,
+        topic: str = "norman",
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.host = host
+        self.port = port
+        self.topic = topic
+        self.username = username
+        self.password = password
+        if mqtt:
+            self.client = mqtt.Client()
+            if username and password:
+                self.client.username_pw_set(username, password)
+            self.client.on_message = self._on_message
+        else:  # pragma: no cover - tests may run without mqtt installed
+            self.client = None
+
+    async def send_message(self, message: str) -> None:
+        if not mqtt:
+            raise RuntimeError("paho-mqtt not installed")
+        self.client.connect(self.host, self.port)
+        self.client.publish(self.topic, message)
+        self.client.disconnect()
+
+    async def listen_and_process(self) -> None:
+        if not mqtt:
+            raise RuntimeError("paho-mqtt not installed")
+        self.client.connect(self.host, self.port)
+        self.client.subscribe(self.topic)
+        self.client.loop_start()
+        try:
+            while True:
+                await asyncio.sleep(1)
+        finally:
+            self.client.loop_stop()
+            self.client.disconnect()
+
+    async def process_incoming(self, message: str):
+        print(f"MQTT received: {message}")
+
+    def _on_message(self, client, userdata, msg):  # pragma: no cover - callback
+        asyncio.create_task(self.process_incoming(msg.payload.decode()))

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -53,6 +53,13 @@ class Settings(BaseSettings):
     smtp_password: str
     smtp_from_address: str
     smtp_to_address: str
+    mqtt_host: str
+    mqtt_port: int = 1883
+    mqtt_topic: str
+    mqtt_username: str
+    mqtt_password: str
+    mastodon_base_url: str
+    mastodon_access_token: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -45,6 +45,13 @@ smtp_username: "your_smtp_username"
 smtp_password: "your_smtp_password"
 smtp_from_address: "your_from@example.com"
 smtp_to_address: "your_to@example.com"
+mqtt_host: "your_mqtt_host"
+mqtt_port: 1883
+mqtt_topic: "your_mqtt_topic"
+mqtt_username: "your_mqtt_username"
+mqtt_password: "your_mqtt_password"
+mastodon_base_url: "https://mastodon.example.com"
+mastodon_access_token: "your_mastodon_token"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -19,7 +19,9 @@ The following connectors are soon to be supported:
 10. [Twitch](./connectors/twitch.md)
 11. [REST Callback](./connectors/rest_callback.md)
 12. [MCP](./connectors/mcp.md)
-12. [SMTP](./connectors/smtp.md)
+13. [SMTP](./connectors/smtp.md)
+14. [MQTT](./connectors/mqtt.md)
+15. [Mastodon](./connectors/mastodon.md)
 
 
 ## Usage
@@ -59,5 +61,7 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Twitch Connector](./connectors/twitch.md)
 - [REST Callback Connector](./connectors/rest_callback.md)
 - [MCP Connector](./connectors/mcp.md)
+- [MQTT Connector](./connectors/mqtt.md)
+- [Mastodon Connector](./connectors/mastodon.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/mastodon.md
+++ b/docs/connectors/mastodon.md
@@ -1,0 +1,20 @@
+# Mastodon Connector
+
+The Mastodon connector posts updates to a Mastodon server using its REST API.
+
+## Requirements
+
+- A Mastodon account and access token
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+mastodon_base_url: "https://mastodon.example.com"
+mastodon_access_token: "your_mastodon_token"
+```
+
+## Usage
+
+After configuration, Norman can send status updates to Mastodon. Incoming message processing is not yet implemented.

--- a/docs/connectors/mqtt.md
+++ b/docs/connectors/mqtt.md
@@ -1,0 +1,28 @@
+# MQTT Connector
+
+The MQTT connector allows Norman to publish and subscribe to topics on an MQTT broker.
+
+## Requirements
+
+- An MQTT broker accessible from Norman
+- Credentials (if required by the broker)
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+mqtt_host: "mqtt.example.com"
+mqtt_port: 1883
+mqtt_topic: "norman"
+mqtt_username: "your_username"
+mqtt_password: "your_password"
+```
+
+## Usage
+
+Once configured, Norman can publish messages to the configured topic and listen for incoming messages.
+
+## Limitations
+
+This connector uses the `paho-mqtt` library. Ensure it is installed in your environment.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ email-validator
 pyjwt
 openai
 tiktoken
+paho-mqtt

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -22,6 +22,8 @@ from app.connectors.signal_connector import SignalConnector
 from app.connectors.rest_callback_connector import RESTCallbackConnector
 from app.connectors.mcp_connector import MCPConnector
 from app.connectors.smtp_connector import SMTPConnector
+from app.connectors.mqtt_connector import MQTTConnector
+from app.connectors.mastodon_connector import MastodonConnector
 from app.core.test_settings import TestSettings
 
 
@@ -50,6 +52,18 @@ def test_get_connector_returns_smtp(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     connector = get_connector('smtp')
     assert isinstance(connector, SMTPConnector)
+
+
+def test_get_connector_returns_mqtt(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('mqtt')
+    assert isinstance(connector, MQTTConnector)
+
+
+def test_get_connector_returns_mastodon(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('mastodon')
+    assert isinstance(connector, MastodonConnector)
 
 
 def test_get_connectors_data_missing_config(monkeypatch):


### PR DESCRIPTION
## Summary
- implement new MQTT and Mastodon connectors
- configure settings and default configuration
- register connectors and update docs
- mark TODOs as done
- expand connector util tests
- add paho-mqtt dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683adc749a74833398f5a1f54a5ee045