### PR TITLE
Add connectors for Kafka, NATS, PagerDuty, LINE, and Viber

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -47,6 +47,11 @@ from .acars_connector import ACARSConnector
 from .rfc5425_connector import RFC5425Connector
 from .amqp_connector import AMQPConnector
 from .redis_pubsub_connector import RedisPubSubConnector
+from .kafka_connector import KafkaConnector
+from .nats_connector import NATSConnector
+from .pagerduty_connector import PagerDutyConnector
+from .line_connector import LineConnector
+from .viber_connector import ViberConnector
 
 from .aws_iot_core_connector import AWSIoTCoreConnector
 from .aws_eventbridge_connector import AWSEventBridgeConnector
@@ -248,4 +253,23 @@ def init_connectors(app: FastAPI, settings: Settings):
         host=settings.redis_host,
         port=settings.redis_port,
         channel=settings.redis_channel,
+    )
+    app.state.kafka_connector = KafkaConnector(
+        bootstrap_servers=settings.kafka_bootstrap_servers,
+        topic=settings.kafka_topic,
+    )
+    app.state.nats_connector = NATSConnector(
+        servers=settings.nats_servers,
+        subject=settings.nats_subject,
+    )
+    app.state.pagerduty_connector = PagerDutyConnector(
+        routing_key=settings.pagerduty_routing_key,
+    )
+    app.state.line_connector = LineConnector(
+        channel_access_token=settings.line_channel_access_token,
+        user_id=settings.line_user_id,
+    )
+    app.state.viber_connector = ViberConnector(
+        auth_token=settings.viber_auth_token,
+        receiver=settings.viber_receiver,
     )

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -57,6 +57,11 @@ from .acars_connector import ACARSConnector
 from .rfc5425_connector import RFC5425Connector
 from .amqp_connector import AMQPConnector
 from .redis_pubsub_connector import RedisPubSubConnector
+from .kafka_connector import KafkaConnector
+from .nats_connector import NATSConnector
+from .pagerduty_connector import PagerDutyConnector
+from .line_connector import LineConnector
+from .viber_connector import ViberConnector
 
 from .aws_iot_core_connector import AWSIoTCoreConnector
 from .aws_eventbridge_connector import AWSEventBridgeConnector
@@ -110,6 +115,11 @@ connector_classes: Dict[str, type] = {
     "rfc5425": RFC5425Connector,
     "amqp": AMQPConnector,
     "redis_pubsub": RedisPubSubConnector,
+    "kafka": KafkaConnector,
+    "nats": NATSConnector,
+    "pagerduty": PagerDutyConnector,
+    "line": LineConnector,
+    "viber": ViberConnector,
 }
 
 

--- a/app/connectors/kafka_connector.py
+++ b/app/connectors/kafka_connector.py
@@ -1,0 +1,39 @@
+"""Connector for sending messages to Kafka or Redpanda."""
+
+from typing import Optional
+
+try:
+    from confluent_kafka import Producer
+except ImportError:  # pragma: no cover - optional dependency
+    Producer = None  # type: ignore
+
+from .base_connector import BaseConnector
+
+
+class KafkaConnector(BaseConnector):
+    """Minimal connector using ``confluent-kafka``."""
+
+    id = "kafka"
+    name = "Kafka/Redpanda"
+
+    def __init__(self, bootstrap_servers: str = "localhost:9092", topic: str = "norman", config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.bootstrap_servers = bootstrap_servers
+        self.topic = topic
+        self._producer: Optional[Producer] = Producer({"bootstrap.servers": self.bootstrap_servers}) if Producer else None
+
+    def send_message(self, message: str) -> Optional[str]:
+        if not Producer:
+            raise RuntimeError("confluent-kafka not installed")
+        if not self._producer:
+            self._producer = Producer({"bootstrap.servers": self.bootstrap_servers})
+        self._producer.produce(self.topic, value=message.encode())
+        self._producer.flush()
+        return "ok"
+
+    async def listen_and_process(self) -> None:
+        """Listening for messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message: str) -> str:
+        return message

--- a/app/connectors/line_connector.py
+++ b/app/connectors/line_connector.py
@@ -1,0 +1,38 @@
+"""Connector for the LINE Messaging API."""
+
+from typing import Any, Dict, Optional
+
+import requests
+
+from .base_connector import BaseConnector
+
+
+class LineConnector(BaseConnector):
+    """Send messages to LINE users via the Messaging API."""
+
+    id = "line"
+    name = "LINE Messaging"
+
+    def __init__(self, channel_access_token: str, user_id: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.channel_access_token = channel_access_token
+        self.user_id = user_id
+        self.api_url = "https://api.line.me/v2/bot/message/push"
+
+    def send_message(self, text: str) -> Optional[str]:
+        headers = {"Authorization": f"Bearer {self.channel_access_token}"}
+        payload = {"to": self.user_id, "messages": [{"type": "text", "text": text}]}
+        try:
+            resp = requests.post(self.api_url, json=payload, headers=headers)
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending LINE message: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Listening for LINE messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/connectors/nats_connector.py
+++ b/app/connectors/nats_connector.py
@@ -1,0 +1,51 @@
+"""Connector for sending messages over NATS or JetStream."""
+
+import asyncio
+from typing import Optional
+
+try:
+    import nats
+except ImportError:  # pragma: no cover - optional dependency
+    nats = None  # type: ignore
+
+from .base_connector import BaseConnector
+
+
+class NATSConnector(BaseConnector):
+    """Minimal connector using ``nats-py``."""
+
+    id = "nats"
+    name = "NATS/JetStream"
+
+    def __init__(self, servers: str = "nats://127.0.0.1:4222", subject: str = "norman", config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.servers = servers
+        self.subject = subject
+        self._nc: Optional[nats.NATS] = None if nats else None
+
+    async def connect(self) -> None:
+        if not nats:
+            raise RuntimeError("nats-py not installed")
+        self._nc = await nats.connect(servers=self.servers)
+
+    async def disconnect(self) -> None:
+        if self._nc:
+            await self._nc.drain()
+            await self._nc.close()
+            self._nc = None
+
+    async def send_message(self, message: str) -> Optional[str]:
+        if not nats:
+            raise RuntimeError("nats-py not installed")
+        if not self._nc:
+            await self.connect()
+        assert self._nc is not None
+        await self._nc.publish(self.subject, message.encode())
+        return "ok"
+
+    async def listen_and_process(self) -> None:
+        """Listening for messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message: str) -> str:
+        return message

--- a/app/connectors/pagerduty_connector.py
+++ b/app/connectors/pagerduty_connector.py
@@ -1,0 +1,44 @@
+"""Connector for sending events via PagerDuty Events v2 API."""
+
+from typing import Any, Dict, Optional
+
+import requests
+
+from .base_connector import BaseConnector
+
+
+class PagerDutyConnector(BaseConnector):
+    """Connector that triggers PagerDuty incidents."""
+
+    id = "pagerduty"
+    name = "PagerDuty Events v2"
+
+    def __init__(self, routing_key: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.routing_key = routing_key
+        self.api_url = "https://events.pagerduty.com/v2/enqueue"
+
+    def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        payload = {
+            "routing_key": self.routing_key,
+            "event_action": message.get("event_action", "trigger"),
+            "payload": {
+                "summary": message.get("summary", "Norman Event"),
+                "source": message.get("source", "norman"),
+                "severity": message.get("severity", "info"),
+            },
+        }
+        try:
+            response = requests.post(self.api_url, json=payload)
+            response.raise_for_status()
+            return response.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending PagerDuty event: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Listening is not implemented."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/connectors/viber_connector.py
+++ b/app/connectors/viber_connector.py
@@ -1,0 +1,38 @@
+"""Connector for the Viber Bots API."""
+
+from typing import Any, Dict, Optional
+
+import requests
+
+from .base_connector import BaseConnector
+
+
+class ViberConnector(BaseConnector):
+    """Send messages to Viber using the Bots API."""
+
+    id = "viber"
+    name = "Viber Bots"
+
+    def __init__(self, auth_token: str, receiver: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.auth_token = auth_token
+        self.receiver = receiver
+        self.api_url = "https://chatapi.viber.com/pa/send_message"
+
+    def send_message(self, text: str) -> Optional[str]:
+        headers = {"X-Viber-Auth-Token": self.auth_token}
+        payload = {"receiver": self.receiver, "type": "text", "text": text}
+        try:
+            resp = requests.post(self.api_url, json=payload, headers=headers)
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending Viber message: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Listening for Viber messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -136,6 +136,15 @@ class Settings(BaseSettings):
     redis_host: str
     redis_port: int
     redis_channel: str
+    kafka_bootstrap_servers: str
+    kafka_topic: str
+    nats_servers: str
+    nats_subject: str
+    pagerduty_routing_key: str
+    line_channel_access_token: str
+    line_user_id: str
+    viber_auth_token: str
+    viber_receiver: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -128,6 +128,15 @@ amqp_queue: "your_amqp_queue"
 redis_host: "your_redis_host"
 redis_port: 6379
 redis_channel: "your_redis_channel"
+kafka_bootstrap_servers: "your_kafka_bootstrap_servers"
+kafka_topic: "your_kafka_topic"
+nats_servers: "your_nats_servers"
+nats_subject: "your_nats_subject"
+pagerduty_routing_key: "your_pagerduty_routing_key"
+line_channel_access_token: "your_line_channel_access_token"
+line_user_id: "your_line_user_id"
+viber_auth_token: "your_viber_auth_token"
+viber_receiver: "your_viber_receiver"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -48,6 +48,11 @@ The following connectors are soon to be supported:
 39. [RFC 5425](./connectors/rfc5425.md)
 40. [AMQP](./connectors/amqp.md)
 41. [Redis Pub/Sub](./connectors/redis_pubsub.md)
+42. [Kafka](./connectors/kafka.md)
+43. [NATS](./connectors/nats.md)
+44. [PagerDuty Events v2](./connectors/pagerduty.md)
+45. [LINE Messaging](./connectors/line.md)
+46. [Viber Bots](./connectors/viber.md)
 
 
 ## Usage

--- a/docs/connectors/kafka.md
+++ b/docs/connectors/kafka.md
@@ -1,0 +1,21 @@
+# Kafka Connector
+
+The Kafka connector publishes messages to a Kafka or Redpanda cluster using the `confluent-kafka` library.
+
+## Requirements
+
+- A Kafka-compatible broker (Kafka or Redpanda)
+- The `confluent-kafka` Python package installed
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+kafka_bootstrap_servers: "localhost:9092"
+kafka_topic: "norman"
+```
+
+## Usage
+
+This connector currently only supports publishing messages to the configured topic.

--- a/docs/connectors/line.md
+++ b/docs/connectors/line.md
@@ -1,0 +1,19 @@
+# LINE Messaging Connector
+
+The LINE connector sends messages via the LINE Messaging API.
+
+## Requirements
+
+- LINE channel access token
+- The user ID to send messages to
+
+## Configuration
+
+```yaml
+line_channel_access_token: "your_channel_access_token"
+line_user_id: "target_user_id"
+```
+
+## Usage
+
+Norman can push text messages to the specified user. Receiving messages is not implemented.

--- a/docs/connectors/nats.md
+++ b/docs/connectors/nats.md
@@ -1,0 +1,21 @@
+# NATS Connector
+
+The NATS connector sends messages over NATS or JetStream using the `nats-py` library.
+
+## Requirements
+
+- A running NATS server
+- The `nats-py` Python package installed
+
+## Configuration
+
+Add the following settings to your `config.yaml`:
+
+```yaml
+nats_servers: "nats://127.0.0.1:4222"
+nats_subject: "norman"
+```
+
+## Usage
+
+The connector currently publishes messages to the specified subject. Listening for messages is not implemented.

--- a/docs/connectors/pagerduty.md
+++ b/docs/connectors/pagerduty.md
@@ -1,0 +1,19 @@
+# PagerDuty Events v2 Connector
+
+This connector triggers PagerDuty incidents via the Events v2 REST API.
+
+## Requirements
+
+- A PagerDuty account with an integration key
+
+## Configuration
+
+Add the following to your `config.yaml`:
+
+```yaml
+pagerduty_routing_key: "your_integration_key"
+```
+
+## Usage
+
+Sending a dictionary with `summary`, `source`, and `severity` fields will create or update incidents in PagerDuty.

--- a/docs/connectors/viber.md
+++ b/docs/connectors/viber.md
@@ -1,0 +1,19 @@
+# Viber Bots Connector
+
+The Viber connector sends messages using the Viber Bots API.
+
+## Requirements
+
+- A Viber bot token
+- The receiver's ID
+
+## Configuration
+
+```yaml
+viber_auth_token: "your_viber_auth_token"
+viber_receiver: "receiver_id"
+```
+
+## Usage
+
+The connector can push text messages to Viber users. Listening for incoming messages is not implemented.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -43,6 +43,11 @@ from app.connectors.google_pubsub_connector import GooglePubSubConnector
 from app.connectors.azure_eventgrid_connector import AzureEventGridConnector
 from app.connectors.imessage_connector import IMessageConnector
 from app.connectors.rfc5425_connector import RFC5425Connector
+from app.connectors.kafka_connector import KafkaConnector
+from app.connectors.nats_connector import NATSConnector
+from app.connectors.pagerduty_connector import PagerDutyConnector
+from app.connectors.line_connector import LineConnector
+from app.connectors.viber_connector import ViberConnector
 from app.core.test_settings import TestSettings
 
 
@@ -281,3 +286,33 @@ def test_get_connector_returns_redis_pubsub(monkeypatch):
     connector = get_connector('redis_pubsub')
     from app.connectors.redis_pubsub_connector import RedisPubSubConnector
     assert isinstance(connector, RedisPubSubConnector)
+
+
+def test_get_connector_returns_kafka(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('kafka')
+    assert isinstance(connector, KafkaConnector)
+
+
+def test_get_connector_returns_nats(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('nats')
+    assert isinstance(connector, NATSConnector)
+
+
+def test_get_connector_returns_pagerduty(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('pagerduty')
+    assert isinstance(connector, PagerDutyConnector)
+
+
+def test_get_connector_returns_line(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('line')
+    assert isinstance(connector, LineConnector)
+
+
+def test_get_connector_returns_viber(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('viber')
+    assert isinstance(connector, ViberConnector)


### PR DESCRIPTION
## Summary
- add new connector modules for Kafka/Redpanda, NATS/JetStream, PagerDuty Events v2, LINE Messaging and Viber Bots
- register the connectors and their configuration options
- document new connectors and list them
- support new configuration settings
- test new connector registrations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0c5767808333aabd8c32d62d31fb