### PR TITLE
Expand connectors with in-memory logic and add tests

### DIFF
--- a/app/connectors/bluesky_connector.py
+++ b/app/connectors/bluesky_connector.py
@@ -11,15 +11,17 @@ class BlueskyConnector(BaseConnector):
         super().__init__(config)
         self.handle = handle
         self.app_password = app_password
+        self.sent_messages = []
 
-    async def send_message(self, message):
-        # Placeholder for sending a post to Bluesky
-        pass
+    async def send_message(self, message) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
 
     async def listen_and_process(self):
-        # Listening not implemented for Bluesky yet
-        pass
+        """Listening not implemented for Bluesky yet."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound Bluesky messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/instagram_dm_connector.py
+++ b/app/connectors/instagram_dm_connector.py
@@ -11,15 +11,17 @@ class InstagramDMConnector(BaseConnector):
         super().__init__(config)
         self.access_token = access_token
         self.user_id = user_id
+        self.sent_messages = []
 
-    async def send_message(self, message):
-        # Placeholder for sending a message via Instagram DM
-        pass
+    async def send_message(self, message) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
 
     async def listen_and_process(self):
-        # Placeholder for listening for Instagram DM messages
-        pass
+        """Listening for Instagram DM messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound Instagram DM messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/linkedin_connector.py
+++ b/app/connectors/linkedin_connector.py
@@ -10,15 +10,17 @@ class LinkedInConnector(BaseConnector):
     def __init__(self, access_token: str, config=None):
         super().__init__(config)
         self.access_token = access_token
+        self.sent_messages = []
 
-    async def send_message(self, message):
-        # Placeholder for sending a LinkedIn message
-        pass
+    async def send_message(self, message) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
 
     async def listen_and_process(self):
-        # Placeholder for listening to LinkedIn messages
-        pass
+        """Listening for LinkedIn messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound LinkedIn messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/mattermost_connector.py
+++ b/app/connectors/mattermost_connector.py
@@ -9,18 +9,20 @@ class MattermostConnector(BaseConnector):
 
     def __init__(self, url: str, token: str, channel_id: str, config=None):
         super().__init__(config)
-        self.url = url.rstrip('/')
+        self.url = url.rstrip("/")
         self.token = token
         self.channel_id = channel_id
+        self.sent_messages = []
 
-    async def send_message(self, message):
-        # Placeholder for sending a message to Mattermost
-        pass
+    async def send_message(self, message) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
 
     async def listen_and_process(self):
-        # Placeholder for listening to Mattermost messages
-        pass
+        """Listening for Mattermost messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound Mattermost messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/reddit_chat_connector.py
+++ b/app/connectors/reddit_chat_connector.py
@@ -7,22 +7,32 @@ class RedditChatConnector(BaseConnector):
     id = "reddit_chat"
     name = "Reddit Chat"
 
-    def __init__(self, client_id: str, client_secret: str, username: str, password: str, user_agent: str, config=None):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        username: str,
+        password: str,
+        user_agent: str,
+        config=None,
+    ):
         super().__init__(config)
         self.client_id = client_id
         self.client_secret = client_secret
         self.username = username
         self.password = password
         self.user_agent = user_agent
+        self.sent_messages = []
 
-    async def send_message(self, message):
-        # Placeholder for sending a Reddit Chat message
-        pass
+    async def send_message(self, message) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
 
     async def listen_and_process(self):
-        # Placeholder for listening to Reddit Chat messages
-        pass
+        """Listening to Reddit Chat messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound Reddit Chat messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/skype_connector.py
+++ b/app/connectors/skype_connector.py
@@ -11,15 +11,17 @@ class SkypeConnector(BaseConnector):
         super().__init__(config)
         self.app_id = app_id
         self.app_password = app_password
+        self.sent_messages = []
 
-    async def send_message(self, message):
-        # Placeholder for sending a Skype message
-        pass
+    async def send_message(self, message) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
 
     async def listen_and_process(self):
-        # Placeholder for listening to Skype messages
-        pass
+        """Listening for Skype messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound Skype messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/twitter_connector.py
+++ b/app/connectors/twitter_connector.py
@@ -7,21 +7,30 @@ class TwitterConnector(BaseConnector):
     id = "twitter"
     name = "X.com (Twitter)"
 
-    def __init__(self, api_key: str, api_secret: str, access_token: str, access_token_secret: str, config=None):
+    def __init__(
+        self,
+        api_key: str,
+        api_secret: str,
+        access_token: str,
+        access_token_secret: str,
+        config=None,
+    ):
         super().__init__(config)
         self.api_key = api_key
         self.api_secret = api_secret
         self.access_token = access_token
         self.access_token_secret = access_token_secret
+        self.sent_messages = []
 
-    async def send_message(self, message):
-        # Placeholder for sending a message via X.com/Twitter
-        pass
+    async def send_message(self, message) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
 
     async def listen_and_process(self):
-        # Placeholder for listening to X.com/Twitter messages
-        pass
+        """Listening to X.com/Twitter messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound X.com/Twitter messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/wechat_connector.py
+++ b/app/connectors/wechat_connector.py
@@ -11,15 +11,17 @@ class WeChatConnector(BaseConnector):
         super().__init__(config)
         self.app_id = app_id
         self.app_secret = app_secret
+        self.sent_messages = []
 
-    async def send_message(self, message):
-        # Placeholder for sending a WeChat message
-        pass
+    async def send_message(self, message) -> str:
+        """Store ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
 
     async def listen_and_process(self):
-        # Placeholder for listening to WeChat messages
-        pass
+        """Listening for WeChat messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound WeChat messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/tests/connectors/test_bluesky.py
+++ b/tests/connectors/test_bluesky.py
@@ -1,0 +1,17 @@
+import asyncio
+from app.connectors.bluesky_connector import BlueskyConnector
+
+
+def test_send_message():
+    connector = BlueskyConnector("h", "pw")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = BlueskyConnector("h", "pw")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"x": 1})
+    )
+    assert result == {"x": 1}

--- a/tests/connectors/test_instagram_dm.py
+++ b/tests/connectors/test_instagram_dm.py
@@ -1,0 +1,17 @@
+import asyncio
+from app.connectors.instagram_dm_connector import InstagramDMConnector
+
+
+def test_send_message():
+    connector = InstagramDMConnector("tok", "uid")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = InstagramDMConnector("tok", "uid")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"d": 3})
+    )
+    assert result == {"d": 3}

--- a/tests/connectors/test_linkedin.py
+++ b/tests/connectors/test_linkedin.py
@@ -1,0 +1,19 @@
+import asyncio
+from app.connectors.linkedin_connector import LinkedInConnector
+
+
+def test_send_message():
+    connector = LinkedInConnector("token")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hello")
+    )
+    assert result == "sent"
+    assert connector.sent_messages == ["hello"]
+
+
+def test_process_incoming():
+    connector = LinkedInConnector("token")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"foo": "bar"})
+    )
+    assert result == {"foo": "bar"}

--- a/tests/connectors/test_mattermost.py
+++ b/tests/connectors/test_mattermost.py
@@ -1,0 +1,17 @@
+import asyncio
+from app.connectors.mattermost_connector import MattermostConnector
+
+
+def test_send_message():
+    connector = MattermostConnector("http://mm", "tok", "chan")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = MattermostConnector("http://mm", "tok", "chan")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"foo": "bar"})
+    )
+    assert result == {"foo": "bar"}

--- a/tests/connectors/test_reddit_chat.py
+++ b/tests/connectors/test_reddit_chat.py
@@ -1,0 +1,17 @@
+import asyncio
+from app.connectors.reddit_chat_connector import RedditChatConnector
+
+
+def test_send_message():
+    connector = RedditChatConnector("id", "sec", "u", "p", "ua")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = RedditChatConnector("id", "sec", "u", "p", "ua")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"bar": 2})
+    )
+    assert result == {"bar": 2}

--- a/tests/connectors/test_skype.py
+++ b/tests/connectors/test_skype.py
@@ -1,0 +1,17 @@
+import asyncio
+from app.connectors.skype_connector import SkypeConnector
+
+
+def test_send_message():
+    connector = SkypeConnector("id", "pass")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = SkypeConnector("id", "pass")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"a": 1})
+    )
+    assert result == {"a": 1}

--- a/tests/connectors/test_twitter.py
+++ b/tests/connectors/test_twitter.py
@@ -1,0 +1,17 @@
+import asyncio
+from app.connectors.twitter_connector import TwitterConnector
+
+
+def test_send_message():
+    connector = TwitterConnector("k", "s", "at", "ats")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = TwitterConnector("k", "s", "at", "ats")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"msg": 1})
+    )
+    assert result == {"msg": 1}

--- a/tests/connectors/test_wechat.py
+++ b/tests/connectors/test_wechat.py
@@ -1,0 +1,17 @@
+import asyncio
+from app.connectors.wechat_connector import WeChatConnector
+
+
+def test_send_message():
+    connector = WeChatConnector("id", "secret")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = WeChatConnector("id", "secret")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"foo": 1})
+    )
+    assert result == {"foo": 1}


### PR DESCRIPTION
## Summary
- implement simple in-memory implementations for WeChat, LinkedIn, Skype, Mattermost, Bluesky, Twitter, Reddit Chat and Instagram DM connectors
- add connector unit tests covering the new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b245760608333a08c46a91b2c20b2