### PR TITLE
Add connectors for CoAP, OPC UA, AIS and CAP

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -52,6 +52,10 @@ from .nats_connector import NATSConnector
 from .pagerduty_connector import PagerDutyConnector
 from .line_connector import LineConnector
 from .viber_connector import ViberConnector
+from .coap_oscore_connector import CoAPOSCOREConnector
+from .opcua_pubsub_connector import OPCUAPubSubConnector
+from .ais_safety_text_connector import AISSafetyTextConnector
+from .cap_connector import CAPConnector
 
 from .aws_iot_core_connector import AWSIoTCoreConnector
 from .aws_eventbridge_connector import AWSEventBridgeConnector
@@ -272,4 +276,18 @@ def init_connectors(app: FastAPI, settings: Settings):
     app.state.viber_connector = ViberConnector(
         auth_token=settings.viber_auth_token,
         receiver=settings.viber_receiver,
+    )
+    app.state.coap_oscore_connector = CoAPOSCOREConnector(
+        host=settings.coap_oscore_host,
+        port=settings.coap_oscore_port,
+    )
+    app.state.opcua_pubsub_connector = OPCUAPubSubConnector(
+        endpoint=settings.opcua_pubsub_endpoint,
+    )
+    app.state.ais_safety_text_connector = AISSafetyTextConnector(
+        host=settings.ais_host,
+        port=settings.ais_port,
+    )
+    app.state.cap_connector = CAPConnector(
+        endpoint=settings.cap_endpoint,
     )

--- a/app/connectors/ais_safety_text_connector.py
+++ b/app/connectors/ais_safety_text_connector.py
@@ -1,0 +1,29 @@
+"""Connector for AIS safety-related text messages (VDM 6/12)."""
+
+from typing import Any, Optional
+
+from .base_connector import BaseConnector
+
+
+class AISSafetyTextConnector(BaseConnector):
+    """Placeholder connector for AIS VDM 6/12 messages."""
+
+    id = "ais_safety_text"
+    name = "AIS Safety-Related Text"
+
+    def __init__(self, host: str, port: int = 12345, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.host = host
+        self.port = port
+
+    async def send_message(self, message: str) -> None:
+        # Placeholder for sending an AIS safety-related text message
+        pass
+
+    async def listen_and_process(self) -> None:
+        # Placeholder for listening for AIS messages
+        pass
+
+    async def process_incoming(self, message: Any) -> Any:
+        # Placeholder for processing inbound AIS messages
+        return message

--- a/app/connectors/cap_connector.py
+++ b/app/connectors/cap_connector.py
@@ -1,0 +1,27 @@
+"""Connector for sending alerts using the Common Alerting Protocol (CAP v1.2)."""
+
+from typing import Any, Optional
+
+from .base_connector import BaseConnector
+
+
+class CAPConnector(BaseConnector):
+    """Placeholder connector for CAP 1.2 messages."""
+
+    id = "cap"
+    name = "Common Alerting Protocol v1.2"
+
+    def __init__(self, endpoint: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.endpoint = endpoint
+
+    async def send_message(self, message: Any) -> None:
+        # Placeholder for sending a CAP alert
+        pass
+
+    async def listen_and_process(self) -> None:
+        # CAP is typically outbound only
+        pass
+
+    async def process_incoming(self, message: Any) -> Any:
+        return message

--- a/app/connectors/coap_oscore_connector.py
+++ b/app/connectors/coap_oscore_connector.py
@@ -1,0 +1,29 @@
+"""Connector for sending messages over CoAP secured with OSCORE."""
+
+from typing import Any, Optional
+
+from .base_connector import BaseConnector
+
+
+class CoAPOSCOREConnector(BaseConnector):
+    """Minimal placeholder connector for CoAP + OSCORE."""
+
+    id = "coap_oscore"
+    name = "CoAP + OSCORE"
+
+    def __init__(self, host: str, port: int = 5684, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.host = host
+        self.port = port
+
+    async def send_message(self, message: Any) -> None:
+        # Placeholder for sending a CoAP message with OSCORE protection
+        pass
+
+    async def listen_and_process(self) -> None:
+        # Placeholder for listening for CoAP messages
+        pass
+
+    async def process_incoming(self, message: Any) -> Any:
+        # Placeholder for processing inbound CoAP messages
+        return message

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -62,6 +62,10 @@ from .nats_connector import NATSConnector
 from .pagerduty_connector import PagerDutyConnector
 from .line_connector import LineConnector
 from .viber_connector import ViberConnector
+from .coap_oscore_connector import CoAPOSCOREConnector
+from .opcua_pubsub_connector import OPCUAPubSubConnector
+from .ais_safety_text_connector import AISSafetyTextConnector
+from .cap_connector import CAPConnector
 
 from .aws_iot_core_connector import AWSIoTCoreConnector
 from .aws_eventbridge_connector import AWSEventBridgeConnector
@@ -120,6 +124,10 @@ connector_classes: Dict[str, type] = {
     "pagerduty": PagerDutyConnector,
     "line": LineConnector,
     "viber": ViberConnector,
+    "coap_oscore": CoAPOSCOREConnector,
+    "opcua_pubsub": OPCUAPubSubConnector,
+    "ais_safety_text": AISSafetyTextConnector,
+    "cap": CAPConnector,
 }
 
 

--- a/app/connectors/opcua_pubsub_connector.py
+++ b/app/connectors/opcua_pubsub_connector.py
@@ -1,0 +1,28 @@
+"""Connector for publishing messages using OPC UA PubSub."""
+
+from typing import Any, Optional
+
+from .base_connector import BaseConnector
+
+
+class OPCUAPubSubConnector(BaseConnector):
+    """Placeholder connector for OPC UA PubSub."""
+
+    id = "opcua_pubsub"
+    name = "OPC UA PubSub"
+
+    def __init__(self, endpoint: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.endpoint = endpoint
+
+    async def send_message(self, message: Any) -> None:
+        # Placeholder for publishing a message via OPC UA PubSub
+        pass
+
+    async def listen_and_process(self) -> None:
+        # Placeholder for subscribing to OPC UA messages
+        pass
+
+    async def process_incoming(self, message: Any) -> Any:
+        # Placeholder for processing inbound OPC UA messages
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -145,6 +145,12 @@ class Settings(BaseSettings):
     line_user_id: str
     viber_auth_token: str
     viber_receiver: str
+    coap_oscore_host: str
+    coap_oscore_port: int
+    opcua_pubsub_endpoint: str
+    ais_host: str
+    ais_port: int
+    cap_endpoint: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -137,6 +137,12 @@ line_channel_access_token: "your_line_channel_access_token"
 line_user_id: "your_line_user_id"
 viber_auth_token: "your_viber_auth_token"
 viber_receiver: "your_viber_receiver"
+coap_oscore_host: "your_coap_oscore_host"
+coap_oscore_port: 5684
+opcua_pubsub_endpoint: "your_opcua_pubsub_endpoint"
+ais_host: "your_ais_host"
+ais_port: 12345
+cap_endpoint: "your_cap_endpoint"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -53,6 +53,10 @@ The following connectors are soon to be supported:
 44. [PagerDuty Events v2](./connectors/pagerduty.md)
 45. [LINE Messaging](./connectors/line.md)
 46. [Viber Bots](./connectors/viber.md)
+47. [CoAP + OSCORE](./connectors/coap_oscore.md)
+48. [OPC UA PubSub](./connectors/opcua_pubsub.md)
+49. [AIS Safety-Related Text](./connectors/ais_safety_text.md)
+50. [Common Alerting Protocol](./connectors/cap.md)
 
 
 ## Usage
@@ -104,5 +108,9 @@ For more detailed information on each connector, please refer to the platform-sp
 - [RFC 5425 Connector](./connectors/rfc5425.md)
 - [AMQP Connector](./connectors/amqp.md)
 - [Redis Pub/Sub Connector](./connectors/redis_pubsub.md)
+- [CoAP + OSCORE Connector](./connectors/coap_oscore.md)
+- [OPC UA PubSub Connector](./connectors/opcua_pubsub.md)
+- [AIS Safety-Related Text Connector](./connectors/ais_safety_text.md)
+- [Common Alerting Protocol Connector](./connectors/cap.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/ais_safety_text.md
+++ b/docs/connectors/ais_safety_text.md
@@ -1,0 +1,14 @@
+# AIS Safety-Related Text Connector
+
+Placeholder connector for AIS "safety-related text" messages (VDM 6/12).
+
+## Configuration
+
+```yaml
+ais_host: "your_ais_host"
+ais_port: 12345
+```
+
+## Usage
+
+Future versions may send and receive AIS messages using this connector.

--- a/docs/connectors/cap.md
+++ b/docs/connectors/cap.md
@@ -1,0 +1,13 @@
+# Common Alerting Protocol Connector
+
+This connector sends alerts using CAP version 1.2.
+
+## Configuration
+
+```yaml
+cap_endpoint: "your_cap_endpoint"
+```
+
+## Usage
+
+The current implementation is a stub for future CAP support.

--- a/docs/connectors/coap_oscore.md
+++ b/docs/connectors/coap_oscore.md
@@ -1,0 +1,16 @@
+# CoAP + OSCORE Connector
+
+This connector is a placeholder for sending CoAP messages secured with OSCORE.
+
+## Configuration
+
+Add the following settings to your `config.yaml`:
+
+```yaml
+coap_oscore_host: "your_coap_oscore_host"
+coap_oscore_port: 5684
+```
+
+## Usage
+
+The implementation currently only defines the interface for future support.

--- a/docs/connectors/opcua_pubsub.md
+++ b/docs/connectors/opcua_pubsub.md
@@ -1,0 +1,13 @@
+# OPC UA PubSub Connector
+
+This connector acts as a placeholder for publishing messages via OPC UA PubSub.
+
+## Configuration
+
+```yaml
+opcua_pubsub_endpoint: "your_opcua_pubsub_endpoint"
+```
+
+## Usage
+
+Message publishing and subscription are not yet implemented.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -48,6 +48,10 @@ from app.connectors.nats_connector import NATSConnector
 from app.connectors.pagerduty_connector import PagerDutyConnector
 from app.connectors.line_connector import LineConnector
 from app.connectors.viber_connector import ViberConnector
+from app.connectors.coap_oscore_connector import CoAPOSCOREConnector
+from app.connectors.opcua_pubsub_connector import OPCUAPubSubConnector
+from app.connectors.ais_safety_text_connector import AISSafetyTextConnector
+from app.connectors.cap_connector import CAPConnector
 from app.core.test_settings import TestSettings
 
 
@@ -316,3 +320,27 @@ def test_get_connector_returns_viber(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
     connector = get_connector('viber')
     assert isinstance(connector, ViberConnector)
+
+
+def test_get_connector_returns_coap_oscore(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('coap_oscore')
+    assert isinstance(connector, CoAPOSCOREConnector)
+
+
+def test_get_connector_returns_opcua_pubsub(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('opcua_pubsub')
+    assert isinstance(connector, OPCUAPubSubConnector)
+
+
+def test_get_connector_returns_ais_safety_text(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('ais_safety_text')
+    assert isinstance(connector, AISSafetyTextConnector)
+
+
+def test_get_connector_returns_cap(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    connector = get_connector('cap')
+    assert isinstance(connector, CAPConnector)


### PR DESCRIPTION
## Summary
- add placeholder connectors for CoAP + OSCORE, OPC UA PubSub, AIS safety text and CAP v1.2
- wire new connectors into the connector registry and init routine
- document configuration examples for the new connectors
- extend config defaults with new fields
- test connector utilities for new connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0de3bad483339c0105fa6eb910b0