### PR TITLE
Add TAP/SNPP and ACARS connectors

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -42,6 +42,8 @@ from .ifttt_connector import IFTTTConnector
 from .salesforce_connector import SalesforceConnector
 from .github_connector import GitHubConnector
 from .jira_service_desk_connector import JiraServiceDeskConnector
+from .tap_snpp_connector import TAPSNPPConnector
+from .acars_connector import ACARSConnector
 
 from .connector_utils import get_connector
 
@@ -199,4 +201,13 @@ def init_connectors(app: FastAPI, settings: Settings):
         email=settings.jira_service_desk_email,
         api_token=settings.jira_service_desk_api_token,
         project_key=settings.jira_service_desk_project_key,
+    )
+    app.state.tap_snpp_connector = TAPSNPPConnector(
+        host=settings.tap_snpp_host,
+        port=settings.tap_snpp_port,
+        password=settings.tap_snpp_password,
+    )
+    app.state.acars_connector = ACARSConnector(
+        host=settings.acars_host,
+        port=settings.acars_port,
     )

--- a/app/connectors/acars_connector.py
+++ b/app/connectors/acars_connector.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from .base_connector import BaseConnector
+
+
+class ACARSConnector(BaseConnector):
+    """Connector for ACARS data link messages."""
+
+    id = "acars"
+    name = "ACARS"
+
+    def __init__(self, host: str, port: int = 429, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.host = host
+        self.port = port
+
+    async def send_message(self, message: str) -> None:
+        # Placeholder for sending an ACARS message
+        pass
+
+    async def listen_and_process(self) -> None:
+        # Placeholder for listening for ACARS messages
+        pass
+
+    async def process_incoming(self, message):
+        # Placeholder for processing inbound ACARS messages
+        pass

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -52,6 +52,8 @@ from .ifttt_connector import IFTTTConnector
 from .salesforce_connector import SalesforceConnector
 from .github_connector import GitHubConnector
 from .jira_service_desk_connector import JiraServiceDeskConnector
+from .tap_snpp_connector import TAPSNPPConnector
+from .acars_connector import ACARSConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -92,6 +94,8 @@ connector_classes: Dict[str, type] = {
     "salesforce": SalesforceConnector,
     "github": GitHubConnector,
     "jira_service_desk": JiraServiceDeskConnector,
+    "tap_snpp": TAPSNPPConnector,
+    "acars": ACARSConnector,
 }
 
 

--- a/app/connectors/tap_snpp_connector.py
+++ b/app/connectors/tap_snpp_connector.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from .base_connector import BaseConnector
+
+
+class TAPSNPPConnector(BaseConnector):
+    """Connector for TAP/SNPP paging services."""
+
+    id = "tap_snpp"
+    name = "TAP/SNPP"
+
+    def __init__(self, host: str, port: int = 444, password: Optional[str] = None, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.host = host
+        self.port = port
+        self.password = password
+
+    async def send_message(self, message: str) -> None:
+        # Placeholder for sending a page via TAP or SNPP
+        pass
+
+    async def listen_and_process(self) -> None:
+        # TAP/SNPP connectors are typically outbound only
+        return None
+
+    async def process_incoming(self, message):
+        # Placeholder for processing inbound TAP/SNPP messages
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -114,6 +114,11 @@ class Settings(BaseSettings):
     jira_service_desk_email: str
     jira_service_desk_api_token: str
     jira_service_desk_project_key: str
+    tap_snpp_host: str
+    tap_snpp_port: int
+    tap_snpp_password: str
+    acars_host: str
+    acars_port: int
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -106,6 +106,11 @@ jira_service_desk_url: "https://your-domain.atlassian.net"
 jira_service_desk_email: "your_email@example.com"
 jira_service_desk_api_token: "your_jira_api_token"
 jira_service_desk_project_key: "PROJ"
+tap_snpp_host: "your_tap_snpp_host"
+tap_snpp_port: 444
+tap_snpp_password: "your_tap_snpp_password"
+acars_host: "your_acars_host"
+acars_port: 429
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -43,6 +43,8 @@ The following connectors are soon to be supported:
 34. [Salesforce](./connectors/salesforce.md)
 35. [GitHub](./connectors/github.md)
 36. [Jira Service Desk](./connectors/jira_service_desk.md)
+37. [TAP/SNPP](./connectors/tap_snpp.md)
+38. [ACARS](./connectors/acars.md)
 
 
 ## Usage
@@ -89,5 +91,7 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Salesforce Connector](./connectors/salesforce.md)
 - [GitHub Connector](./connectors/github.md)
 - [Jira Service Desk Connector](./connectors/jira_service_desk.md)
+- [TAP/SNPP Connector](./connectors/tap_snpp.md)
+- [ACARS Connector](./connectors/acars.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/acars.md
+++ b/docs/connectors/acars.md
@@ -1,0 +1,16 @@
+# ACARS Connector
+
+The ACARS connector is a placeholder for communicating with ACARS ground stations.
+
+## Configuration
+
+Add these keys to your `config.yaml`:
+
+```yaml
+acars_host: "your_acars_host"
+acars_port: 429
+```
+
+## Usage
+
+This connector currently includes placeholder methods for sending and receiving ACARS messages.

--- a/docs/connectors/tap_snpp.md
+++ b/docs/connectors/tap_snpp.md
@@ -1,0 +1,17 @@
+# TAP/SNPP Connector
+
+The TAP/SNPP connector is a placeholder for sending pages using the Telocator Alphanumeric Protocol or Simple Network Paging Protocol.
+
+## Configuration
+
+Add these keys to your `config.yaml`:
+
+```yaml
+tap_snpp_host: "your_tap_snpp_host"
+tap_snpp_port: 444
+tap_snpp_password: "your_tap_snpp_password"
+```
+
+## Usage
+
+This connector currently contains placeholder methods for sending and receiving pages.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -213,6 +213,20 @@ def test_get_connector_returns_jira_service_desk(monkeypatch):
     assert isinstance(connector, JiraServiceDeskConnector)
 
 
+def test_get_connector_returns_tap_snpp(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('tap_snpp')
+    from app.connectors.tap_snpp_connector import TAPSNPPConnector
+    assert isinstance(connector, TAPSNPPConnector)
+
+
+def test_get_connector_returns_acars(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('acars')
+    from app.connectors.acars_connector import ACARSConnector
+    assert isinstance(connector, ACARSConnector)
+
+
 def test_get_connectors_data_missing_config(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     data = get_connectors_data()


### PR DESCRIPTION
## Summary
- add TAP/SNPP and ACARS connector modules
- register connectors in `connector_utils` and initialization
- document connectors and list in overview
- expose new configuration settings
- test connector lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aea160ac88333af804e2d6fd03b4c