### PR TITLE
Add basic implementations for more connectors

### DIFF
--- a/app/connectors/facebook_messenger_connector.py
+++ b/app/connectors/facebook_messenger_connector.py
@@ -1,3 +1,8 @@
+"""Simple Facebook Messenger connector using the Graph API."""
+
+import httpx
+from typing import Any, Dict, Optional
+
 from .base_connector import BaseConnector
 
 
@@ -7,19 +12,28 @@ class FacebookMessengerConnector(BaseConnector):
     id = "facebook_messenger"
     name = "Facebook Messenger"
 
-    def __init__(self, page_token: str, verify_token: str, config=None):
+    def __init__(self, page_token: str, verify_token: str, config: Optional[dict] = None) -> None:
         super().__init__(config)
         self.page_token = page_token
         self.verify_token = verify_token
+        self.api_url = "https://graph.facebook.com/v17.0/me/messages"
 
-    async def send_message(self, message):
-        # Placeholder for sending a message via Facebook Messenger
-        pass
+    async def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        """Send ``message`` payload using the Graph API."""
+        params = {"access_token": self.page_token}
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(self.api_url, params=params, json=message)
+                resp.raise_for_status()
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                print(f"Error sending Facebook message: {exc}")
+                return None
 
     async def listen_and_process(self):
-        # Placeholder for listening to Facebook Messenger messages
-        pass
+        """Listening for Messenger messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound Facebook Messenger messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/imessage_connector.py
+++ b/app/connectors/imessage_connector.py
@@ -1,3 +1,8 @@
+"""Connector for sending Apple iMessage/Business Chat messages."""
+
+import httpx
+from typing import Any, Dict, Optional
+
 from .base_connector import BaseConnector
 
 
@@ -7,19 +12,27 @@ class IMessageConnector(BaseConnector):
     id = "imessage"
     name = "Apple RCS/iMessage"
 
-    def __init__(self, service_url: str, phone_number: str, config=None):
+    def __init__(self, service_url: str, phone_number: str, config: Optional[dict] = None) -> None:
         super().__init__(config)
         self.service_url = service_url
         self.phone_number = phone_number
 
-    async def send_message(self, message):
-        # Placeholder for sending a message via iMessage
-        pass
+    async def send_message(self, message: str) -> Optional[str]:
+        """POST ``message`` to the configured service URL."""
+        payload = {"to": self.phone_number, "message": message}
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(self.service_url, json=payload)
+                resp.raise_for_status()
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                print(f"Error sending iMessage: {exc}")
+                return None
 
     async def listen_and_process(self):
-        # Placeholder for listening to iMessage messages
-        pass
+        """Listening for iMessage messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Placeholder for processing inbound iMessage messages
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/matrix_connector.py
+++ b/app/connectors/matrix_connector.py
@@ -1,3 +1,8 @@
+"""Minimal Matrix connector leveraging the client-server API."""
+
+import httpx
+from typing import Any, Dict, Optional
+
 from .base_connector import BaseConnector
 
 class MatrixConnector(BaseConnector):
@@ -6,23 +11,30 @@ class MatrixConnector(BaseConnector):
     id = 'matrix'
     name = 'Matrix'
 
-    def __init__(self, homeserver: str, user_id: str, access_token: str, room_id: str, config=None):
+    def __init__(self, homeserver: str, user_id: str, access_token: str, room_id: str, config: Optional[dict] = None) -> None:
         super().__init__(config)
         self.homeserver = homeserver
         self.user_id = user_id
         self.access_token = access_token
         self.room_id = room_id
+        self._send_url = f"{self.homeserver}/_matrix/client/v3/rooms/{self.room_id}/send/m.room.message"
 
     async def send_message(self, message):
-        # Code to send a message using the Matrix API
-        pass
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        payload = {"msgtype": "m.text", "body": message}
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(self._send_url, json=payload, headers=headers)
+                resp.raise_for_status()
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                print(f"Error sending Matrix message: {exc}")
+                return None
 
     async def listen_and_process(self):
-        # Code to listen for incoming messages from Matrix
-        # and call process_incoming for each message
-        pass
+        """Listening for Matrix events is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Code to process the incoming message, including applying filters
-        # and calling the appropriate action(s)
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/signal_connector.py
+++ b/app/connectors/signal_connector.py
@@ -1,3 +1,8 @@
+"""Connector for sending messages via a Signal service."""
+
+import httpx
+from typing import Any, Dict, Optional
+
 from .base_connector import BaseConnector
 
 
@@ -7,21 +12,26 @@ class SignalConnector(BaseConnector):
     id = 'signal'
     name = 'Signal'
 
-    def __init__(self, service_url: str, phone_number: str, config=None):
+    def __init__(self, service_url: str, phone_number: str, config: Optional[dict] = None) -> None:
         super().__init__(config)
         self.service_url = service_url
         self.phone_number = phone_number
 
-    async def send_message(self, message):
-        # Code to send a message using Signal service
-        pass
+    async def send_message(self, message: str) -> Optional[str]:
+        payload = {"recipient": self.phone_number, "message": message}
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(self.service_url, json=payload)
+                resp.raise_for_status()
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                print(f"Error sending Signal message: {exc}")
+                return None
 
     async def listen_and_process(self):
-        # Code to listen for incoming messages from Signal
-        # and call process_incoming for each message
-        pass
+        """Listening for Signal messages is not implemented."""
+        return None
 
     async def process_incoming(self, message):
-        # Code to process the incoming message, including applying filters
-        # and calling the appropriate action(s)
-        pass
+        """Return the incoming ``message`` payload."""
+        return message

--- a/app/connectors/tox_connector.py
+++ b/app/connectors/tox_connector.py
@@ -1,6 +1,6 @@
 """Placeholder connector for the Tox peer-to-peer network."""
 
-from typing import Any, Optional
+from typing import Any, Optional, List
 
 from .base_connector import BaseConnector
 
@@ -22,14 +22,16 @@ class ToxConnector(BaseConnector):
         self.bootstrap_host = bootstrap_host
         self.bootstrap_port = bootstrap_port
         self.friend_id = friend_id
+        self.sent_messages: List[Any] = []
 
-    async def send_message(self, message: Any) -> None:
-        # Placeholder for sending a message via Tox
-        pass
+    async def send_message(self, message: Any) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
 
     async def listen_and_process(self) -> None:
-        # Placeholder for listening for messages
-        pass
+        """Listening for Tox messages is not implemented."""
+        return None
 
     async def process_incoming(self, message: Any) -> Any:
         # Placeholder for processing inbound messages

--- a/tests/connectors/test_facebook_messenger.py
+++ b/tests/connectors/test_facebook_messenger.py
@@ -1,0 +1,65 @@
+import asyncio
+import httpx
+
+from app.connectors.facebook_messenger_connector import FacebookMessengerConnector
+
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, params=None, json=None):
+        self.sent = (url, params, json)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    client = DummyClient(resp)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
+    connector = FacebookMessengerConnector("TOKEN", "VERIFY")
+    msg = {"message": {"text": "hi"}, "recipient": {"id": "U"}}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message(msg)
+    )
+    assert result == "sent"
+    assert client.sent[0].startswith("https://graph.facebook.com")
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, params=None, json=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = FacebookMessengerConnector("TOKEN", "VERIFY")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message({"message": {"text": "hi"}})
+    )
+    assert result is None
+
+
+def test_process_incoming():
+    connector = FacebookMessengerConnector("TOKEN", "VERIFY")
+    payload = {"foo": 1}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload

--- a/tests/connectors/test_imessage.py
+++ b/tests/connectors/test_imessage.py
@@ -1,0 +1,65 @@
+import asyncio
+import httpx
+
+from app.connectors.imessage_connector import IMessageConnector
+
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None):
+        self.sent = (url, json)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    client = DummyClient(resp)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
+    connector = IMessageConnector("http://api", "+1")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result == "sent"
+    assert client.sent[0] == "http://api"
+    assert client.sent[1]["to"] == "+1"
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = IMessageConnector("http://api", "+1")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result is None
+
+
+def test_process_incoming():
+    connector = IMessageConnector("http://api", "+1")
+    payload = {"foo": 1}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload

--- a/tests/connectors/test_matrix.py
+++ b/tests/connectors/test_matrix.py
@@ -1,0 +1,64 @@
+import asyncio
+import httpx
+
+from app.connectors.matrix_connector import MatrixConnector
+
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, headers=None):
+        self.sent = (url, json, headers)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    client = DummyClient(resp)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
+    connector = MatrixConnector("https://hs", "@u:hs", "TOK", "!room")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result == "sent"
+    assert client.sent[2]["Authorization"] == "Bearer TOK"
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None, headers=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = MatrixConnector("https://hs", "@u:hs", "TOK", "!room")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result is None
+
+
+def test_process_incoming():
+    connector = MatrixConnector("https://hs", "@u:hs", "TOK", "!room")
+    payload = {"foo": 1}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload

--- a/tests/connectors/test_signal.py
+++ b/tests/connectors/test_signal.py
@@ -1,0 +1,64 @@
+import asyncio
+import httpx
+
+from app.connectors.signal_connector import SignalConnector
+
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None):
+        self.sent = (url, json)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    client = DummyClient(resp)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
+    connector = SignalConnector("http://signal", "+1")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result == "sent"
+    assert client.sent[0] == "http://signal"
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = SignalConnector("http://signal", "+1")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result is None
+
+
+def test_process_incoming():
+    connector = SignalConnector("http://signal", "+1")
+    payload = {"foo": 1}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload

--- a/tests/connectors/test_tox.py
+++ b/tests/connectors/test_tox.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from app.connectors.tox_connector import ToxConnector
+
+
+def test_send_message():
+    connector = ToxConnector("host")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = ToxConnector("host")
+    payload = {"foo": 1}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload


### PR DESCRIPTION
## Summary
- implement minimal send/receive logic for several connectors
- add test coverage for the new connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b29da065883339bd4c83fd3817996