### PR TITLE
Fix bot creation endpoint and add API test

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -73,10 +73,7 @@ async def messages_endpoint(request: Request):
 @app_routes.post("/api/bots/create")
 async def create_bot_endpoint(request: Request, db: Session = Depends(get_async_db)):
     form_data = await request.json()
-    bot = BotCreate
-    bot.name = form_data["name"]
-    bot.description = form_data["description"]
-    # Add logic to create bot in the database
+    bot = BotCreate(**form_data)
     bot = create_bot(db=db, bot_create=bot)
     return JSONResponse(content={"id": bot.id, "name": bot.name, "description": bot.description})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,14 @@
 # tests/conftest.py
 import os
+import sys
+from pydantic import typing as _pydantic_typing
+
+if sys.version_info >= (3, 12):
+    def _evaluate_forwardref(type_, globalns, localns):
+        return type_._evaluate(globalns, localns, None, recursive_guard=set())
+
+    _pydantic_typing.evaluate_forwardref = _evaluate_forwardref
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -24,6 +33,13 @@ settings.database_url = f"sqlite:///{db_dir}/test.db"
 engine = create_engine(settings.database_url)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base.metadata.create_all(bind=engine)
+
+# Override the application's SessionLocal to ensure the API uses the test database
+from app.db import session as db_session
+db_session.SessionLocal = TestingSessionLocal
+db_session.engine = engine
+import app.api.deps as api_deps
+api_deps.SessionLocal = TestingSessionLocal
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+
+def test_create_bot_api(test_app: TestClient, db: Session) -> None:
+    payload = {"name": "test bot", "description": "desc", "gpt_model": "gpt-4"}
+    response = test_app.post("/api/bots/create", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == payload["name"]
+    assert data["description"] == payload["description"]
+    assert "id" in data


### PR DESCRIPTION
## Summary
- fix `create_bot_endpoint` to instantiate `BotCreate` from request body
- patch pydantic forward-ref evaluation for Python 3.12 in tests
- override DB session in tests so API uses the test DB
- add a test ensuring bot creation via API works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b25d4f13c833380d5d96b724881db