### PR TITLE
Add GitHub and Jira Service Desk connectors

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -40,6 +40,8 @@ from .ax25_connector import AX25Connector
 from .zapier_connector import ZapierConnector
 from .ifttt_connector import IFTTTConnector
 from .salesforce_connector import SalesforceConnector
+from .github_connector import GitHubConnector
+from .jira_service_desk_connector import JiraServiceDeskConnector
 
 from .connector_utils import get_connector
 
@@ -187,4 +189,14 @@ def init_connectors(app: FastAPI, settings: Settings):
         instance_url=settings.salesforce_instance_url,
         access_token=settings.salesforce_access_token,
         endpoint=settings.salesforce_endpoint,
+    )
+    app.state.github_connector = GitHubConnector(
+        token=settings.github_token,
+        repo=settings.github_repo,
+    )
+    app.state.jira_service_desk_connector = JiraServiceDeskConnector(
+        url=settings.jira_service_desk_url,
+        email=settings.jira_service_desk_email,
+        api_token=settings.jira_service_desk_api_token,
+        project_key=settings.jira_service_desk_project_key,
     )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -50,6 +50,8 @@ from .ax25_connector import AX25Connector
 from .zapier_connector import ZapierConnector
 from .ifttt_connector import IFTTTConnector
 from .salesforce_connector import SalesforceConnector
+from .github_connector import GitHubConnector
+from .jira_service_desk_connector import JiraServiceDeskConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -88,6 +90,8 @@ connector_classes: Dict[str, type] = {
     "zapier": ZapierConnector,
     "ifttt": IFTTTConnector,
     "salesforce": SalesforceConnector,
+    "github": GitHubConnector,
+    "jira_service_desk": JiraServiceDeskConnector,
 }
 
 

--- a/app/connectors/github_connector.py
+++ b/app/connectors/github_connector.py
@@ -1,0 +1,48 @@
+import requests
+from typing import Any, Dict, Optional
+
+from .base_connector import BaseConnector
+
+
+class GitHubConnector(BaseConnector):
+    """Connector for interacting with GitHub issues and pull requests."""
+
+    id = "github"
+    name = "GitHub"
+
+    def __init__(self, token: str, repo: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.token = token
+        self.repo = repo
+        self.api_url = "https://api.github.com"
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+        }
+
+    def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        """Create an issue or comment on GitHub."""
+        issue_number = message.get("issue_number") or message.get("pr_number")
+        if issue_number:
+            url = f"{self.api_url}/repos/{self.repo}/issues/{issue_number}/comments"
+            payload = {"body": message.get("body", "")}
+        else:
+            url = f"{self.api_url}/repos/{self.repo}/issues"
+            payload = {"title": message.get("title", "Norman Issue"), "body": message.get("body", "")}
+        try:
+            response = requests.post(url, json=payload, headers=self._headers())
+            response.raise_for_status()
+            return response.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error communicating with GitHub: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """GitHub connector does not listen for inbound messages."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        self.send_message(message)
+        return message

--- a/app/connectors/jira_service_desk_connector.py
+++ b/app/connectors/jira_service_desk_connector.py
@@ -1,0 +1,57 @@
+import base64
+import requests
+from typing import Any, Dict, Optional
+
+from .base_connector import BaseConnector
+
+
+class JiraServiceDeskConnector(BaseConnector):
+    """Connector for Jira Service Desk comments and issues."""
+
+    id = "jira_service_desk"
+    name = "Jira Service Desk"
+
+    def __init__(self, url: str, email: str, api_token: str, project_key: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.url = url.rstrip("/")
+        self.email = email
+        self.api_token = api_token
+        self.project_key = project_key
+
+    def _headers(self) -> Dict[str, str]:
+        token = base64.b64encode(f"{self.email}:{self.api_token}".encode()).decode()
+        return {
+            "Authorization": f"Basic {token}",
+            "Content-Type": "application/json",
+        }
+
+    def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        issue_key = message.get("issue_key")
+        if issue_key:
+            url = f"{self.url}/rest/api/3/issue/{issue_key}/comment"
+            payload = {"body": message.get("body", "")}
+        else:
+            url = f"{self.url}/rest/api/3/issue"
+            payload = {
+                "fields": {
+                    "project": {"key": self.project_key},
+                    "summary": message.get("summary", "Norman Ticket"),
+                    "description": message.get("body", ""),
+                    "issuetype": {"name": "Task"},
+                }
+            }
+        try:
+            resp = requests.post(url, json=payload, headers=self._headers())
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error communicating with Jira Service Desk: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """This connector does not listen for inbound messages."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        self.send_message(message)
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -108,6 +108,12 @@ class Settings(BaseSettings):
     salesforce_instance_url: str
     salesforce_access_token: str
     salesforce_endpoint: str
+    github_token: str
+    github_repo: str
+    jira_service_desk_url: str
+    jira_service_desk_email: str
+    jira_service_desk_api_token: str
+    jira_service_desk_project_key: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -100,6 +100,12 @@ ifttt_webhook_url: "your_ifttt_webhook_url"
 salesforce_instance_url: "your_salesforce_instance_url"
 salesforce_access_token: "your_salesforce_access_token"
 salesforce_endpoint: "your_salesforce_endpoint"
+github_token: "your_github_token"
+github_repo: "your_username/your_repo"
+jira_service_desk_url: "https://your-domain.atlassian.net"
+jira_service_desk_email: "your_email@example.com"
+jira_service_desk_api_token: "your_jira_api_token"
+jira_service_desk_project_key: "PROJ"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -41,6 +41,8 @@ The following connectors are soon to be supported:
 32. [Zapier](./connectors/zapier.md)
 33. [IFTTT](./connectors/ifttt.md)
 34. [Salesforce](./connectors/salesforce.md)
+35. [GitHub](./connectors/github.md)
+36. [Jira Service Desk](./connectors/jira_service_desk.md)
 
 
 ## Usage
@@ -85,5 +87,7 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Zapier Connector](./connectors/zapier.md)
 - [IFTTT Connector](./connectors/ifttt.md)
 - [Salesforce Connector](./connectors/salesforce.md)
+- [GitHub Connector](./connectors/github.md)
+- [Jira Service Desk Connector](./connectors/jira_service_desk.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -1,0 +1,27 @@
+# GitHub Connector
+
+The GitHub connector lets Norman create issues or comments in a GitHub repository.
+
+## Requirements
+
+- A GitHub personal access token
+- The repository name in `owner/repo` format
+
+## Configuration
+
+Add these settings to your `config.yaml` file:
+
+```yaml
+github_token: "your_github_token"
+github_repo: "owner/repo"
+```
+
+## Usage
+
+When invoked, Norman will create a new issue or comment on an existing issue or pull request.
+Include `issue_number` or `pr_number` in the message payload to comment, otherwise a new issue is opened.
+
+## Troubleshooting
+
+1. Ensure the token has the `repo` scope.
+2. Check the repository name is correct and the bot has access.

--- a/docs/connectors/jira_service_desk.md
+++ b/docs/connectors/jira_service_desk.md
@@ -1,0 +1,29 @@
+# Jira Service Desk Connector
+
+This connector posts new issues or comments to Jira Service Desk.
+
+## Requirements
+
+- Jira Cloud instance and API token
+- Project key where issues should be created
+
+## Configuration
+
+Add the following keys to `config.yaml`:
+
+```yaml
+jira_service_desk_url: "https://your-domain.atlassian.net"
+jira_service_desk_email: "your_email@example.com"
+jira_service_desk_api_token: "your_jira_api_token"
+jira_service_desk_project_key: "PROJ"
+```
+
+## Usage
+
+Provide `issue_key` in the message payload to add a comment to an existing issue.
+If omitted, a new issue is created using the `summary` and `body` fields.
+
+## Troubleshooting
+
+1. Verify the API token and email are correct.
+2. Ensure the project key exists and the user has permission to create issues.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -199,6 +199,20 @@ def test_get_connector_returns_salesforce(monkeypatch):
     assert isinstance(connector, SalesforceConnector)
 
 
+def test_get_connector_returns_github(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('github')
+    from app.connectors.github_connector import GitHubConnector
+    assert isinstance(connector, GitHubConnector)
+
+
+def test_get_connector_returns_jira_service_desk(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('jira_service_desk')
+    from app.connectors.jira_service_desk_connector import JiraServiceDeskConnector
+    assert isinstance(connector, JiraServiceDeskConnector)
+
+
 def test_get_connectors_data_missing_config(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     data = get_connectors_data()


### PR DESCRIPTION
## Summary
- implement GitHub and Jira Service Desk connectors
- register connectors and document configuration
- extend settings & sample config
- document connectors in connectors list
- test utility function for new connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae816d5f48333b7059eb0a0130594