### PR TITLE
Add IRC connector tests

### DIFF
--- a/app/connectors/irc_connector.py
+++ b/app/connectors/irc_connector.py
@@ -70,3 +70,15 @@ class IRCConnector(BaseConnector):
 
     def is_connected(self):
         return self.socket is not None and self.socket.getpeername() is not None
+
+    async def listen_and_process(self) -> None:
+        """Listen for a single IRC message and process it."""
+        if not self.socket:
+            return None
+        msg = self.receive_message()
+        if msg:
+            await self.process_incoming(msg)
+
+    async def process_incoming(self, message):
+        """Return the raw ``message`` payload."""
+        return message

--- a/tests/connectors/test_irc.py
+++ b/tests/connectors/test_irc.py
@@ -1,15 +1,75 @@
-import pytest
-from app.connectors import irc
+import socket
+import ssl
+from app.connectors.irc_connector import IRCConnector
 
-@pytest.mark.skip("Requires a real IRC server")
-def test_irc_connection():
-    # Replace with your actual test IRC server and credentials
-    irc_server = "irc.example.com"
-    irc_port = 6667
-    irc_channel = "#test"
-    irc_nickname = "test_bot"
-    irc_password = "your_password"
+class DummySocket:
+    def __init__(self):
+        self.sent = []
+        self.to_recv = [b"PING :server\r\n", b":u!u@h PRIVMSG #chan :hello\r\n"]
+        self.closed = False
+    def sendall(self, data):
+        self.sent.append(data)
+    def recv(self, n):
+        return self.to_recv.pop(0)
+    def close(self):
+        self.closed = True
+    def getpeername(self):
+        return ("host", 6667)
 
-    connector = irc.IRCConnector(server=irc_server, port=irc_port, channel=irc_channel,
-                                  nickname=irc_nickname, password=irc_password)
-    assert connector.connect() is True
+class DummyContext:
+    def __init__(self):
+        self.wrapped = None
+    def wrap_socket(self, sock, server_hostname=None):
+        self.wrapped = sock
+        return sock
+
+
+def make_connector(monkeypatch, use_ssl=False):
+    sock = DummySocket()
+    monkeypatch.setattr(socket, "create_connection", lambda addr: sock)
+    if use_ssl:
+        monkeypatch.setattr(ssl, "create_default_context", lambda: DummyContext())
+    connector = IRCConnector(
+        server="irc.example.com",
+        port=6667,
+        nickname="nick",
+        password="pass",
+        channels=["#chan"],
+        use_ssl=use_ssl,
+    )
+    return connector, sock
+
+
+def test_connect(monkeypatch):
+    connector, sock = make_connector(monkeypatch, use_ssl=True)
+    connector.connect()
+    assert sock.sent[0] == b"PASS pass\r\n"
+    assert b"NICK nick" in sock.sent[1]
+    assert b"USER nick" in sock.sent[2]
+    assert b"JOIN #chan" in sock.sent[-1]
+
+
+def test_send_and_receive(monkeypatch):
+    connector, sock = make_connector(monkeypatch)
+    connector.connect()
+    connector.send_message("#chan", "hi")
+    assert sock.sent[-1] == b"PRIVMSG #chan :hi\r\n"
+    message = connector.receive_message()
+    assert message == ":u!u@h PRIVMSG #chan :hello\r\n"
+    assert sock.sent[-1] == b"PONG :server\r\n"
+
+
+def test_disconnect(monkeypatch):
+    connector, sock = make_connector(monkeypatch)
+    connector.connect()
+    connector.disconnect()
+    assert sock.closed
+    assert connector.socket is None
+
+
+def test_is_connected(monkeypatch):
+    connector, _ = make_connector(monkeypatch)
+    connector.connect()
+    assert connector.is_connected()
+    connector.disconnect()
+    assert not connector.is_connected()


### PR DESCRIPTION
## Summary
- implement async stubs for IRC connector
- add new unit tests for the IRC connector

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b00c6b09c833396d85bcaf1670faa