### PR TITLE
Fix Bot creation logic and schema

### DIFF
--- a/app/crud/bot.py
+++ b/app/crud/bot.py
@@ -5,7 +5,14 @@ def get_bot_by_id(db: Session, bot_id: int):
     return db.query(models.Bot).filter(models.Bot.id == bot_id).first()
 
 def create_bot(db: Session, bot_create: schemas.BotCreate):
-    bot = models.Bot(name=bot_create.name, description=bot_create.description)
+    """Create and persist a new :class:`~app.models.bot.Bot`."""
+
+    description = bot_create.description or ""
+    bot = models.Bot(
+        name=bot_create.name,
+        description=description,
+        gpt_model=bot_create.gpt_model,
+    )
     db.add(bot)
     db.commit()
     db.refresh(bot)

--- a/app/models/bot.py
+++ b/app/models/bot.py
@@ -6,7 +6,7 @@ class Bot(Base):
     __tablename__ = "bots"
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
-    description = Column(String, nullable=False)
+    description = Column(String, nullable=True)
     user_id = Column(Integer, ForeignKey("users.id"))
     gpt_model = Column(String, nullable=False, default="gpt-4")
     system_prompt = Column(String, nullable=False, default="You are a helpful assistant.")

--- a/app/schemas/bot.py
+++ b/app/schemas/bot.py
@@ -3,7 +3,6 @@ from pydantic import BaseModel
 
 class BotBase(BaseModel):
     name: str
-    session_id: str
     gpt_model: str
 
 class BotCreate(BaseModel):


### PR DESCRIPTION
## Summary
- fix `create_bot` to use gpt_model and handle missing description
- make bot description column optional
- remove unused session_id from bot schemas

## Testing
- `pytest tests/test_bots.py::test_create_bot -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_683b348eb4448333819159f4f2f30625