### PR TITLE
Add cloud event connectors

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -44,6 +44,10 @@ from .github_connector import GitHubConnector
 from .jira_service_desk_connector import JiraServiceDeskConnector
 from .tap_snpp_connector import TAPSNPPConnector
 from .acars_connector import ACARSConnector
+from .aws_iot_core_connector import AWSIoTCoreConnector
+from .eventbridge_connector import EventBridgeConnector
+from .google_pubsub_connector import GooglePubSubConnector
+from .azure_event_grid_connector import AzureEventGridConnector
 
 from .connector_utils import get_connector
 
@@ -210,4 +214,28 @@ def init_connectors(app: FastAPI, settings: Settings):
     app.state.acars_connector = ACARSConnector(
         host=settings.acars_host,
         port=settings.acars_port,
+    )
+    app.state.aws_iot_core_connector = AWSIoTCoreConnector(
+        topic=settings.aws_iot_core_topic,
+        region_name=settings.aws_region,
+        endpoint=settings.aws_iot_core_endpoint,
+        access_key=settings.aws_access_key,
+        secret_key=settings.aws_secret_key,
+        session_token=settings.aws_session_token,
+    )
+    app.state.eventbridge_connector = EventBridgeConnector(
+        event_bus_name=settings.eventbridge_event_bus_name,
+        source=settings.eventbridge_source,
+        region_name=settings.aws_region,
+        access_key=settings.aws_access_key,
+        secret_key=settings.aws_secret_key,
+        session_token=settings.aws_session_token,
+    )
+    app.state.google_pubsub_connector = GooglePubSubConnector(
+        project_id=settings.google_pubsub_project_id,
+        topic_id=settings.google_pubsub_topic_id,
+    )
+    app.state.azure_event_grid_connector = AzureEventGridConnector(
+        endpoint=settings.azure_event_grid_endpoint,
+        access_key=settings.azure_event_grid_access_key,
     )

--- a/app/connectors/aws_iot_core_connector.py
+++ b/app/connectors/aws_iot_core_connector.py
@@ -1,0 +1,60 @@
+import json
+from typing import Optional
+
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:  # pragma: no cover - optional dependency
+    boto3 = None
+    BotoCoreError = ClientError = Exception
+
+from .base_connector import BaseConnector
+
+
+class AWSIoTCoreConnector(BaseConnector):
+    """Connector that publishes messages to AWS IoT Core."""
+
+    id = "aws_iot_core"
+    name = "AWS IoT Core"
+
+    def __init__(
+        self,
+        topic: str,
+        region_name: str = "us-east-1",
+        endpoint: Optional[str] = None,
+        access_key: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        session_token: Optional[str] = None,
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.topic = topic
+        if boto3:
+            self.client = boto3.client(
+                "iot-data",
+                region_name=region_name,
+                endpoint_url=endpoint,
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                aws_session_token=session_token,
+            )
+        else:  # pragma: no cover - library may not be installed
+            self.client = None
+
+    async def send_message(self, message: str) -> Optional[str]:
+        if not boto3:
+            raise RuntimeError("boto3 not installed")
+        try:
+            resp = self.client.publish(topic=self.topic, qos=0, payload=message)
+            return json.dumps(resp)
+        except (BotoCoreError, ClientError) as exc:  # pragma: no cover - network
+            print(f"Error publishing to AWS IoT Core: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """AWS IoT Core connector does not receive messages."""
+        return None
+
+    async def process_incoming(self, message: str) -> str:
+        await self.send_message(message)
+        return message

--- a/app/connectors/azure_event_grid_connector.py
+++ b/app/connectors/azure_event_grid_connector.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, Optional
+
+try:
+    from azure.eventgrid import EventGridPublisherClient, EventGridEvent
+    from azure.core.credentials import AzureKeyCredential
+except ImportError:  # pragma: no cover - optional dependency
+    EventGridPublisherClient = None
+    EventGridEvent = None
+    AzureKeyCredential = None
+
+from .base_connector import BaseConnector
+
+
+class AzureEventGridConnector(BaseConnector):
+    """Connector for sending events to Azure Event Grid."""
+
+    id = "azure_event_grid"
+    name = "Azure Event Grid"
+
+    def __init__(
+        self,
+        endpoint: str,
+        access_key: str,
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.endpoint = endpoint
+        self.access_key = access_key
+        if EventGridPublisherClient:
+            credential = AzureKeyCredential(access_key)
+            self.client = EventGridPublisherClient(endpoint, credential)
+        else:  # pragma: no cover
+            self.client = None
+
+    async def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        if not EventGridPublisherClient:
+            raise RuntimeError("azure-eventgrid not installed")
+        event = EventGridEvent(
+            subject=message.get("subject", "Norman"),
+            data=message.get("data", {}),
+            event_type=message.get("event_type", "Norman.Event"),
+            data_version=message.get("data_version", "1.0"),
+        )
+        try:
+            self.client.send([event])
+            return "sent"
+        except Exception as exc:  # pragma: no cover - network
+            print(f"Error sending to Event Grid: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Event Grid connector does not receive messages."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        await self.send_message(message)
+        return message

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -54,6 +54,10 @@ from .github_connector import GitHubConnector
 from .jira_service_desk_connector import JiraServiceDeskConnector
 from .tap_snpp_connector import TAPSNPPConnector
 from .acars_connector import ACARSConnector
+from .aws_iot_core_connector import AWSIoTCoreConnector
+from .eventbridge_connector import EventBridgeConnector
+from .google_pubsub_connector import GooglePubSubConnector
+from .azure_event_grid_connector import AzureEventGridConnector
 
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
@@ -96,6 +100,10 @@ connector_classes: Dict[str, type] = {
     "jira_service_desk": JiraServiceDeskConnector,
     "tap_snpp": TAPSNPPConnector,
     "acars": ACARSConnector,
+    "aws_iot_core": AWSIoTCoreConnector,
+    "eventbridge": EventBridgeConnector,
+    "google_pubsub": GooglePubSubConnector,
+    "azure_event_grid": AzureEventGridConnector,
 }
 
 

--- a/app/connectors/eventbridge_connector.py
+++ b/app/connectors/eventbridge_connector.py
@@ -1,0 +1,66 @@
+import json
+from typing import Any, Dict, Optional
+
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:  # pragma: no cover - optional dependency
+    boto3 = None
+    BotoCoreError = ClientError = Exception
+
+from .base_connector import BaseConnector
+
+
+class EventBridgeConnector(BaseConnector):
+    """Connector that sends events to AWS EventBridge."""
+
+    id = "eventbridge"
+    name = "AWS EventBridge"
+
+    def __init__(
+        self,
+        event_bus_name: str,
+        source: str = "norman",
+        region_name: str = "us-east-1",
+        access_key: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        session_token: Optional[str] = None,
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.event_bus_name = event_bus_name
+        self.source = source
+        if boto3:
+            self.client = boto3.client(
+                "events",
+                region_name=region_name,
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                aws_session_token=session_token,
+            )
+        else:  # pragma: no cover
+            self.client = None
+
+    async def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        if not boto3:
+            raise RuntimeError("boto3 not installed")
+        entry = {
+            "EventBusName": self.event_bus_name,
+            "Source": self.source,
+            "DetailType": message.get("detail_type", "NormanEvent"),
+            "Detail": json.dumps(message.get("detail", {})),
+        }
+        try:
+            resp = self.client.put_events(Entries=[entry])
+            return str(resp)
+        except (BotoCoreError, ClientError) as exc:  # pragma: no cover
+            print(f"Error sending event to EventBridge: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """EventBridge connector does not receive messages."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        await self.send_message(message)
+        return message

--- a/app/connectors/google_pubsub_connector.py
+++ b/app/connectors/google_pubsub_connector.py
@@ -1,0 +1,44 @@
+from typing import Optional
+
+try:
+    from google.cloud import pubsub_v1
+except ImportError:  # pragma: no cover - optional dependency
+    pubsub_v1 = None
+
+from .base_connector import BaseConnector
+
+
+class GooglePubSubConnector(BaseConnector):
+    """Connector that publishes messages to Google Pub/Sub."""
+
+    id = "google_pubsub"
+    name = "Google Pub/Sub"
+
+    def __init__(
+        self,
+        project_id: str,
+        topic_id: str,
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.project_id = project_id
+        self.topic_id = topic_id
+        if pubsub_v1:
+            self.publisher = pubsub_v1.PublisherClient()
+            self.topic_path = self.publisher.topic_path(project_id, topic_id)
+        else:  # pragma: no cover
+            self.publisher = None
+            self.topic_path = None
+
+    async def send_message(self, message: str) -> None:
+        if not pubsub_v1:
+            raise RuntimeError("google-cloud-pubsub not installed")
+        self.publisher.publish(self.topic_path, message.encode())
+
+    async def listen_and_process(self) -> None:
+        """Pub/Sub connector does not support inbound messages."""
+        return None
+
+    async def process_incoming(self, message: str) -> str:
+        await self.send_message(message)
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -119,6 +119,18 @@ class Settings(BaseSettings):
     tap_snpp_password: str
     acars_host: str
     acars_port: int
+    aws_region: str
+    aws_iot_core_endpoint: str
+    aws_iot_core_topic: str
+    aws_access_key: str
+    aws_secret_key: str
+    aws_session_token: str
+    eventbridge_event_bus_name: str
+    eventbridge_source: str
+    google_pubsub_project_id: str
+    google_pubsub_topic_id: str
+    azure_event_grid_endpoint: str
+    azure_event_grid_access_key: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -112,6 +112,24 @@ tap_snpp_password: "your_tap_snpp_password"
 acars_host: "your_acars_host"
 acars_port: 429
 
+# AWS IoT Core / EventBridge
+aws_region: "us-east-1"
+aws_iot_core_endpoint: "your_iot_endpoint"
+aws_iot_core_topic: "your_iot_topic"
+aws_access_key: "your_aws_access_key"
+aws_secret_key: "your_aws_secret_key"
+aws_session_token: "your_aws_session_token"
+eventbridge_event_bus_name: "default"
+eventbridge_source: "norman"
+
+# Google Pub/Sub
+google_pubsub_project_id: "your_gcp_project"
+google_pubsub_topic_id: "your_pubsub_topic"
+
+# Azure Event Grid
+azure_event_grid_endpoint: "https://your-eventgrid-endpoint"
+azure_event_grid_access_key: "your_event_grid_key"
+
 openai_api_key:
 
 # Database

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -45,6 +45,10 @@ The following connectors are soon to be supported:
 36. [Jira Service Desk](./connectors/jira_service_desk.md)
 37. [TAP/SNPP](./connectors/tap_snpp.md)
 38. [ACARS](./connectors/acars.md)
+39. [AWS IoT Core](./connectors/aws_iot_core.md)
+40. [AWS EventBridge](./connectors/eventbridge.md)
+41. [Google Pub/Sub](./connectors/google_pubsub.md)
+42. [Azure Event Grid](./connectors/azure_event_grid.md)
 
 
 ## Usage
@@ -93,5 +97,9 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Jira Service Desk Connector](./connectors/jira_service_desk.md)
 - [TAP/SNPP Connector](./connectors/tap_snpp.md)
 - [ACARS Connector](./connectors/acars.md)
+- [AWS IoT Core Connector](./connectors/aws_iot_core.md)
+- [AWS EventBridge Connector](./connectors/eventbridge.md)
+- [Google Pub/Sub Connector](./connectors/google_pubsub.md)
+- [Azure Event Grid Connector](./connectors/azure_event_grid.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/aws_iot_core.md
+++ b/docs/connectors/aws_iot_core.md
@@ -1,0 +1,26 @@
+# AWS IoT Core Connector
+
+The AWS IoT Core connector publishes messages to an AWS IoT Core topic.
+
+## Requirements
+
+- An AWS account with IoT Core enabled
+- Credentials with permission to publish to the topic
+- The `boto3` package installed
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+aws_region: "us-east-1"
+aws_iot_core_endpoint: "your_iot_endpoint"
+aws_iot_core_topic: "your_iot_topic"
+aws_access_key: "your_aws_access_key"
+aws_secret_key: "your_aws_secret_key"
+aws_session_token: "your_aws_session_token"
+```
+
+## Usage
+
+Once configured, Norman will publish messages to the specified topic.

--- a/docs/connectors/azure_event_grid.md
+++ b/docs/connectors/azure_event_grid.md
@@ -1,0 +1,19 @@
+# Azure Event Grid Connector
+
+This connector posts events to Azure Event Grid.
+
+## Requirements
+
+- An Event Grid topic endpoint and access key
+- The `azure-eventgrid` package installed
+
+## Configuration
+
+```yaml
+azure_event_grid_endpoint: "https://your-eventgrid-endpoint"
+azure_event_grid_access_key: "your_event_grid_key"
+```
+
+## Usage
+
+Messages are published as Event Grid events to the configured topic.

--- a/docs/connectors/eventbridge.md
+++ b/docs/connectors/eventbridge.md
@@ -1,0 +1,24 @@
+# AWS EventBridge Connector
+
+This connector sends events to an AWS EventBridge bus.
+
+## Requirements
+
+- An AWS account with EventBridge enabled
+- Credentials allowing `events:PutEvents`
+- The `boto3` package installed
+
+## Configuration
+
+```yaml
+aws_region: "us-east-1"
+eventbridge_event_bus_name: "default"
+eventbridge_source: "norman"
+aws_access_key: "your_aws_access_key"
+aws_secret_key: "your_aws_secret_key"
+aws_session_token: "your_aws_session_token"
+```
+
+## Usage
+
+Norman posts JSON events to the configured EventBridge bus.

--- a/docs/connectors/google_pubsub.md
+++ b/docs/connectors/google_pubsub.md
@@ -1,0 +1,20 @@
+# Google Pub/Sub Connector
+
+The Google Pub/Sub connector publishes messages to a Pub/Sub topic.
+
+## Requirements
+
+- A Google Cloud project with Pub/Sub enabled
+- A service account with publish permissions
+- The `google-cloud-pubsub` package installed
+
+## Configuration
+
+```yaml
+google_pubsub_project_id: "your_gcp_project"
+google_pubsub_topic_id: "your_pubsub_topic"
+```
+
+## Usage
+
+Norman sends each message as a Pub/Sub message to the configured topic.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -227,6 +227,34 @@ def test_get_connector_returns_acars(monkeypatch):
     assert isinstance(connector, ACARSConnector)
 
 
+def test_get_connector_returns_aws_iot_core(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('aws_iot_core')
+    from app.connectors.aws_iot_core_connector import AWSIoTCoreConnector
+    assert isinstance(connector, AWSIoTCoreConnector)
+
+
+def test_get_connector_returns_eventbridge(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('eventbridge')
+    from app.connectors.eventbridge_connector import EventBridgeConnector
+    assert isinstance(connector, EventBridgeConnector)
+
+
+def test_get_connector_returns_google_pubsub(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('google_pubsub')
+    from app.connectors.google_pubsub_connector import GooglePubSubConnector
+    assert isinstance(connector, GooglePubSubConnector)
+
+
+def test_get_connector_returns_azure_event_grid(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('azure_event_grid')
+    from app.connectors.azure_event_grid_connector import AzureEventGridConnector
+    assert isinstance(connector, AzureEventGridConnector)
+
+
 def test_get_connectors_data_missing_config(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     data = get_connectors_data()


### PR DESCRIPTION
## Summary
- add connector implementations for AWS IoT Core, AWS EventBridge, Google Pub/Sub and Azure Event Grid
- document new connectors and list them in the connector index
- expose new configuration options
- register new connectors in the factory and init
- test connector factory for new connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683af2bdb7608333a16d18b145eee698