### PR TITLE
Add additional messaging connectors

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -32,6 +32,9 @@ from .rocketchat_connector import RocketChatConnector
 from .mattermost_connector import MattermostConnector
 from .wechat_connector import WeChatConnector
 from .reddit_chat_connector import RedditChatConnector
+from .instagram_dm_connector import InstagramDMConnector
+from .twitter_connector import TwitterConnector
+from .imessage_connector import IMessageConnector
 
 from .connector_utils import get_connector
 
@@ -144,4 +147,18 @@ def init_connectors(app: FastAPI, settings: Settings):
         username=settings.reddit_username,
         password=settings.reddit_password,
         user_agent=settings.reddit_user_agent,
+    )
+    app.state.instagram_dm_connector = InstagramDMConnector(
+        access_token=settings.instagram_access_token,
+        user_id=settings.instagram_user_id,
+    )
+    app.state.twitter_connector = TwitterConnector(
+        api_key=settings.twitter_api_key,
+        api_secret=settings.twitter_api_secret,
+        access_token=settings.twitter_access_token,
+        access_token_secret=settings.twitter_access_token_secret,
+    )
+    app.state.imessage_connector = IMessageConnector(
+        service_url=settings.imessage_service_url,
+        phone_number=settings.imessage_phone_number,
     )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -42,6 +42,9 @@ from .rocketchat_connector import RocketChatConnector
 from .mattermost_connector import MattermostConnector
 from .wechat_connector import WeChatConnector
 from .reddit_chat_connector import RedditChatConnector
+from .instagram_dm_connector import InstagramDMConnector
+from .twitter_connector import TwitterConnector
+from .imessage_connector import IMessageConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -72,6 +75,9 @@ connector_classes: Dict[str, type] = {
     "mattermost": MattermostConnector,
     "wechat": WeChatConnector,
     "reddit_chat": RedditChatConnector,
+    "instagram_dm": InstagramDMConnector,
+    "twitter": TwitterConnector,
+    "imessage": IMessageConnector,
 }
 
 

--- a/app/connectors/imessage_connector.py
+++ b/app/connectors/imessage_connector.py
@@ -1,0 +1,25 @@
+from .base_connector import BaseConnector
+
+
+class IMessageConnector(BaseConnector):
+    """Connector for Apple RCS/iMessage."""
+
+    id = "imessage"
+    name = "Apple RCS/iMessage"
+
+    def __init__(self, service_url: str, phone_number: str, config=None):
+        super().__init__(config)
+        self.service_url = service_url
+        self.phone_number = phone_number
+
+    async def send_message(self, message):
+        # Placeholder for sending a message via iMessage
+        pass
+
+    async def listen_and_process(self):
+        # Placeholder for listening to iMessage messages
+        pass
+
+    async def process_incoming(self, message):
+        # Placeholder for processing inbound iMessage messages
+        pass

--- a/app/connectors/instagram_dm_connector.py
+++ b/app/connectors/instagram_dm_connector.py
@@ -1,0 +1,25 @@
+from .base_connector import BaseConnector
+
+
+class InstagramDMConnector(BaseConnector):
+    """Connector for Instagram direct messages."""
+
+    id = "instagram_dm"
+    name = "Instagram DM"
+
+    def __init__(self, access_token: str, user_id: str, config=None):
+        super().__init__(config)
+        self.access_token = access_token
+        self.user_id = user_id
+
+    async def send_message(self, message):
+        # Placeholder for sending a message via Instagram DM
+        pass
+
+    async def listen_and_process(self):
+        # Placeholder for listening for Instagram DM messages
+        pass
+
+    async def process_incoming(self, message):
+        # Placeholder for processing inbound Instagram DM messages
+        pass

--- a/app/connectors/twitter_connector.py
+++ b/app/connectors/twitter_connector.py
@@ -1,0 +1,27 @@
+from .base_connector import BaseConnector
+
+
+class TwitterConnector(BaseConnector):
+    """Connector for X.com (Twitter) direct messages."""
+
+    id = "twitter"
+    name = "X.com (Twitter)"
+
+    def __init__(self, api_key: str, api_secret: str, access_token: str, access_token_secret: str, config=None):
+        super().__init__(config)
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.access_token = access_token
+        self.access_token_secret = access_token_secret
+
+    async def send_message(self, message):
+        # Placeholder for sending a message via X.com/Twitter
+        pass
+
+    async def listen_and_process(self):
+        # Placeholder for listening to X.com/Twitter messages
+        pass
+
+    async def process_incoming(self, message):
+        # Placeholder for processing inbound X.com/Twitter messages
+        pass

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -89,6 +89,14 @@ class Settings(BaseSettings):
     reddit_username: str
     reddit_password: str
     reddit_user_agent: str
+    instagram_access_token: str
+    instagram_user_id: str
+    twitter_api_key: str
+    twitter_api_secret: str
+    twitter_access_token: str
+    twitter_access_token_secret: str
+    imessage_service_url: str
+    imessage_phone_number: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -81,6 +81,14 @@ reddit_client_secret: "your_reddit_client_secret"
 reddit_username: "your_reddit_username"
 reddit_password: "your_reddit_password"
 reddit_user_agent: "your_reddit_user_agent"
+instagram_access_token: "your_instagram_access_token"
+instagram_user_id: "your_instagram_user_id"
+twitter_api_key: "your_twitter_api_key"
+twitter_api_secret: "your_twitter_api_secret"
+twitter_access_token: "your_twitter_access_token"
+twitter_access_token_secret: "your_twitter_access_token_secret"
+imessage_service_url: "your_imessage_service_url"
+imessage_phone_number: "your_imessage_phone_number"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -32,6 +32,10 @@ The following connectors are soon to be supported:
 23. [Mattermost](./connectors/mattermost.md)
 24. [WeChat](./connectors/wechat.md)
 25. [Reddit Chat](./connectors/reddit_chat.md)
+26. [Signal](./connectors/signal.md)
+27. [Instagram DM](./connectors/instagram_dm.md)
+28. [X.com (Twitter)](./connectors/twitter.md)
+29. [Apple RCS/iMessage](./connectors/imessage.md)
 
 
 ## Usage

--- a/docs/connectors/imessage.md
+++ b/docs/connectors/imessage.md
@@ -1,0 +1,16 @@
+# Apple RCS/iMessage Connector
+
+The iMessage connector allows Norman to communicate through Apple's RCS/iMessage service.
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+imessage_service_url: "your_imessage_service_url"
+imessage_phone_number: "your_imessage_phone_number"
+```
+
+## Usage
+
+Once these settings are in place, Norman can send and receive iMessage messages via the configured service. The implementation is a stub that can be expanded to integrate with your chosen gateway.

--- a/docs/connectors/instagram_dm.md
+++ b/docs/connectors/instagram_dm.md
@@ -1,0 +1,16 @@
+# Instagram DM Connector
+
+The Instagram DM connector enables Norman to interact with Instagram direct messages.
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+instagram_access_token: "your_instagram_access_token"
+instagram_user_id: "your_instagram_user_id"
+```
+
+## Usage
+
+Once configured, Norman can send and receive direct messages via Instagram. The current implementation is a stub meant to be extended for your preferred integration method.

--- a/docs/connectors/twitter.md
+++ b/docs/connectors/twitter.md
@@ -1,0 +1,18 @@
+# X.com (Twitter) Connector
+
+This connector allows Norman to interact with X.com (formerly Twitter) via direct messages.
+
+## Configuration
+
+Add the following settings to your `config.yaml` file:
+
+```yaml
+twitter_api_key: "your_twitter_api_key"
+twitter_api_secret: "your_twitter_api_secret"
+twitter_access_token: "your_twitter_access_token"
+twitter_access_token_secret: "your_twitter_access_token_secret"
+```
+
+## Usage
+
+With these values provided, Norman will be able to send and receive messages through X.com. The current code is a stub intended for integration with the Twitter API.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -35,6 +35,9 @@ from app.connectors.rocketchat_connector import RocketChatConnector
 from app.connectors.mattermost_connector import MattermostConnector
 from app.connectors.wechat_connector import WeChatConnector
 from app.connectors.reddit_chat_connector import RedditChatConnector
+from app.connectors.instagram_dm_connector import InstagramDMConnector
+from app.connectors.twitter_connector import TwitterConnector
+from app.connectors.imessage_connector import IMessageConnector
 from app.core.test_settings import TestSettings
 
 
@@ -141,6 +144,24 @@ def test_get_connector_returns_reddit_chat(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     connector = get_connector('reddit_chat')
     assert isinstance(connector, RedditChatConnector)
+
+
+def test_get_connector_returns_instagram_dm(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('instagram_dm')
+    assert isinstance(connector, InstagramDMConnector)
+
+
+def test_get_connector_returns_twitter(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('twitter')
+    assert isinstance(connector, TwitterConnector)
+
+
+def test_get_connector_returns_imessage(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('imessage')
+    assert isinstance(connector, IMessageConnector)
 
 
 def test_get_connectors_data_missing_config(monkeypatch):


### PR DESCRIPTION
## Summary
- add stub connectors for Instagram DM, X.com (Twitter) and Apple iMessage
- support new connectors in connector utils and init routines
- expand `Settings` and `config.yaml.dist` with new configuration keys
- document the new connectors and list them in `connectors.md`
- test `get_connector` for the new connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae2ebcf248333975471687b6acf6d