### PR TITLE
Rename test settings instance and update tests

### DIFF
--- a/app/core/test_settings.py
+++ b/app/core/test_settings.py
@@ -1,7 +1,7 @@
 # app/core/test_settings.py
 from app.core.config import Settings, load_config
 
-__all__ = ["TestSettings"]
+__all__ = ["TestSettings", "test_settings"]
 __test__ = False
 
 
@@ -10,5 +10,7 @@ class TestSettings(Settings):
         env_prefix = ""
 
 test_defaults = load_config()
-TestSettings = Settings(**{**test_defaults, "database_url": "sqlite:///./db/test.db"})
+test_settings = Settings(
+    **{**test_defaults, "database_url": "sqlite:///./db/test.db"}
+)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,11 @@ from pathlib import Path
 os.environ["SKIP_MIGRATIONS"] = "1"
 from app.main import app
 from app.connectors import init_connectors
-from app.core.test_settings import TestSettings
+from app.core.test_settings import test_settings
 from app.core.config import settings
 from app.api.deps import get_db
 from app.models.base import Base
 
-test_settings = TestSettings
 
 # Ensure the test database directory exists
 db_dir = Path("./db")

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -52,295 +52,295 @@ from app.connectors.coap_oscore_connector import CoAPOSCOREConnector
 from app.connectors.opcua_pubsub_connector import OPCUAPubSubConnector
 from app.connectors.ais_safety_text_connector import AISSafetyTextConnector
 from app.connectors.cap_connector import CAPConnector
-from app.core.test_settings import TestSettings
+from app.core.test_settings import test_settings
 
 
 def test_get_connector_returns_slack(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('slack')
     assert isinstance(connector, SlackConnector)
 
 
 def test_get_connector_returns_signal(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('signal')
     assert isinstance(connector, SignalConnector)
 
 
 def test_get_connector_returns_rest_callback(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('rest_callback')
     assert isinstance(connector, RESTCallbackConnector)
 
 def test_get_connector_returns_mcp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('mcp')
     assert isinstance(connector, MCPConnector)
 def test_get_connector_returns_smtp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('smtp')
     assert isinstance(connector, SMTPConnector)
 
 
 def test_get_connector_returns_mqtt(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('mqtt')
     assert isinstance(connector, MQTTConnector)
 
 
 def test_get_connector_returns_mastodon(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('mastodon')
     assert isinstance(connector, MastodonConnector)
 
 
 def test_get_connector_returns_sms(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('sms')
     assert isinstance(connector, SMSConnector)
 
 
 def test_get_connector_returns_steam_chat(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('steam_chat')
     assert isinstance(connector, SteamChatConnector)
 
 
 def test_get_connector_returns_xmpp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('xmpp')
     assert isinstance(connector, XMPPConnector)
 
 
 def test_get_connector_returns_bluesky(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('bluesky')
     assert isinstance(connector, BlueskyConnector)
 
 
 def test_get_connector_returns_facebook_messenger(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('facebook_messenger')
     assert isinstance(connector, FacebookMessengerConnector)
 
 
 def test_get_connector_returns_linkedin(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('linkedin')
     assert isinstance(connector, LinkedInConnector)
 
 
 def test_get_connector_returns_skype(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('skype')
     assert isinstance(connector, SkypeConnector)
 
 
 def test_get_connector_returns_rocketchat(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('rocketchat')
     assert isinstance(connector, RocketChatConnector)
 
 
 def test_get_connector_returns_mattermost(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('mattermost')
     assert isinstance(connector, MattermostConnector)
 
 
 def test_get_connector_returns_wechat(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('wechat')
     assert isinstance(connector, WeChatConnector)
 
 
 def test_get_connector_returns_reddit_chat(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('reddit_chat')
     assert isinstance(connector, RedditChatConnector)
 
 
 def test_get_connector_returns_instagram_dm(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('instagram_dm')
     assert isinstance(connector, InstagramDMConnector)
 
 
 def test_get_connector_returns_twitter(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('twitter')
     assert isinstance(connector, TwitterConnector)
 
 
 def test_get_connector_returns_imessage(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('imessage')
     assert isinstance(connector, IMessageConnector)
 
 
 def test_get_connector_returns_aprs(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('aprs')
     from app.connectors.aprs_connector import APRSConnector
     assert isinstance(connector, APRSConnector)
 
 
 def test_get_connector_returns_ax25(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('ax25')
     from app.connectors.ax25_connector import AX25Connector
     assert isinstance(connector, AX25Connector)
 
 
 def test_get_connector_returns_zapier(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('zapier')
     from app.connectors.zapier_connector import ZapierConnector
     assert isinstance(connector, ZapierConnector)
 
 
 def test_get_connector_returns_ifttt(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('ifttt')
     from app.connectors.ifttt_connector import IFTTTConnector
     assert isinstance(connector, IFTTTConnector)
 
 
 def test_get_connector_returns_salesforce(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('salesforce')
     from app.connectors.salesforce_connector import SalesforceConnector
     assert isinstance(connector, SalesforceConnector)
 
 
 def test_get_connector_returns_github(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('github')
     from app.connectors.github_connector import GitHubConnector
     assert isinstance(connector, GitHubConnector)
 
 
 def test_get_connector_returns_jira_service_desk(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('jira_service_desk')
     from app.connectors.jira_service_desk_connector import JiraServiceDeskConnector
     assert isinstance(connector, JiraServiceDeskConnector)
 
 
 def test_get_connector_returns_tap_snpp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('tap_snpp')
     from app.connectors.tap_snpp_connector import TAPSNPPConnector
     assert isinstance(connector, TAPSNPPConnector)
 
 
 def test_get_connector_returns_acars(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('acars')
     from app.connectors.acars_connector import ACARSConnector
     assert isinstance(connector, ACARSConnector)
 
 
 def test_get_connector_returns_rfc5425(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('rfc5425')
     assert isinstance(connector, RFC5425Connector)
 
 
 def test_get_connectors_data_missing_config(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     data = get_connectors_data()
     assert all(item['status'] == 'missing_config' for item in data)
     slack_data = next(item for item in data if item['id'] == 'slack')
     assert slack_data['status'] == 'missing_config'
 
 def test_get_connector_returns_aws_iot_core(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('aws_iot_core')
     assert isinstance(connector, AWSIoTCoreConnector)
 
 
 def test_get_connector_returns_aws_eventbridge(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('aws_eventbridge')
     assert isinstance(connector, AWSEventBridgeConnector)
 
 
 def test_get_connector_returns_google_pubsub(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('google_pubsub')
     assert isinstance(connector, GooglePubSubConnector)
 
 
 def test_get_connector_returns_azure_eventgrid(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('azure_eventgrid')
     assert isinstance(connector, AzureEventGridConnector)
 
 
 def test_get_connector_returns_amqp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('amqp')
     from app.connectors.amqp_connector import AMQPConnector
     assert isinstance(connector, AMQPConnector)
 
 
 def test_get_connector_returns_redis_pubsub(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('redis_pubsub')
     from app.connectors.redis_pubsub_connector import RedisPubSubConnector
     assert isinstance(connector, RedisPubSubConnector)
 
 
 def test_get_connector_returns_kafka(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('kafka')
     assert isinstance(connector, KafkaConnector)
 
 
 def test_get_connector_returns_nats(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('nats')
     assert isinstance(connector, NATSConnector)
 
 
 def test_get_connector_returns_pagerduty(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('pagerduty')
     assert isinstance(connector, PagerDutyConnector)
 
 
 def test_get_connector_returns_line(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('line')
     assert isinstance(connector, LineConnector)
 
 
 def test_get_connector_returns_viber(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('viber')
     assert isinstance(connector, ViberConnector)
 
 
 def test_get_connector_returns_coap_oscore(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('coap_oscore')
     assert isinstance(connector, CoAPOSCOREConnector)
 
 
 def test_get_connector_returns_opcua_pubsub(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('opcua_pubsub')
     assert isinstance(connector, OPCUAPubSubConnector)
 
 
 def test_get_connector_returns_ais_safety_text(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('ais_safety_text')
     assert isinstance(connector, AISSafetyTextConnector)
 
 
 def test_get_connector_returns_cap(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: TestSettings)
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('cap')
     assert isinstance(connector, CAPConnector)

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -4,7 +4,7 @@ import types
 
 import pytest
 
-from app.core.test_settings import TestSettings
+from app.core.test_settings import test_settings
 
 
 def load_encryption_module(monkeypatch):
@@ -60,7 +60,7 @@ def load_encryption_module(monkeypatch):
 
 def test_encrypt_decrypt_round_trip(monkeypatch):
     enc = load_encryption_module(monkeypatch)
-    monkeypatch.setattr(enc, "get_settings", lambda: TestSettings)
+    monkeypatch.setattr(enc, "get_settings", lambda: test_settings)
     manager = enc.EncryptionManager()
     plaintext = "secret message"
     encrypted = manager.encrypt(plaintext)

--- a/tests/test_slack_router.py
+++ b/tests/test_slack_router.py
@@ -22,10 +22,10 @@ if 'slack_sdk' not in sys.modules:
     sys.modules['slack_sdk.errors'] = errors_mod
 
 from app.api.api_v1.routers.connectors.slack import get_slack_connector
-from app.core.test_settings import TestSettings
+from app.core.test_settings import test_settings
 
 
 def test_get_slack_connector_uses_settings():
-    connector = get_slack_connector(TestSettings)
-    assert connector.token == TestSettings.slack_token
-    assert connector.channel_id == TestSettings.slack_channel_id
+    connector = get_slack_connector(test_settings)
+    assert connector.token == test_settings.slack_token
+    assert connector.channel_id == test_settings.slack_channel_id

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -1,10 +1,10 @@
 from app.api.api_v1.routers.connectors.webhook import get_webhook_connector
-from app.core.test_settings import TestSettings
+from app.core.test_settings import test_settings
 import pytest
 
 pytest.skip("Webhook router tests not implemented", allow_module_level=True)
 
 
 def test_get_webhook_connector_uses_settings():
-    connector = get_webhook_connector(TestSettings)
-    assert connector.webhook_url == TestSettings.webhook_secret
+    connector = get_webhook_connector(test_settings)
+    assert connector.webhook_url == test_settings.webhook_secret


### PR DESCRIPTION
## Summary
- export the `TestSettings` class and new `test_settings` instance
- update all tests to import the new instance name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b25daf2e883339153bd4e7cc5db2d