### PR TITLE
Add tests for additional connectors

### DIFF
--- a/tests/connectors/test_google_business_rcs.py
+++ b/tests/connectors/test_google_business_rcs.py
@@ -1,0 +1,43 @@
+import requests
+import asyncio
+
+from app.connectors.google_business_rcs_connector import GoogleBusinessRCSConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError("error")
+
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        assert "/conversations/PHONE/messages" in url
+        assert json["message"]["text"] == "hi"
+        assert headers["Authorization"] == "Bearer TOKEN"
+        return DummyResponse("sent")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = GoogleBusinessRCSConnector("TOKEN", "PHONE")
+    assert connector.send_message("hi") == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = GoogleBusinessRCSConnector("TOKEN", "PHONE")
+    assert connector.send_message("hi") is None
+
+
+def test_process_incoming():
+    connector = GoogleBusinessRCSConnector("TOKEN", "PHONE")
+    payload = {"foo": "bar"}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload

--- a/tests/connectors/test_line.py
+++ b/tests/connectors/test_line.py
@@ -1,0 +1,44 @@
+import requests
+import asyncio
+
+from app.connectors.line_connector import LineConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError("error")
+
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        assert url == "https://api.line.me/v2/bot/message/push"
+        assert json["to"] == "USER"
+        assert json["messages"][0]["text"] == "hi"
+        assert headers["Authorization"] == "Bearer TOKEN"
+        return DummyResponse("sent")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = LineConnector("TOKEN", "USER")
+    assert connector.send_message("hi") == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = LineConnector("TOKEN", "USER")
+    assert connector.send_message("hi") is None
+
+
+def test_process_incoming():
+    connector = LineConnector("TOKEN", "USER")
+    payload = {"foo": "bar"}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload

--- a/tests/connectors/test_viber.py
+++ b/tests/connectors/test_viber.py
@@ -1,0 +1,44 @@
+import requests
+import asyncio
+
+from app.connectors.viber_connector import ViberConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError("error")
+
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        assert url == "https://chatapi.viber.com/pa/send_message"
+        assert json["receiver"] == "USER"
+        assert json["text"] == "hi"
+        assert headers["X-Viber-Auth-Token"] == "TOKEN"
+        return DummyResponse("sent")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = ViberConnector("TOKEN", "USER")
+    assert connector.send_message("hi") == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = ViberConnector("TOKEN", "USER")
+    assert connector.send_message("hi") is None
+
+
+def test_process_incoming():
+    connector = ViberConnector("TOKEN", "USER")
+    payload = {"foo": "bar"}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload


### PR DESCRIPTION
## Summary
- expand unit tests to cover LINE, Viber and Google Business RCS connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b27d5b6cc8333be3b9e32e5e4d8db