### PR TITLE
Fix middleware logging

### DIFF
--- a/app/core/middlewares.py
+++ b/app/core/middlewares.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+import time
 
 from app.core.config import settings
 


### PR DESCRIPTION
## Summary
- add `time` import for `logging_middleware`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b25c099f08333b27dc4c3c65e7445