### PR TITLE
Add basic connectors and tests

### DIFF
--- a/app/connectors/mcp_connector.py
+++ b/app/connectors/mcp_connector.py
@@ -1,3 +1,8 @@
+"""Connector for sending events to a generic MCP HTTP service."""
+
+import httpx
+from typing import Any, Dict, Optional
+
 from .base_connector import BaseConnector
 
 class MCPConnector(BaseConnector):
@@ -6,19 +11,30 @@ class MCPConnector(BaseConnector):
     id = 'mcp'
     name = 'MCP'
 
-    def __init__(self, api_url: str, api_key: str, config=None):
+    def __init__(self, api_url: str, api_key: str, config: Optional[dict] = None) -> None:
         super().__init__(config)
-        self.api_url = api_url
+        self.api_url = api_url.rstrip("/")
         self.api_key = api_key
 
-    async def send_message(self, message):
-        # Implement sending a message to MCP
-        pass
+    async def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        """POST ``message`` to the MCP API."""
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(
+                    self.api_url,
+                    json=message,
+                    headers={"Authorization": f"Bearer {self.api_key}"},
+                )
+                resp.raise_for_status()
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                print(f"Error sending message to MCP: {exc}")
+                return None
 
-    async def listen_and_process(self):
-        # Implement listening for MCP events
-        pass
+    async def listen_and_process(self) -> None:
+        """This connector does not actively listen for events."""
+        return None
 
-    async def process_incoming(self, message):
-        # Process an incoming MCP message
-        pass
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        await self.send_message(message)
+        return message

--- a/app/connectors/whatsapp_connector.py
+++ b/app/connectors/whatsapp_connector.py
@@ -1,3 +1,8 @@
+"""WhatsApp connector implemented using the Twilio API."""
+
+import requests
+from typing import Any, Dict, Optional
+
 from .base_connector import BaseConnector
 
 class WhatsAppConnector(BaseConnector):
@@ -6,23 +11,48 @@ class WhatsAppConnector(BaseConnector):
     id = 'whatsapp'
     name = 'WhatsApp'
 
-    def __init__(self, account_sid: str, auth_token: str, from_number: str, to_number: str, config=None):
+    def __init__(
+        self,
+        account_sid: str,
+        auth_token: str,
+        from_number: str,
+        to_number: str,
+        config: Optional[dict] = None,
+    ) -> None:
         super().__init__(config)
         self.account_sid = account_sid
         self.auth_token = auth_token
         self.from_number = from_number
         self.to_number = to_number
 
-    async def send_message(self, message):
-        # Code to send a message using the Twilio API
-        pass
+    def _url(self) -> str:
+        return (
+            f"https://api.twilio.com/2010-04-01/Accounts/{self.account_sid}/Messages.json"
+        )
+
+    def send_message(self, text: str) -> Optional[str]:
+        """Send ``text`` to the configured WhatsApp number via Twilio."""
+        data = {
+            "From": f"whatsapp:{self.from_number}",
+            "To": f"whatsapp:{self.to_number}",
+            "Body": text,
+        }
+        try:
+            resp = requests.post(
+                self._url(), data=data, auth=(self.account_sid, self.auth_token)
+            )
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending WhatsApp message: {exc}")
+            return None
 
     async def listen_and_process(self):
         # Code to listen for incoming messages from WhatsApp
         # and call process_incoming for each message
-        pass
+        return None
 
     async def process_incoming(self, message):
         # Code to process the incoming message, including applying filters
         # and calling the appropriate action(s)
-        pass
+        return message

--- a/tests/connectors/test_mcp.py
+++ b/tests/connectors/test_mcp.py
@@ -1,0 +1,71 @@
+import asyncio
+import httpx
+import pytest
+
+from app.connectors.mcp_connector import MCPConnector
+
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, headers=None):
+        self.sent = (url, json, headers)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(resp))
+    connector = MCPConnector("http://api", "KEY")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message({"hi": 1})
+    )
+    assert result == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None, headers=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = MCPConnector("http://api", "KEY")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message({"hi": 1})
+    )
+    assert result is None
+
+
+def test_process_incoming(monkeypatch):
+    called = {}
+
+    async def fake_send(message):
+        called["msg"] = message
+        return "ok"
+
+    connector = MCPConnector("http://api", "KEY")
+    monkeypatch.setattr(connector, "send_message", fake_send)
+    msg = {"foo": "bar"}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(msg)
+    )
+    assert result == msg
+    assert called["msg"] == msg

--- a/tests/connectors/test_rest_callback.py
+++ b/tests/connectors/test_rest_callback.py
@@ -1,0 +1,71 @@
+import asyncio
+import httpx
+import pytest
+
+from app.connectors.rest_callback_connector import RESTCallbackConnector
+
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None):
+        self.sent = (url, json)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(resp))
+    connector = RESTCallbackConnector("http://example.com")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message({"hi": 1})
+    )
+    assert result == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = RESTCallbackConnector("http://example.com")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message({"hi": 1})
+    )
+    assert result is None
+
+
+def test_process_incoming(monkeypatch):
+    called = {}
+
+    async def fake_send(msg):
+        called["msg"] = msg
+        return "ok"
+
+    connector = RESTCallbackConnector("http://example.com")
+    monkeypatch.setattr(connector, "send_message", fake_send)
+    payload = {"foo": 1}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload
+    assert called["msg"] == payload

--- a/tests/connectors/test_whatsapp.py
+++ b/tests/connectors/test_whatsapp.py
@@ -1,0 +1,45 @@
+import requests
+from app.connectors.whatsapp_connector import WhatsAppConnector
+
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError("error")
+
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, data=None, auth=None):
+        assert "Accounts" in url
+        assert data["From"].startswith("whatsapp:")
+        assert auth == ("SID", "TOKEN")
+        return DummyResponse("sent")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = WhatsAppConnector("SID", "TOKEN", "+1", "+2")
+    assert connector.send_message("hi") == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, data=None, auth=None):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = WhatsAppConnector("SID", "TOKEN", "+1", "+2")
+    assert connector.send_message("hi") is None
+
+
+import asyncio
+
+
+def test_process_incoming():
+    connector = WhatsAppConnector("SID", "TOKEN", "+1", "+2")
+    payload = {"body": "hello"}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload


### PR DESCRIPTION
## Summary
- expand WhatsAppConnector with Twilio implementation
- add MCPConnector HTTP implementation
- test WhatsApp, MCP and REST callback connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aedb721e08333bdd517a8ec9e51db