### PR TITLE
Add cloud connectors

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -46,6 +46,10 @@ from .tap_snpp_connector import TAPSNPPConnector
 from .acars_connector import ACARSConnector
 from .rfc5425_connector import RFC5425Connector
 
+from .aws_iot_core_connector import AWSIoTCoreConnector
+from .aws_eventbridge_connector import AWSEventBridgeConnector
+from .google_pubsub_connector import GooglePubSubConnector
+from .azure_eventgrid_connector import AzureEventGridConnector
 from .connector_utils import get_connector
 
 def init_connectors(app: FastAPI, settings: Settings):
@@ -215,4 +219,22 @@ def init_connectors(app: FastAPI, settings: Settings):
     app.state.rfc5425_connector = RFC5425Connector(
         host=settings.rfc5425_host,
         port=settings.rfc5425_port,
+    )
+    app.state.aws_iot_core_connector = AWSIoTCoreConnector(
+        region=settings.aws_iot_core_region,
+        topic=settings.aws_iot_core_topic,
+        endpoint=settings.aws_iot_core_endpoint,
+    )
+    app.state.aws_eventbridge_connector = AWSEventBridgeConnector(
+        region=settings.aws_eventbridge_region,
+        event_bus_name=settings.aws_eventbridge_event_bus_name,
+    )
+    app.state.google_pubsub_connector = GooglePubSubConnector(
+        project_id=settings.google_pubsub_project_id,
+        topic_id=settings.google_pubsub_topic_id,
+        credentials_path=settings.google_pubsub_credentials_path,
+    )
+    app.state.azure_eventgrid_connector = AzureEventGridConnector(
+        endpoint=settings.azure_eventgrid_endpoint,
+        key=settings.azure_eventgrid_key,
     )

--- a/app/connectors/aws_eventbridge_connector.py
+++ b/app/connectors/aws_eventbridge_connector.py
@@ -1,0 +1,45 @@
+"""Connector for sending events to AWS EventBridge."""
+
+import json
+from typing import Any, Dict, Optional
+
+try:
+    import boto3
+except ImportError:  # pragma: no cover - optional dependency
+    boto3 = None
+
+from .base_connector import BaseConnector
+
+
+class AWSEventBridgeConnector(BaseConnector):
+    """Simple connector using boto3's EventBridge client."""
+
+    id = "aws_eventbridge"
+    name = "AWS EventBridge"
+
+    def __init__(self, region: str, event_bus_name: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.region = region
+        self.event_bus_name = event_bus_name
+        if boto3:
+            self.client = boto3.client("events", region_name=self.region)
+        else:  # pragma: no cover - dependency may be missing
+            self.client = None
+
+    async def send_message(self, message: Dict[str, Any]) -> Any:
+        if not boto3:
+            raise RuntimeError("boto3 not installed")
+        entry = {
+            "Source": "norman",
+            "DetailType": "message",
+            "Detail": json.dumps(message),
+            "EventBusName": self.event_bus_name,
+        }
+        return self.client.put_events(Entries=[entry])
+
+    async def listen_and_process(self) -> None:
+        """EventBridge does not support listening for messages."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/connectors/aws_iot_core_connector.py
+++ b/app/connectors/aws_iot_core_connector.py
@@ -1,0 +1,42 @@
+"""Connector for publishing messages to AWS IoT Core."""
+
+from typing import Any, Dict, Optional
+
+try:
+    import boto3
+except ImportError:  # pragma: no cover - optional dependency
+    boto3 = None
+
+from .base_connector import BaseConnector
+
+
+class AWSIoTCoreConnector(BaseConnector):
+    """Simple connector using the AWS IoT Data plane."""
+
+    id = "aws_iot_core"
+    name = "AWS IoT Core"
+
+    def __init__(self, region: str, topic: str, endpoint: Optional[str] = None, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.region = region
+        self.topic = topic
+        self.endpoint = endpoint
+        if boto3:
+            params: Dict[str, Any] = {"region_name": self.region}
+            if self.endpoint:
+                params["endpoint_url"] = self.endpoint
+            self.client = boto3.client("iot-data", **params)
+        else:  # pragma: no cover - dependency may be missing
+            self.client = None
+
+    async def send_message(self, message: str) -> Any:
+        if not boto3:
+            raise RuntimeError("boto3 not installed")
+        return self.client.publish(topic=self.topic, qos=1, payload=message)
+
+    async def listen_and_process(self) -> None:
+        """Listening is not implemented for AWS IoT Core."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/connectors/azure_eventgrid_connector.py
+++ b/app/connectors/azure_eventgrid_connector.py
@@ -1,0 +1,44 @@
+"""Connector for publishing events to Azure Event Grid."""
+
+from typing import Any, Dict, Optional
+
+try:
+    from azure.eventgrid import EventGridPublisherClient, EventGridEvent
+    from azure.core.credentials import AzureKeyCredential
+except ImportError:  # pragma: no cover - optional dependency
+    EventGridPublisherClient = None
+    EventGridEvent = None
+    AzureKeyCredential = None
+
+from .base_connector import BaseConnector
+
+
+class AzureEventGridConnector(BaseConnector):
+    """Connector using Azure EventGridPublisherClient."""
+
+    id = "azure_eventgrid"
+    name = "Azure Event Grid"
+
+    def __init__(self, endpoint: str, key: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.endpoint = endpoint
+        self.key = key
+        if EventGridPublisherClient and AzureKeyCredential:
+            credential = AzureKeyCredential(self.key)
+            self.client = EventGridPublisherClient(self.endpoint, credential)
+        else:  # pragma: no cover - dependency may be missing
+            self.client = None
+
+    async def send_message(self, message: Dict[str, Any]) -> Any:
+        if not EventGridPublisherClient:
+            raise RuntimeError("azure-eventgrid not installed")
+        event = EventGridEvent(subject="norman", event_type="Message", data=message, data_version="1.0")
+        self.client.send([event])
+        return "ok"
+
+    async def listen_and_process(self) -> None:
+        """Listening is not implemented for Event Grid."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -56,6 +56,10 @@ from .tap_snpp_connector import TAPSNPPConnector
 from .acars_connector import ACARSConnector
 from .rfc5425_connector import RFC5425Connector
 
+from .aws_iot_core_connector import AWSIoTCoreConnector
+from .aws_eventbridge_connector import AWSEventBridgeConnector
+from .google_pubsub_connector import GooglePubSubConnector
+from .azure_eventgrid_connector import AzureEventGridConnector
 # Registry of available connectors keyed by their identifier.
 connector_classes: Dict[str, type] = {
     "discord": DiscordConnector,
@@ -97,6 +101,10 @@ connector_classes: Dict[str, type] = {
     "jira_service_desk": JiraServiceDeskConnector,
     "tap_snpp": TAPSNPPConnector,
     "acars": ACARSConnector,
+    "aws_iot_core": AWSIoTCoreConnector,
+    "aws_eventbridge": AWSEventBridgeConnector,
+    "google_pubsub": GooglePubSubConnector,
+    "azure_eventgrid": AzureEventGridConnector,
     "rfc5425": RFC5425Connector,
 }
 

--- a/app/connectors/google_pubsub_connector.py
+++ b/app/connectors/google_pubsub_connector.py
@@ -1,0 +1,44 @@
+"""Connector for publishing messages to Google Pub/Sub."""
+
+from typing import Any, Dict, Optional
+
+try:
+    from google.cloud import pubsub_v1
+except ImportError:  # pragma: no cover - optional dependency
+    pubsub_v1 = None
+
+from .base_connector import BaseConnector
+
+
+class GooglePubSubConnector(BaseConnector):
+    """Simple connector using the google-cloud-pubsub client."""
+
+    id = "google_pubsub"
+    name = "Google Pub/Sub"
+
+    def __init__(self, project_id: str, topic_id: str, credentials_path: Optional[str] = None, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.project_id = project_id
+        self.topic_id = topic_id
+        self.credentials_path = credentials_path
+        if pubsub_v1:
+            if self.credentials_path:
+                self.publisher = pubsub_v1.PublisherClient.from_service_account_file(self.credentials_path)
+            else:
+                self.publisher = pubsub_v1.PublisherClient()
+        else:  # pragma: no cover - dependency may be missing
+            self.publisher = None
+
+    async def send_message(self, message: str) -> Any:
+        if not pubsub_v1:
+            raise RuntimeError("google-cloud-pubsub not installed")
+        topic_path = self.publisher.topic_path(self.project_id, self.topic_id)
+        future = self.publisher.publish(topic_path, message.encode())
+        return future.result()
+
+    async def listen_and_process(self) -> None:
+        """Pub/Sub listening not implemented."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -121,6 +121,16 @@ class Settings(BaseSettings):
     acars_port: int
     rfc5425_host: str
     rfc5425_port: int
+    aws_eventbridge_region: str
+    aws_eventbridge_event_bus_name: str
+    aws_iot_core_region: str
+    aws_iot_core_topic: str
+    aws_iot_core_endpoint: str
+    azure_eventgrid_endpoint: str
+    azure_eventgrid_key: str
+    google_pubsub_project_id: str
+    google_pubsub_topic_id: str
+    google_pubsub_credentials_path: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -113,6 +113,16 @@ acars_host: "your_acars_host"
 acars_port: 429
 rfc5425_host: "your_rfc5425_host"
 rfc5425_port: 6514
+aws_eventbridge_region: "your_aws_eventbridge_region"
+aws_eventbridge_event_bus_name: "your_aws_eventbridge_event_bus_name"
+aws_iot_core_region: "your_aws_iot_core_region"
+aws_iot_core_topic: "your_aws_iot_core_topic"
+aws_iot_core_endpoint: "your_aws_iot_core_endpoint"
+azure_eventgrid_endpoint: "your_azure_eventgrid_endpoint"
+azure_eventgrid_key: "your_azure_eventgrid_key"
+google_pubsub_project_id: "your_google_pubsub_project_id"
+google_pubsub_topic_id: "your_google_pubsub_topic_id"
+google_pubsub_credentials_path: "your_google_pubsub_credentials_path"
 
 openai_api_key:
 

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -37,6 +37,10 @@ from app.connectors.wechat_connector import WeChatConnector
 from app.connectors.reddit_chat_connector import RedditChatConnector
 from app.connectors.instagram_dm_connector import InstagramDMConnector
 from app.connectors.twitter_connector import TwitterConnector
+from app.connectors.aws_iot_core_connector import AWSIoTCoreConnector
+from app.connectors.aws_eventbridge_connector import AWSEventBridgeConnector
+from app.connectors.google_pubsub_connector import GooglePubSubConnector
+from app.connectors.azure_eventgrid_connector import AzureEventGridConnector
 from app.connectors.imessage_connector import IMessageConnector
 from app.connectors.rfc5425_connector import RFC5425Connector
 from app.core.test_settings import TestSettings
@@ -240,3 +244,26 @@ def test_get_connectors_data_missing_config(monkeypatch):
     assert all(item['status'] == 'missing_config' for item in data)
     slack_data = next(item for item in data if item['id'] == 'slack')
     assert slack_data['status'] == 'missing_config'
+
+def test_get_connector_returns_aws_iot_core(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('aws_iot_core')
+    assert isinstance(connector, AWSIoTCoreConnector)
+
+
+def test_get_connector_returns_aws_eventbridge(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('aws_eventbridge')
+    assert isinstance(connector, AWSEventBridgeConnector)
+
+
+def test_get_connector_returns_google_pubsub(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('google_pubsub')
+    assert isinstance(connector, GooglePubSubConnector)
+
+
+def test_get_connector_returns_azure_eventgrid(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('azure_eventgrid')
+    assert isinstance(connector, AzureEventGridConnector)


### PR DESCRIPTION
## Summary
- support AWS IoT Core, AWS EventBridge, Google Pub/Sub and Azure Event Grid connectors
- register the new connectors
- wire new connectors into the settings and default configuration
- test that `get_connector` can construct new connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683af42944e883339ffc7806340d6a24