### PR TITLE
Add APRS and AX.25 connectors

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -35,6 +35,8 @@ from .reddit_chat_connector import RedditChatConnector
 from .instagram_dm_connector import InstagramDMConnector
 from .twitter_connector import TwitterConnector
 from .imessage_connector import IMessageConnector
+from .aprs_connector import APRSConnector
+from .ax25_connector import AX25Connector
 
 from .connector_utils import get_connector
 
@@ -161,4 +163,14 @@ def init_connectors(app: FastAPI, settings: Settings):
     app.state.imessage_connector = IMessageConnector(
         service_url=settings.imessage_service_url,
         phone_number=settings.imessage_phone_number,
+    )
+    app.state.aprs_connector = APRSConnector(
+        host=settings.aprs_host,
+        port=settings.aprs_port,
+        callsign=settings.aprs_callsign,
+        passcode=settings.aprs_passcode,
+    )
+    app.state.ax25_connector = AX25Connector(
+        port=settings.ax25_port,
+        callsign=settings.ax25_callsign,
     )

--- a/app/connectors/aprs_connector.py
+++ b/app/connectors/aprs_connector.py
@@ -1,0 +1,55 @@
+from typing import Optional
+
+try:
+    import aprslib
+except ImportError:  # pragma: no cover - library optional
+    aprslib = None
+
+from .base_connector import BaseConnector
+
+
+class APRSConnector(BaseConnector):
+    """Connector for sending and receiving APRS packets via APRS-IS."""
+
+    id = "aprs"
+    name = "APRS"
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 14580,
+        callsign: str = "N0CALL",
+        passcode: str = "00000",
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.host = host
+        self.port = port
+        self.callsign = callsign
+        self.passcode = passcode
+        if aprslib:
+            self.client = aprslib.IS(callsign, passwd=passcode, host=host, port=port)
+        else:
+            self.client = None
+
+    async def send_message(self, message: str) -> None:
+        if not aprslib:
+            raise RuntimeError("aprslib not installed")
+        self.client.connect()
+        try:
+            self.client.sendall(message)
+        finally:
+            self.client.close()
+
+    async def listen_and_process(self) -> None:
+        if not aprslib:
+            raise RuntimeError("aprslib not installed")
+        self.client.connect()
+        try:
+            for msg in self.client:
+                await self.process_incoming(msg)
+        finally:
+            self.client.close()
+
+    async def process_incoming(self, message):
+        print(f"APRS received: {message}")

--- a/app/connectors/ax25_connector.py
+++ b/app/connectors/ax25_connector.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+try:
+    import ax25
+except ImportError:  # pragma: no cover - library optional
+    ax25 = None
+
+from .base_connector import BaseConnector
+
+
+class AX25Connector(BaseConnector):
+    """Connector for AX.25 packet radio."""
+
+    id = "ax25"
+    name = "AX.25"
+
+    def __init__(
+        self,
+        port: str,
+        callsign: str,
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.port = port
+        self.callsign = callsign
+        self.handle = None
+
+    async def send_message(self, message: str) -> None:
+        # Placeholder for sending a message via AX.25
+        pass
+
+    async def listen_and_process(self) -> None:
+        # Placeholder for listening for AX.25 messages
+        pass
+
+    async def process_incoming(self, message):
+        # Placeholder for processing inbound AX.25 messages
+        pass

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -45,6 +45,8 @@ from .reddit_chat_connector import RedditChatConnector
 from .instagram_dm_connector import InstagramDMConnector
 from .twitter_connector import TwitterConnector
 from .imessage_connector import IMessageConnector
+from .aprs_connector import APRSConnector
+from .ax25_connector import AX25Connector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -78,6 +80,8 @@ connector_classes: Dict[str, type] = {
     "instagram_dm": InstagramDMConnector,
     "twitter": TwitterConnector,
     "imessage": IMessageConnector,
+    "aprs": APRSConnector,
+    "ax25": AX25Connector,
 }
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -97,6 +97,12 @@ class Settings(BaseSettings):
     twitter_access_token_secret: str
     imessage_service_url: str
     imessage_phone_number: str
+    aprs_host: str
+    aprs_port: int
+    aprs_callsign: str
+    aprs_passcode: str
+    ax25_port: str
+    ax25_callsign: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -89,6 +89,12 @@ twitter_access_token: "your_twitter_access_token"
 twitter_access_token_secret: "your_twitter_access_token_secret"
 imessage_service_url: "your_imessage_service_url"
 imessage_phone_number: "your_imessage_phone_number"
+aprs_host: "your_aprs_host"
+aprs_port: 14580
+aprs_callsign: "your_aprs_callsign"
+aprs_passcode: "your_aprs_passcode"
+ax25_port: "your_ax25_port"
+ax25_callsign: "your_ax25_callsign"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -36,6 +36,8 @@ The following connectors are soon to be supported:
 27. [Instagram DM](./connectors/instagram_dm.md)
 28. [X.com (Twitter)](./connectors/twitter.md)
 29. [Apple RCS/iMessage](./connectors/imessage.md)
+30. [APRS](./connectors/aprs.md)
+31. [AX.25](./connectors/ax25.md)
 
 
 ## Usage

--- a/docs/connectors/aprs.md
+++ b/docs/connectors/aprs.md
@@ -1,0 +1,22 @@
+# APRS Connector
+
+The APRS connector allows Norman to send and receive packets over the APRS-IS network.
+
+## Configuration
+
+Add these keys to your `config.yaml`:
+
+```yaml
+aprs_host: "rotate.aprs.net"
+aprs_port: 14580
+aprs_callsign: "N0CALL"
+aprs_passcode: "00000"
+```
+
+## Usage
+
+Once configured, Norman can publish APRS packets to the specified server and listen for incoming packets.
+
+## Limitations
+
+This connector relies on the optional `aprslib` library. Ensure it is installed in your environment.

--- a/docs/connectors/ax25.md
+++ b/docs/connectors/ax25.md
@@ -1,0 +1,15 @@
+# AX.25 Connector
+
+The AX.25 connector is a placeholder for interacting with local packet radio hardware.
+
+## Configuration
+
+```yaml
+ax25_port: "your_ax25_port"
+ax25_callsign: "N0CALL"
+```
+
+## Usage
+
+This connector currently contains placeholder methods for sending and receiving AX.25 frames.
+

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -164,6 +164,20 @@ def test_get_connector_returns_imessage(monkeypatch):
     assert isinstance(connector, IMessageConnector)
 
 
+def test_get_connector_returns_aprs(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('aprs')
+    from app.connectors.aprs_connector import APRSConnector
+    assert isinstance(connector, APRSConnector)
+
+
+def test_get_connector_returns_ax25(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('ax25')
+    from app.connectors.ax25_connector import AX25Connector
+    assert isinstance(connector, AX25Connector)
+
+
 def test_get_connectors_data_missing_config(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     data = get_connectors_data()


### PR DESCRIPTION
## Summary
- add APRSConnector and AX25Connector classes
- initialize the new connectors and expose them through connector_utils
- update application settings and sample config
- document APRS and AX.25 connectors
- extend connector utility tests to cover new connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae4ae036c8333835967f7bb3e036f