### PR TITLE
Add initial app integration tests

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -28,6 +28,7 @@ from app.api.deps import get_async_db
 
 from datetime import timedelta
 import os
+import traceback
 
 from .views import home, connectors, filters, channels, process_message, bots, messages, login, logout, get_bots
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,11 +1,24 @@
+"""Basic integration tests for the FastAPI application."""
+
 import json
-import pytest
 
-pytest.skip("App tests not implemented", allow_module_level=True)
+from fastapi.testclient import TestClient
 
-def test_get_users(test_app):
-    response = test_app.get("/users")
+
+def test_homepage_returns_html(test_app: TestClient) -> None:
+    """The root endpoint should return the index page."""
+    response = test_app.get("/")
     assert response.status_code == 200
-    users = json.loads(response.text)
-    assert isinstance(users, list)
-    assert len(users) > 0
+    assert "text/html" in response.headers.get("content-type", "")
+
+
+def test_get_bot_messages_empty(test_app: TestClient) -> None:
+    """The messages endpoint should return an empty list for a new bot."""
+    payload = {"name": "test bot", "description": "desc", "gpt_model": "gpt-4"}
+    create = test_app.post("/api/bots/create", json=payload)
+    assert create.status_code == 200
+    bot_id = create.json()["id"]
+
+    response = test_app.get(f"/api/bots/{bot_id}/messages")
+    assert response.status_code == 200
+    assert json.loads(response.text) == []

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -1,10 +1,8 @@
 from app.api.api_v1.routers.connectors.webhook import get_webhook_connector
 from app.core.test_settings import test_settings
-import pytest
-
-pytest.skip("Webhook router tests not implemented", allow_module_level=True)
 
 
-def test_get_webhook_connector_uses_settings():
+def test_get_webhook_connector_uses_settings() -> None:
+    """The dependency should build the connector using the provided settings."""
     connector = get_webhook_connector(test_settings)
     assert connector.webhook_url == test_settings.webhook_secret


### PR DESCRIPTION
## Summary
- add functional tests for homepage and bot messages
- enable webhook router test
- fix missing traceback import in app routes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b2f86fb548333a3b5371fde8d7d07