### PR TITLE
Fix ForwardRef patch for Python 3.9

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,11 +4,21 @@ from typing import ForwardRef, Any, cast
 import inspect
 import pydantic.typing as _pydantic_typing
 
-# Pydantic 1.x doesn't support Python 3.12's updated ForwardRef._evaluate
+# Pydantic 1.x doesn't fully support Python's various ForwardRef._evaluate
+# signatures across versions. We inspect the signature and delegate accordingly
+# so that both Python <3.12 and >=3.12 work.
 sig = inspect.signature(ForwardRef._evaluate)
 if 'recursive_guard' in sig.parameters:
     def _evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
-        return cast(Any, type_)._evaluate(globalns, localns, None, recursive_guard=set())
+        if 'type_params' in sig.parameters:
+            # Python >=3.12 has a ``type_params`` positional argument and
+            # ``recursive_guard`` is keyword only
+            return cast(Any, type_)._evaluate(
+                globalns, localns, None, recursive_guard=set()
+            )
+        else:
+            # Older versions expect ``recursive_guard`` as the third positional
+            return cast(Any, type_)._evaluate(globalns, localns, recursive_guard=set())
 
     _pydantic_typing.evaluate_forwardref = _evaluate_forwardref
 


### PR DESCRIPTION
## Summary
- handle different ForwardRef._evaluate signatures across Python versions

## Testing
- `coverage run -m pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_683aef53661483338512d0698f3f8f7f