### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -18,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/KristopherKubicki/norman/actions/workflows/ci_cd.yml/badge.svg)](https://github.com/KristopherKubicki/norman/actions/workflows/ci_cd.yml)
 [![Codecov](https://codecov.io/gh/KristopherKubicki/norman/branch/main/graph/badge.svg)](https://codecov.io/gh/KristopherKubicki/norman)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
-[![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/)
+[![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/)
 
 Norman is an open-source chatbot that leverages OpenAI's GPT models to assist and automate communication on various chat platforms like Slack and IRC. The project is built with FastAPI, SQLite, and SQLAlchemy, and is designed to be easily extensible with additional connectors.
 
@@ -44,7 +44,7 @@ Norman is an open-source chatbot that leverages OpenAI's GPT models to assist an
 
 ### Prerequisites
 
-- Python 3.8 or higher
+- Python 3.8 to 3.11
 - pip
 - SQLite
 - virtualenv (optional)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,7 +17,7 @@ This document outlines the steps to deploy Norman on a server or cloud provider.
 
 Before deploying Norman, ensure that your server meets the following requirements:
 
-- Python 3.8 or higher
+- Python 3.8 to 3.11
 - SQLite (or another supported database system)
 - A compatible operating system, such as Ubuntu, Debian, or CentOS
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
             "pytest-asyncio",
         ]
     },
+    python_requires=">=3.8, <3.12",
     entry_points={
         "console_scripts": [
             "norman = main:main",


### PR DESCRIPTION
## Summary
- test against Python 3.8-3.11 in CI
- show Python 3.11 badge in README
- document Python 3.8-3.11 requirement
- specify compatible Python versions in `setup.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aeddc59248333b0586193a792074b