### PR TITLE
Add RFC 5425 connector

### DIFF
--- a/app/connectors/TODO.md
+++ b/app/connectors/TODO.md
@@ -17,3 +17,4 @@ This file tracks connectors that we would like to implement in the future.
 - [x] Mattermost
 - [x] WeChat
 - [x] Reddit Chat
+- [x] RFC 5425 Syslog

--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -44,6 +44,7 @@ from .github_connector import GitHubConnector
 from .jira_service_desk_connector import JiraServiceDeskConnector
 from .tap_snpp_connector import TAPSNPPConnector
 from .acars_connector import ACARSConnector
+from .rfc5425_connector import RFC5425Connector
 
 from .connector_utils import get_connector
 
@@ -210,4 +211,8 @@ def init_connectors(app: FastAPI, settings: Settings):
     app.state.acars_connector = ACARSConnector(
         host=settings.acars_host,
         port=settings.acars_port,
+    )
+    app.state.rfc5425_connector = RFC5425Connector(
+        host=settings.rfc5425_host,
+        port=settings.rfc5425_port,
     )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -54,6 +54,7 @@ from .github_connector import GitHubConnector
 from .jira_service_desk_connector import JiraServiceDeskConnector
 from .tap_snpp_connector import TAPSNPPConnector
 from .acars_connector import ACARSConnector
+from .rfc5425_connector import RFC5425Connector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -96,6 +97,7 @@ connector_classes: Dict[str, type] = {
     "jira_service_desk": JiraServiceDeskConnector,
     "tap_snpp": TAPSNPPConnector,
     "acars": ACARSConnector,
+    "rfc5425": RFC5425Connector,
 }
 
 

--- a/app/connectors/rfc5425_connector.py
+++ b/app/connectors/rfc5425_connector.py
@@ -1,0 +1,52 @@
+"""Connector for sending syslog messages over TLS as defined in RFC 5425."""
+
+import ssl
+import socket
+from typing import Optional
+
+from .base_connector import BaseConnector
+
+
+class RFC5425Connector(BaseConnector):
+    """Simple connector for RFC 5425 TLS syslog servers."""
+
+    id = "rfc5425"
+    name = "RFC 5425 Syslog"
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 6514,
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.host = host
+        self.port = port
+        self._socket: Optional[socket.socket] = None
+
+    def connect(self) -> None:
+        context = ssl.create_default_context()
+        raw_sock = socket.create_connection((self.host, self.port))
+        self._socket = context.wrap_socket(raw_sock, server_hostname=self.host)
+
+    def disconnect(self) -> None:
+        if self._socket:
+            try:
+                self._socket.close()
+            finally:
+                self._socket = None
+
+    def send_message(self, message: str) -> None:
+        if not self._socket:
+            self.connect()
+        assert self._socket is not None  # mypy helper
+        data = message.encode("utf-8")
+        framed = f"{len(data)} ".encode("ascii") + data
+        self._socket.sendall(framed)
+
+    async def listen_and_process(self) -> None:
+        """RFC 5425 is typically used for outbound logs only."""
+        return None
+
+    async def process_incoming(self, message):
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -119,6 +119,8 @@ class Settings(BaseSettings):
     tap_snpp_password: str
     acars_host: str
     acars_port: int
+    rfc5425_host: str
+    rfc5425_port: int
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -111,6 +111,8 @@ tap_snpp_port: 444
 tap_snpp_password: "your_tap_snpp_password"
 acars_host: "your_acars_host"
 acars_port: 429
+rfc5425_host: "your_rfc5425_host"
+rfc5425_port: 6514
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -45,6 +45,7 @@ The following connectors are soon to be supported:
 36. [Jira Service Desk](./connectors/jira_service_desk.md)
 37. [TAP/SNPP](./connectors/tap_snpp.md)
 38. [ACARS](./connectors/acars.md)
+39. [RFC 5425](./connectors/rfc5425.md)
 
 
 ## Usage
@@ -93,5 +94,6 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Jira Service Desk Connector](./connectors/jira_service_desk.md)
 - [TAP/SNPP Connector](./connectors/tap_snpp.md)
 - [ACARS Connector](./connectors/acars.md)
+- [RFC 5425 Connector](./connectors/rfc5425.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/rfc5425.md
+++ b/docs/connectors/rfc5425.md
@@ -1,0 +1,23 @@
+# RFC 5425 Connector
+
+The RFC 5425 connector sends syslog messages to a remote server using TLS.
+
+## Requirements
+
+- A syslog server that supports RFC 5425 (syslog over TLS)
+- Hostname and port for the server
+
+## Configuration
+
+Add the following settings to your `config.yaml`:
+
+```yaml
+rfc5425_host: "your_rfc5425_host"
+rfc5425_port: 6514
+```
+
+## Usage
+
+Once configured, Norman can send logs to the specified syslog server.
+Incoming messages are not processed.
+

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -38,6 +38,7 @@ from app.connectors.reddit_chat_connector import RedditChatConnector
 from app.connectors.instagram_dm_connector import InstagramDMConnector
 from app.connectors.twitter_connector import TwitterConnector
 from app.connectors.imessage_connector import IMessageConnector
+from app.connectors.rfc5425_connector import RFC5425Connector
 from app.core.test_settings import TestSettings
 
 
@@ -225,6 +226,12 @@ def test_get_connector_returns_acars(monkeypatch):
     connector = get_connector('acars')
     from app.connectors.acars_connector import ACARSConnector
     assert isinstance(connector, ACARSConnector)
+
+
+def test_get_connector_returns_rfc5425(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('rfc5425')
+    assert isinstance(connector, RFC5425Connector)
 
 
 def test_get_connectors_data_missing_config(monkeypatch):


### PR DESCRIPTION
## Summary
- add RFC5425Connector for syslog over TLS
- register the new connector with utilities and init
- document configuration options
- include RFC 5425 in connectors listing and TODO
- add tests for new connector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683af24fd1248333967b7e3fffb39ae6