### PR TITLE
Add connector_id field to Channel model

### DIFF
--- a/alembic/versions/c36c59a135aa_add_connector_id_to_channel.py
+++ b/alembic/versions/c36c59a135aa_add_connector_id_to_channel.py
@@ -1,0 +1,25 @@
+"""add connector_id to channels
+
+Revision ID: c36c59a135aa
+Revises: eacd88a5c06d
+Create Date: 2024-01-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'c36c59a135aa'
+down_revision = 'eacd88a5c06d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('channels', sa.Column('connector_id', sa.Integer(), nullable=False))
+    op.create_foreign_key(None, 'channels', 'connectors', ['connector_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint(None, 'channels', type_='foreignkey')
+    op.drop_column('channels', 'connector_id')

--- a/app/crud/channel.py
+++ b/app/crud/channel.py
@@ -20,7 +20,7 @@ def get_multi(db: Session, skip: int = 0, limit: int = 100) -> List[ChannelModel
 
 def create(db: Session, obj_in: ChannelCreate) -> ChannelModel:
     """Create a new channel."""
-    db_obj = ChannelModel(name=obj_in.name)
+    db_obj = ChannelModel(name=obj_in.name, connector_id=obj_in.connector_id)
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,4 +7,5 @@ from .channel_filter import Filter
 from .interaction import Interaction
 from .user import User
 from .message import Message
+from .connectors import Connector
 

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.sql import func
 from .base import Base
 
@@ -6,5 +6,6 @@ class Channel(Base):
     __tablename__ = "channels"
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True, nullable=False)
+    connector_id = Column(Integer, ForeignKey("connectors.id"), nullable=False)
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, onupdate=func.now())

--- a/app/models/connectors.py
+++ b/app/models/connectors.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime, JSON
 from sqlalchemy.sql import func
-from app.db.base import Base
+from app.models.base import Base
 
 
 class Connector(Base):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,12 +13,17 @@ from app.core.test_settings import TestSettings
 from app.core.config import settings
 from app.api.deps import get_db
 from app.models.base import Base
+import importlib
+importlib.import_module("app.models")  # ensure models are registered
 
 test_settings = TestSettings
 
 # Ensure the test database directory exists
 db_dir = Path("./db")
 db_dir.mkdir(parents=True, exist_ok=True)
+db_file = db_dir / "test.db"
+if db_file.exists():
+    db_file.unlink()
 
 settings.database_url = f"sqlite:///{db_dir}/test.db"
 engine = create_engine(settings.database_url)

--- a/tests/test_channels_crud.py
+++ b/tests/test_channels_crud.py
@@ -1,0 +1,25 @@
+import pytest
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.schemas.channel import ChannelCreate
+from app.schemas.connector import ConnectorCreate
+
+
+def create_connector(db: Session) -> int:
+    connector_in = ConnectorCreate(name="test", connector_type="irc", config={})
+    connector = crud.connector.create(db, obj_in=connector_in)
+    return connector.id
+
+
+def test_create_and_get_channel(db: Session):
+    connector_id = create_connector(db)
+    channel_in = ChannelCreate(name="my_channel", connector_id=connector_id)
+    channel = crud.channel.create(db, obj_in=channel_in)
+    assert channel.name == "my_channel"
+    assert channel.connector_id == connector_id
+
+    fetched = crud.channel.get(db, channel.id)
+    assert fetched is not None
+    assert fetched.id == channel.id
+    assert fetched.connector_id == connector_id


### PR DESCRIPTION
## Summary
- reference connectors in Channel model
- update CRUD to store connector relation
- create Alembic migration for new column
- ensure models package exports Connector and tests use correct metadata
- add CRUD test for channel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b25cf05d08333ad940cf1eb27a15b