### PR TITLE
Unify Base across models

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,7 +5,7 @@ from sqlalchemy import pool
 
 from alembic import context
 
-from app.models.base import Base
+from app.db.base import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,7 +1,6 @@
 # app/core/database.py
 
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
@@ -9,6 +8,6 @@ from app.core.config import settings
 engine = create_engine(settings.database_url)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-Base = declarative_base()
+from app.db.base import Base
 
 

--- a/app/models/action.py
+++ b/app/models/action.py
@@ -1,7 +1,6 @@
 from sqlalchemy import Column, Integer, Text, DateTime, ForeignKey
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql import func
-from .base import Base
+from app.db.base import Base
 
 class Action(Base):
     __tablename__ = "actions"

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,3 +1,0 @@
-from sqlalchemy.ext.declarative import declarative_base
-
-Base = declarative_base()

--- a/app/models/bot.py
+++ b/app/models/bot.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.sql import func
-from .base import Base
+from app.db.base import Base
 
 class Bot(Base):
     __tablename__ = "bots"

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.sql import func
-from .base import Base
+from app.db.base import Base
 
 class Channel(Base):
     __tablename__ = "channels"

--- a/app/models/channel_filter.py
+++ b/app/models/channel_filter.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.sql import func
-from .base import Base
+from app.db.base import Base
 
 class Filter(Base):
     __tablename__ = "filters"

--- a/app/models/interaction.py
+++ b/app/models/interaction.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, Text, DateTime, ForeignKey, String
 from sqlalchemy.sql import func
-from .base import Base
+from app.db.base import Base
 
 class Interaction(Base):
     __tablename__ = "interactions"

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
 from sqlalchemy.sql import func
 from sqlalchemy.sql.schema import FetchedValue
-from .base import Base
+from app.db.base import Base
 
 
 class Message(Base):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,7 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime, Boolean
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql import func
-from .base import Base
+from app.db.base import Base
 
 class User(Base):
     __tablename__ = "users"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from app.connectors import init_connectors
 from app.core.test_settings import TestSettings
 from app.core.config import settings
 from app.api.deps import get_db
-from app.models.base import Base
+from app.db.base import Base
 
 test_settings = TestSettings
 


### PR DESCRIPTION
## Summary
- use `app.db.base.Base` everywhere
- remove duplicate base module
- fix imports in migration env and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b25c83c1c833398df1f47d37bf4dc