### PR TITLE
Fix duplicate logging handlers

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -1,13 +1,24 @@
 import logging
 
-def setup_logger(name: str):
+def setup_logger(name: str) -> logging.Logger:
+    """Return a configured :class:`logging.Logger` instance.
+
+    The function is safe to call multiple times for the same ``name``. A
+    ``StreamHandler`` is only added if the logger doesn't already have one to
+    avoid duplicate log messages when modules import this helper repeatedly.
+    """
+
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
 
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    handler.setFormatter(formatter)
+    has_stream = any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
+    if not has_stream:
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.DEBUG)
+        formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
 
-    logger.addHandler(handler)
     return logger

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,18 @@
+import logging
+from app.core.logging import setup_logger
+
+
+def test_setup_logger_idempotent():
+    name = "test_setup_logger_idempotent"
+    logger1 = setup_logger(name)
+    initial_handlers = list(logger1.handlers)
+    # call again to ensure no duplicate handlers are added
+    logger2 = setup_logger(name)
+    assert logger1 is logger2
+    assert logger1.handlers == initial_handlers
+    # ensure exactly one StreamHandler is attached
+    stream_handlers = [h for h in logger1.handlers if isinstance(h, logging.StreamHandler)]
+    assert len(stream_handlers) == 1
+    # cleanup
+    for handler in list(logger1.handlers):
+        logger1.removeHandler(handler)


### PR DESCRIPTION
## Summary
- prevent duplicate `StreamHandler` creation in `setup_logger`
- add regression test for logger idempotence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b2f58f50c83338b9cb0b4c4f37fd7