### PR TITLE
Use stored channel in connectors

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -239,7 +239,7 @@ async def process_webhook(request: Request, payload: dict = Body(...)):
             # If the filter has a reply, send the reply to the specified channel
             if lfilter.reply:
                 connector = get_connector(lfilter.reply_channel.connector)
-                await connector.send_message(lfilter.reply_channel, filter.reply)
+                await connector.send_message(filter.reply)
 
 @app_routes.post("/token", response_model=Token)
 async def token(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_async_db)):

--- a/app/connectors/irc_connector.py
+++ b/app/connectors/irc_connector.py
@@ -56,9 +56,12 @@ class IRCConnector(BaseConnector):
                 self.socket.close()
                 self.socket = None
 
-    def send_message(self, channel, message):
-        if self.socket:
-            self.socket.sendall(f"PRIVMSG {channel} :{message}\r\n".encode("utf-8"))
+    def send_message(self, message):
+        if self.socket and self.channels:
+            channel = self.channels[0]
+            self.socket.sendall(
+                f"PRIVMSG {channel} :{message}\r\n".encode("utf-8")
+            )
 
     def receive_message(self):
         while True:

--- a/app/connectors/slack_connector.py
+++ b/app/connectors/slack_connector.py
@@ -55,9 +55,9 @@ class SlackConnector(BaseConnector):
             "ts": payload.get("ts"),
         }
 
-    def send_message(self, channel, message):
+    def send_message(self, message):
         try:
-            response = self.client.chat_postMessage(channel=channel, text=message)
+            response = self.client.chat_postMessage(channel=self.channel_id, text=message)
             return response
         except SlackApiError as e:
             print(f"Error sending message: {e}")

--- a/tests/connectors/test_irc.py
+++ b/tests/connectors/test_irc.py
@@ -52,7 +52,7 @@ def test_connect(monkeypatch):
 def test_send_and_receive(monkeypatch):
     connector, sock = make_connector(monkeypatch)
     connector.connect()
-    connector.send_message("#chan", "hi")
+    connector.send_message("hi")
     assert sock.sent[-1] == b"PRIVMSG #chan :hi\r\n"
     message = connector.receive_message()
     assert message == ":u!u@h PRIVMSG #chan :hello\r\n"


### PR DESCRIPTION
## Summary
- slack/irc connectors use stored channel so `send_message` only requires a message
- update slack/irc call site in `app_routes`
- adjust IRC connector tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b2f5568948333b7d21038d55a9200