### PR TITLE
Add connectors for business messaging platforms

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -56,6 +56,9 @@ from .coap_oscore_connector import CoAPOSCOREConnector
 from .opcua_pubsub_connector import OPCUAPubSubConnector
 from .ais_safety_text_connector import AISSafetyTextConnector
 from .cap_connector import CAPConnector
+from .google_business_rcs_connector import GoogleBusinessRCSConnector
+from .apple_messages_business_connector import AppleMessagesBusinessConnector
+from .intercom_connector import IntercomConnector
 
 from .aws_iot_core_connector import AWSIoTCoreConnector
 from .aws_eventbridge_connector import AWSEventBridgeConnector
@@ -290,4 +293,16 @@ def init_connectors(app: FastAPI, settings: Settings):
     )
     app.state.cap_connector = CAPConnector(
         endpoint=settings.cap_endpoint,
+    )
+    app.state.google_business_rcs_connector = GoogleBusinessRCSConnector(
+        access_token=settings.google_business_access_token,
+        phone_number=settings.google_business_phone_number,
+    )
+    app.state.apple_messages_business_connector = AppleMessagesBusinessConnector(
+        access_token=settings.apple_business_access_token,
+        sender_id=settings.apple_business_sender_id,
+    )
+    app.state.intercom_connector = IntercomConnector(
+        access_token=settings.intercom_access_token,
+        app_id=settings.intercom_app_id,
     )

--- a/app/connectors/apple_messages_business_connector.py
+++ b/app/connectors/apple_messages_business_connector.py
@@ -1,0 +1,36 @@
+"""Connector for Apple Messages for Business."""
+
+from typing import Any, Dict, Optional
+import requests
+from .base_connector import BaseConnector
+
+
+class AppleMessagesBusinessConnector(BaseConnector):
+    """Send messages via Apple Messages for Business."""
+
+    id = "apple_messages_business"
+    name = "Apple Messages for Business"
+
+    def __init__(self, access_token: str, sender_id: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.access_token = access_token
+        self.sender_id = sender_id
+        self.api_url = "https://api.apple.com/business/v1/messages"
+
+    def send_message(self, text: str) -> Optional[str]:
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        payload = {"sender": {"id": self.sender_id}, "message": {"text": text}}
+        try:
+            resp = requests.post(self.api_url, json=payload, headers=headers)
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending Apple Messages for Business: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Listening for Apple Messages for Business is not implemented."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -66,6 +66,9 @@ from .coap_oscore_connector import CoAPOSCOREConnector
 from .opcua_pubsub_connector import OPCUAPubSubConnector
 from .ais_safety_text_connector import AISSafetyTextConnector
 from .cap_connector import CAPConnector
+from .google_business_rcs_connector import GoogleBusinessRCSConnector
+from .apple_messages_business_connector import AppleMessagesBusinessConnector
+from .intercom_connector import IntercomConnector
 
 from .aws_iot_core_connector import AWSIoTCoreConnector
 from .aws_eventbridge_connector import AWSEventBridgeConnector
@@ -128,6 +131,9 @@ connector_classes: Dict[str, type] = {
     "opcua_pubsub": OPCUAPubSubConnector,
     "ais_safety_text": AISSafetyTextConnector,
     "cap": CAPConnector,
+    "google_business_rcs": GoogleBusinessRCSConnector,
+    "apple_messages_business": AppleMessagesBusinessConnector,
+    "intercom": IntercomConnector,
 }
 
 

--- a/app/connectors/google_business_rcs_connector.py
+++ b/app/connectors/google_business_rcs_connector.py
@@ -1,0 +1,37 @@
+"""Connector for Google Business Messages / RCS."""
+
+from typing import Any, Dict, Optional
+import requests
+from .base_connector import BaseConnector
+
+
+class GoogleBusinessRCSConnector(BaseConnector):
+    """Send messages using Google Business Messages (RCS)."""
+
+    id = "google_business_rcs"
+    name = "Google Business Messages / RCS"
+
+    def __init__(self, access_token: str, phone_number: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.access_token = access_token
+        self.phone_number = phone_number
+        self.api_url = "https://businessmessages.googleapis.com/v1"
+
+    def send_message(self, text: str) -> Optional[str]:
+        url = f"{self.api_url}/conversations/{self.phone_number}/messages"
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        payload = {"message": {"text": text}}
+        try:
+            resp = requests.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending Google Business message: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Listening for Google Business Messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/connectors/intercom_connector.py
+++ b/app/connectors/intercom_connector.py
@@ -1,0 +1,40 @@
+"""Connector for Intercom conversations."""
+
+from typing import Any, Dict, Optional
+import requests
+from .base_connector import BaseConnector
+
+
+class IntercomConnector(BaseConnector):
+    """Send messages using the Intercom API."""
+
+    id = "intercom"
+    name = "Intercom"
+
+    def __init__(self, access_token: str, app_id: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.access_token = access_token
+        self.app_id = app_id
+        self.api_url = "https://api.intercom.io/messages"
+
+    def send_message(self, text: str) -> Optional[str]:
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        payload = {"message_type": "inapp", "body": text, "app_id": self.app_id}
+        try:
+            resp = requests.post(self.api_url, json=payload, headers=headers)
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending Intercom message: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Listening for Intercom messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -151,6 +151,12 @@ class Settings(BaseSettings):
     ais_host: str
     ais_port: int
     cap_endpoint: str
+    google_business_access_token: str
+    google_business_phone_number: str
+    apple_business_access_token: str
+    apple_business_sender_id: str
+    intercom_access_token: str
+    intercom_app_id: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -143,6 +143,12 @@ opcua_pubsub_endpoint: "your_opcua_pubsub_endpoint"
 ais_host: "your_ais_host"
 ais_port: 12345
 cap_endpoint: "your_cap_endpoint"
+google_business_access_token: "your_google_business_access_token"
+google_business_phone_number: "your_google_business_phone_number"
+apple_business_access_token: "your_apple_business_access_token"
+apple_business_sender_id: "your_apple_business_sender_id"
+intercom_access_token: "your_intercom_access_token"
+intercom_app_id: "your_intercom_app_id"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -57,6 +57,9 @@ The following connectors are soon to be supported:
 48. [OPC UA PubSub](./connectors/opcua_pubsub.md)
 49. [AIS Safety-Related Text](./connectors/ais_safety_text.md)
 50. [Common Alerting Protocol](./connectors/cap.md)
+51. [Google Business Messages / RCS](./connectors/google_business_rcs.md)
+52. [Apple Messages for Business](./connectors/apple_messages_business.md)
+53. [Intercom](./connectors/intercom.md)
 
 
 ## Usage
@@ -112,5 +115,8 @@ For more detailed information on each connector, please refer to the platform-sp
 - [OPC UA PubSub Connector](./connectors/opcua_pubsub.md)
 - [AIS Safety-Related Text Connector](./connectors/ais_safety_text.md)
 - [Common Alerting Protocol Connector](./connectors/cap.md)
+- [Google Business Messages / RCS Connector](./connectors/google_business_rcs.md)
+- [Apple Messages for Business Connector](./connectors/apple_messages_business.md)
+- [Intercom Connector](./connectors/intercom.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/apple_messages_business.md
+++ b/docs/connectors/apple_messages_business.md
@@ -1,0 +1,15 @@
+# Apple Messages for Business Connector
+
+This connector allows Norman to send messages using Apple's Messages for Business service.
+
+## Configuration
+
+```yaml
+apple_business_access_token: "your_access_token"
+apple_business_sender_id: "your_sender_id"
+```
+
+## Usage
+
+Only sending messages is implemented. Receiving messages from Apple
+Messages for Business would require additional webhook handling.

--- a/docs/connectors/google_business_rcs.md
+++ b/docs/connectors/google_business_rcs.md
@@ -1,0 +1,18 @@
+# Google Business Messages / RCS Connector
+
+This connector is a simple wrapper around the Google Business Messages API.
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+google_business_access_token: "your_access_token"
+google_business_phone_number: "your_phone_number"
+```
+
+## Usage
+
+After configuration, Norman can send outbound messages over the Google
+Business Messages (RCS) channel. Incoming message handling is not yet
+implemented.

--- a/docs/connectors/intercom.md
+++ b/docs/connectors/intercom.md
@@ -1,0 +1,15 @@
+# Intercom Connector
+
+Send notifications through the Intercom API.
+
+## Configuration
+
+```yaml
+intercom_access_token: "your_access_token"
+intercom_app_id: "your_app_id"
+```
+
+## Usage
+
+The connector posts simple in-app messages to Intercom. Incoming
+message support has not been added.


### PR DESCRIPTION
## Summary
- add connectors for Google Business Messages / RCS, Apple Messages for Business and Intercom
- configure these connectors
- document new connectors and list them in the connectors overview

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0ffffe74833385284c782deff14a