### PR TITLE
Improve base connector

### DIFF
--- a/app/connectors/base_connector.py
+++ b/app/connectors/base_connector.py
@@ -1,41 +1,74 @@
+"""Base connector class used by all connector implementations."""
+
 import asyncio
+import contextlib
+import logging
 from abc import ABC, abstractmethod
+from typing import Any, Optional
 
 
 class BaseConnector(ABC):
 
-    def __init__(self, config=None):
-        """Initialize the connector with optional configuration.
+    def __init__(self, config: Optional[dict] = None) -> None:
+        """Initialize the connector with optional configuration."""
 
-        Args:
-            config (dict | None): Optional configuration dictionary.  If not
-                provided, an empty dict is used.
-        """
         self.config = config or {}
-    @abstractmethod
-    async def send_message(self, message):
-        """Send a message using the connector.
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self._send_queue: asyncio.Queue[Any] = asyncio.Queue()
+        self._dispatcher_task: Optional[asyncio.Task] = None
+    async def connect(self) -> None:  # pragma: no cover - default no-op
+        """Establish any connection required by the connector."""
 
-        Args:
-            message (dict): A dictionary containing the message data.
-        """
-        pass
-
-    @abstractmethod
-    async def listen_and_process(self):
-        """Listen for incoming messages and process them."""
-        pass
+    async def disconnect(self) -> None:  # pragma: no cover - default no-op
+        """Disconnect and clean up resources."""
 
     @abstractmethod
-    async def process_incoming(self, message):
-        """Process an incoming message.
+    def send_message(self, message: Any) -> Any:
+        """Send ``message`` to the remote service."""
 
-        Args:
-            message (dict): A dictionary containing the message data.
-        """
-        pass
+    @abstractmethod
+    async def listen_and_process(self) -> None:
+        """Listen for incoming messages and pass them to :meth:`process_incoming`."""
 
-    async def run(self):
-        """Start the connector and keep it running."""
-        await self.listen_and_process()
+    @abstractmethod
+    async def process_incoming(self, message: Any) -> Any:
+        """Handle an incoming message from the service."""
+
+    async def queue_message(self, message: Any) -> None:
+        """Queue ``message`` to be sent asynchronously."""
+
+        await self._send_queue.put(message)
+
+    async def _dispatcher(self) -> None:
+        """Background task that sends queued messages."""
+
+        while True:
+            msg = await self._send_queue.get()
+            try:
+                result = self.send_message(msg)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception:  # pylint: disable=broad-except
+                self.logger.exception("Failed to send message")
+            finally:
+                self._send_queue.task_done()
+
+    async def run(self) -> None:
+        """Connect, dispatch queued messages, and listen indefinitely."""
+
+        connect_result = self.connect()
+        if asyncio.iscoroutine(connect_result):
+            await connect_result
+
+        self._dispatcher_task = asyncio.create_task(self._dispatcher())
+        try:
+            await self.listen_and_process()
+        finally:
+            if self._dispatcher_task:
+                self._dispatcher_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._dispatcher_task
+            disconnect_result = self.disconnect()
+            if asyncio.iscoroutine(disconnect_result):
+                await disconnect_result
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -66,7 +66,7 @@ For other connectors, consult the platform-specific documentation for informatio
 
 ### Extending Norman with New Connectors
 
-You can extend Norman with new connectors by creating a new class that inherits from `BaseConnector`. This class should implement the required methods to send and receive messages on the target platform. Then, add the new connector class to the `CONNECTOR_CLASSES` dictionary in `app/connectors/__init__.py` so that it can be used in the application.
+You can extend Norman with new connectors by creating a new class that inherits from `BaseConnector`. Implement `send_message` and optionally `connect` and `disconnect` for any setup or teardown logic. Messages can be queued with `queue_message` and will be dispatched while `run()` is active. Finally, add the new connector class to the `CONNECTOR_CLASSES` dictionary in `app/connectors/__init__.py` so that it can be used in the application.
 
 ## More Information
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -17,7 +17,7 @@ Norman supports various chat platforms through connectors. To create a new conne
 
 1. Create a new Python file in the `app/connectors` directory with a descriptive name, e.g., `custom_connector.py`.
 
-2. Inherit from the `BaseConnector` class and implement the required methods, such as `connect`, `disconnect`, and `send_message`.
+2. Inherit from the `BaseConnector` class and implement the required methods.  At a minimum you should provide `send_message` as well as optional `connect` and `disconnect` hooks.  You can also override `listen_and_process` and `process_incoming` to handle incoming data.
 
 3. Update the `app/connectors/__init__.py` file to import your new connector class.
 
@@ -25,7 +25,9 @@ Norman supports various chat platforms through connectors. To create a new conne
 
 5. Update the configuration files to include any necessary settings for your connector.
 
-6. Test your new connector and ensure it works correctly with Norman's core functionality.
+6. You can send messages by calling `queue_message`; `run()` starts a background dispatcher that forwards queued messages using your `send_message` implementation.
+
+7. Test your new connector and ensure it works correctly with Norman's core functionality.
 
 ## Adding Custom Actions
 


### PR DESCRIPTION
## Summary
- extend `BaseConnector` with connection lifecycle handling
- document how to use queue_message and run()

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683aec6b206483339d1c3e20d36c0c21