### PR TITLE
Add connectors for Zapier, IFTTT and Salesforce

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -37,6 +37,9 @@ from .twitter_connector import TwitterConnector
 from .imessage_connector import IMessageConnector
 from .aprs_connector import APRSConnector
 from .ax25_connector import AX25Connector
+from .zapier_connector import ZapierConnector
+from .ifttt_connector import IFTTTConnector
+from .salesforce_connector import SalesforceConnector
 
 from .connector_utils import get_connector
 
@@ -173,4 +176,15 @@ def init_connectors(app: FastAPI, settings: Settings):
     app.state.ax25_connector = AX25Connector(
         port=settings.ax25_port,
         callsign=settings.ax25_callsign,
+    )
+    app.state.zapier_connector = ZapierConnector(
+        webhook_url=settings.zapier_webhook_url,
+    )
+    app.state.ifttt_connector = IFTTTConnector(
+        webhook_url=settings.ifttt_webhook_url,
+    )
+    app.state.salesforce_connector = SalesforceConnector(
+        instance_url=settings.salesforce_instance_url,
+        access_token=settings.salesforce_access_token,
+        endpoint=settings.salesforce_endpoint,
     )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -47,6 +47,9 @@ from .twitter_connector import TwitterConnector
 from .imessage_connector import IMessageConnector
 from .aprs_connector import APRSConnector
 from .ax25_connector import AX25Connector
+from .zapier_connector import ZapierConnector
+from .ifttt_connector import IFTTTConnector
+from .salesforce_connector import SalesforceConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -82,6 +85,9 @@ connector_classes: Dict[str, type] = {
     "imessage": IMessageConnector,
     "aprs": APRSConnector,
     "ax25": AX25Connector,
+    "zapier": ZapierConnector,
+    "ifttt": IFTTTConnector,
+    "salesforce": SalesforceConnector,
 }
 
 

--- a/app/connectors/ifttt_connector.py
+++ b/app/connectors/ifttt_connector.py
@@ -1,0 +1,33 @@
+import httpx
+from typing import Any, Dict, Optional
+
+from .base_connector import BaseConnector
+
+
+class IFTTTConnector(BaseConnector):
+    """Connector that posts messages to an IFTTT webhook."""
+
+    id = "ifttt"
+    name = "IFTTT"
+
+    def __init__(self, webhook_url: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.webhook_url = webhook_url
+
+    async def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(self.webhook_url, json=message)
+                response.raise_for_status()
+                return response.text
+            except httpx.HTTPError as exc:
+                print(f"Error sending message to IFTTT: {exc}")
+                return None
+
+    async def listen_and_process(self) -> None:
+        """IFTTT webhooks are outbound only."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        await self.send_message(message)
+        return message

--- a/app/connectors/salesforce_connector.py
+++ b/app/connectors/salesforce_connector.py
@@ -1,0 +1,47 @@
+import requests
+from typing import Any, Dict, Optional
+
+from .base_connector import BaseConnector
+
+
+class SalesforceConnector(BaseConnector):
+    """Simple connector for posting data to Salesforce REST endpoints."""
+
+    id = "salesforce"
+    name = "Salesforce"
+
+    def __init__(
+        self,
+        instance_url: str,
+        access_token: str,
+        endpoint: str,
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.instance_url = instance_url.rstrip("/")
+        self.access_token = access_token
+        self.endpoint = endpoint.lstrip("/")
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+
+    def send_message(self, data: Dict[str, Any]) -> Optional[str]:
+        url = f"{self.instance_url}/{self.endpoint}"
+        try:
+            resp = requests.post(url, json=data, headers=self._headers())
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending message to Salesforce: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Salesforce connector does not support inbound messages."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        self.send_message(message)
+        return message

--- a/app/connectors/zapier_connector.py
+++ b/app/connectors/zapier_connector.py
@@ -1,0 +1,33 @@
+import httpx
+from typing import Any, Dict, Optional
+
+from .base_connector import BaseConnector
+
+
+class ZapierConnector(BaseConnector):
+    """Connector that posts messages to a Zapier webhook."""
+
+    id = "zapier"
+    name = "Zapier"
+
+    def __init__(self, webhook_url: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.webhook_url = webhook_url
+
+    async def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(self.webhook_url, json=message)
+                response.raise_for_status()
+                return response.text
+            except httpx.HTTPError as exc:
+                print(f"Error sending message to Zapier: {exc}")
+                return None
+
+    async def listen_and_process(self) -> None:
+        """Zapier webhooks are outbound only."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        await self.send_message(message)
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -103,6 +103,11 @@ class Settings(BaseSettings):
     aprs_passcode: str
     ax25_port: str
     ax25_callsign: str
+    zapier_webhook_url: str
+    ifttt_webhook_url: str
+    salesforce_instance_url: str
+    salesforce_access_token: str
+    salesforce_endpoint: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -95,6 +95,11 @@ aprs_callsign: "your_aprs_callsign"
 aprs_passcode: "your_aprs_passcode"
 ax25_port: "your_ax25_port"
 ax25_callsign: "your_ax25_callsign"
+zapier_webhook_url: "your_zapier_webhook_url"
+ifttt_webhook_url: "your_ifttt_webhook_url"
+salesforce_instance_url: "your_salesforce_instance_url"
+salesforce_access_token: "your_salesforce_access_token"
+salesforce_endpoint: "your_salesforce_endpoint"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -38,6 +38,9 @@ The following connectors are soon to be supported:
 29. [Apple RCS/iMessage](./connectors/imessage.md)
 30. [APRS](./connectors/aprs.md)
 31. [AX.25](./connectors/ax25.md)
+32. [Zapier](./connectors/zapier.md)
+33. [IFTTT](./connectors/ifttt.md)
+34. [Salesforce](./connectors/salesforce.md)
 
 
 ## Usage
@@ -79,5 +82,8 @@ For more detailed information on each connector, please refer to the platform-sp
 - [MCP Connector](./connectors/mcp.md)
 - [MQTT Connector](./connectors/mqtt.md)
 - [Mastodon Connector](./connectors/mastodon.md)
+- [Zapier Connector](./connectors/zapier.md)
+- [IFTTT Connector](./connectors/ifttt.md)
+- [Salesforce Connector](./connectors/salesforce.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/ifttt.md
+++ b/docs/connectors/ifttt.md
@@ -1,0 +1,24 @@
+# IFTTT Connector
+
+The IFTTT connector integrates Norman with the IFTTT Webhooks service.
+
+## Requirements
+
+- An IFTTT Webhooks URL
+
+## Configuration
+
+Add the webhook URL to your `config.yaml` file:
+
+```yaml
+ifttt_webhook_url: "https://maker.ifttt.com/trigger/your-event/json"
+```
+
+## Usage
+
+Norman posts JSON payloads to the configured IFTTT webhook.
+
+## Troubleshooting
+
+1. Ensure the event name and key in the webhook URL are correct.
+2. Check the IFTTT activity log if requests fail.

--- a/docs/connectors/salesforce.md
+++ b/docs/connectors/salesforce.md
@@ -1,0 +1,29 @@
+# Salesforce Connector
+
+The Salesforce connector posts data to a Salesforce REST endpoint. Use it to integrate Norman with your Salesforce workflows.
+
+## Requirements
+
+- A Salesforce instance with API access
+- An OAuth access token for REST API calls
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+salesforce_instance_url: "https://your_instance.salesforce.com"
+salesforce_access_token: "your_salesforce_access_token"
+salesforce_endpoint: "services/data/vXX.X/sobjects/Lead"
+```
+
+`salesforce_endpoint` is appended to the instance URL when sending requests.
+
+## Usage
+
+Norman will POST JSON payloads to the specified Salesforce endpoint using the provided access token.
+
+## Troubleshooting
+
+1. Ensure the access token and instance URL are valid.
+2. Review Salesforce logs for any API errors.

--- a/docs/connectors/zapier.md
+++ b/docs/connectors/zapier.md
@@ -1,0 +1,24 @@
+# Zapier Connector
+
+The Zapier connector allows Norman to trigger Zapier workflows using the Zapier Webhooks service.
+
+## Requirements
+
+- A Zapier Webhooks URL
+
+## Configuration
+
+Add the webhook URL to your `config.yaml` file:
+
+```yaml
+zapier_webhook_url: "https://hooks.zapier.com/hooks/catch/your-id"
+```
+
+## Usage
+
+When enabled, Norman sends POST requests with message data to the configured Zapier webhook.
+
+## Troubleshooting
+
+1. Verify the webhook URL is correct.
+2. Check the Zapier task history for any failures.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -178,6 +178,27 @@ def test_get_connector_returns_ax25(monkeypatch):
     assert isinstance(connector, AX25Connector)
 
 
+def test_get_connector_returns_zapier(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('zapier')
+    from app.connectors.zapier_connector import ZapierConnector
+    assert isinstance(connector, ZapierConnector)
+
+
+def test_get_connector_returns_ifttt(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('ifttt')
+    from app.connectors.ifttt_connector import IFTTTConnector
+    assert isinstance(connector, IFTTTConnector)
+
+
+def test_get_connector_returns_salesforce(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('salesforce')
+    from app.connectors.salesforce_connector import SalesforceConnector
+    assert isinstance(connector, SalesforceConnector)
+
+
 def test_get_connectors_data_missing_config(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     data = get_connectors_data()


### PR DESCRIPTION
## Summary
- implement Zapier, IFTTT and Salesforce connectors
- expose configuration settings for the new connectors
- register connectors in utilities and initialization
- document the new connectors and update connector index
- test connector creation for the new connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae660d2bc8333920eac2e6c0a9382