### PR TITLE
Add AMQP and Redis pub/sub connectors

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -45,6 +45,8 @@ from .jira_service_desk_connector import JiraServiceDeskConnector
 from .tap_snpp_connector import TAPSNPPConnector
 from .acars_connector import ACARSConnector
 from .rfc5425_connector import RFC5425Connector
+from .amqp_connector import AMQPConnector
+from .redis_pubsub_connector import RedisPubSubConnector
 
 from .aws_iot_core_connector import AWSIoTCoreConnector
 from .aws_eventbridge_connector import AWSEventBridgeConnector
@@ -237,4 +239,13 @@ def init_connectors(app: FastAPI, settings: Settings):
     app.state.azure_eventgrid_connector = AzureEventGridConnector(
         endpoint=settings.azure_eventgrid_endpoint,
         key=settings.azure_eventgrid_key,
+    )
+    app.state.amqp_connector = AMQPConnector(
+        url=settings.amqp_url,
+        queue=settings.amqp_queue,
+    )
+    app.state.redis_pubsub_connector = RedisPubSubConnector(
+        host=settings.redis_host,
+        port=settings.redis_port,
+        channel=settings.redis_channel,
     )

--- a/app/connectors/amqp_connector.py
+++ b/app/connectors/amqp_connector.py
@@ -1,0 +1,52 @@
+from typing import Optional
+
+try:
+    import pika
+except ImportError:  # pragma: no cover - optional dependency
+    pika = None
+
+from .base_connector import BaseConnector
+
+
+class AMQPConnector(BaseConnector):
+    """Basic connector for AMQP brokers like RabbitMQ."""
+
+    id = "amqp"
+    name = "AMQP"
+
+    def __init__(self, url: str, queue: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.url = url
+        self.queue = queue
+        self._connection: Optional[pika.BlockingConnection] = None if pika else None
+        self._channel: Optional[pika.adapters.blocking_connection.BlockingChannel] = None
+
+    def connect(self) -> None:
+        if not pika:
+            raise RuntimeError("pika not installed")
+        self._connection = pika.BlockingConnection(pika.URLParameters(self.url))
+        self._channel = self._connection.channel()
+        self._channel.queue_declare(queue=self.queue, durable=True)
+
+    def disconnect(self) -> None:
+        if self._connection:
+            try:
+                self._connection.close()
+            finally:
+                self._connection = None
+                self._channel = None
+
+    def send_message(self, message: str) -> None:
+        if not pika:
+            raise RuntimeError("pika not installed")
+        if not self._channel:
+            self.connect()
+        assert self._channel is not None
+        self._channel.basic_publish(exchange="", routing_key=self.queue, body=message.encode())
+
+    async def listen_and_process(self) -> None:
+        """Listening not implemented."""
+        return None
+
+    async def process_incoming(self, message: str) -> str:
+        return message

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -55,6 +55,8 @@ from .jira_service_desk_connector import JiraServiceDeskConnector
 from .tap_snpp_connector import TAPSNPPConnector
 from .acars_connector import ACARSConnector
 from .rfc5425_connector import RFC5425Connector
+from .amqp_connector import AMQPConnector
+from .redis_pubsub_connector import RedisPubSubConnector
 
 from .aws_iot_core_connector import AWSIoTCoreConnector
 from .aws_eventbridge_connector import AWSEventBridgeConnector
@@ -106,6 +108,8 @@ connector_classes: Dict[str, type] = {
     "google_pubsub": GooglePubSubConnector,
     "azure_eventgrid": AzureEventGridConnector,
     "rfc5425": RFC5425Connector,
+    "amqp": AMQPConnector,
+    "redis_pubsub": RedisPubSubConnector,
 }
 
 

--- a/app/connectors/redis_pubsub_connector.py
+++ b/app/connectors/redis_pubsub_connector.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+try:
+    import redis
+except ImportError:  # pragma: no cover - optional dependency
+    redis = None
+
+from .base_connector import BaseConnector
+
+
+class RedisPubSubConnector(BaseConnector):
+    """Connector using Redis publish/subscribe."""
+
+    id = "redis_pubsub"
+    name = "Redis Pub/Sub"
+
+    def __init__(self, host: str = "localhost", port: int = 6379, channel: str = "norman", config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.host = host
+        self.port = port
+        self.channel = channel
+        self._client: Optional[redis.Redis] = redis.Redis(host=self.host, port=self.port) if redis else None
+
+    def connect(self) -> None:
+        if not redis:
+            raise RuntimeError("redis-py not installed")
+        if not self._client:
+            self._client = redis.Redis(host=self.host, port=self.port)
+
+    def disconnect(self) -> None:
+        # redis-py does not require explicit disconnect for basic clients
+        pass
+
+    def send_message(self, message: str) -> None:
+        if not redis:
+            raise RuntimeError("redis-py not installed")
+        if not self._client:
+            self.connect()
+        assert self._client is not None
+        self._client.publish(self.channel, message)
+
+    async def listen_and_process(self) -> None:
+        """Listening not implemented."""
+        return None
+
+    async def process_incoming(self, message: str) -> str:
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -131,6 +131,11 @@ class Settings(BaseSettings):
     google_pubsub_project_id: str
     google_pubsub_topic_id: str
     google_pubsub_credentials_path: str
+    amqp_url: str
+    amqp_queue: str
+    redis_host: str
+    redis_port: int
+    redis_channel: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -123,6 +123,11 @@ azure_eventgrid_key: "your_azure_eventgrid_key"
 google_pubsub_project_id: "your_google_pubsub_project_id"
 google_pubsub_topic_id: "your_google_pubsub_topic_id"
 google_pubsub_credentials_path: "your_google_pubsub_credentials_path"
+amqp_url: "your_amqp_url"
+amqp_queue: "your_amqp_queue"
+redis_host: "your_redis_host"
+redis_port: 6379
+redis_channel: "your_redis_channel"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -46,6 +46,8 @@ The following connectors are soon to be supported:
 37. [TAP/SNPP](./connectors/tap_snpp.md)
 38. [ACARS](./connectors/acars.md)
 39. [RFC 5425](./connectors/rfc5425.md)
+40. [AMQP](./connectors/amqp.md)
+41. [Redis Pub/Sub](./connectors/redis_pubsub.md)
 
 
 ## Usage
@@ -95,5 +97,7 @@ For more detailed information on each connector, please refer to the platform-sp
 - [TAP/SNPP Connector](./connectors/tap_snpp.md)
 - [ACARS Connector](./connectors/acars.md)
 - [RFC 5425 Connector](./connectors/rfc5425.md)
+- [AMQP Connector](./connectors/amqp.md)
+- [Redis Pub/Sub Connector](./connectors/redis_pubsub.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/amqp.md
+++ b/docs/connectors/amqp.md
@@ -1,0 +1,21 @@
+# AMQP Connector
+
+The AMQP connector allows Norman to publish messages to an AMQP broker such as RabbitMQ.
+
+## Requirements
+
+- An AMQP broker accessible from Norman
+- The `pika` Python package installed
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+amqp_url: "amqp://guest:guest@localhost:5672/"
+amqp_queue: "norman"
+```
+
+## Usage
+
+This connector currently only supports sending messages to the configured queue. Listening for incoming messages is not implemented.

--- a/docs/connectors/redis_pubsub.md
+++ b/docs/connectors/redis_pubsub.md
@@ -1,0 +1,22 @@
+# Redis Pub/Sub Connector
+
+The Redis Pub/Sub connector enables Norman to send messages using Redis channels.
+
+## Requirements
+
+- A Redis server accessible from Norman
+- The `redis` Python package installed
+
+## Configuration
+
+Include the following settings in your `config.yaml`:
+
+```yaml
+redis_host: "localhost"
+redis_port: 6379
+redis_channel: "norman"
+```
+
+## Usage
+
+This connector currently publishes messages to the specified channel. Receiving messages is not yet implemented.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -267,3 +267,17 @@ def test_get_connector_returns_azure_eventgrid(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     connector = get_connector('azure_eventgrid')
     assert isinstance(connector, AzureEventGridConnector)
+
+
+def test_get_connector_returns_amqp(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('amqp')
+    from app.connectors.amqp_connector import AMQPConnector
+    assert isinstance(connector, AMQPConnector)
+
+
+def test_get_connector_returns_redis_pubsub(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('redis_pubsub')
+    from app.connectors.redis_pubsub_connector import RedisPubSubConnector
+    assert isinstance(connector, RedisPubSubConnector)


### PR DESCRIPTION
## Summary
- add AMQP connector using pika
- add Redis pub/sub connector
- register the connectors in utils and app init
- document new connectors and add config fields
- support new settings in config and config template
- test retrieval of new connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b096f733483338088204f333ca2b3