### PR TITLE
Add initial app integration tests

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -28,6 +28,7 @@ from app.api.deps import get_async_db
 
 from datetime import timedelta
 import os
+import traceback
 
 from .views import home, connectors, filters, channels, process_message, bots, messages, login, logout, get_bots
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,14 +1,12 @@
-import pytest
+"""CRUD tests for the Action helpers."""
+
+import app.crud.action  # ensure submodule is available
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app import crud, models
-from app.core.config import settings
+from app import crud
 from app.schemas.action import ActionCreate, ActionUpdate
 from app.tests.utils.utils import random_lower_string
-import pytest
-
-pytest.skip("Action tests not implemented", allow_module_level=True)
 
 def test_create_action(test_app: TestClient, db: Session) -> None:
     prompt = random_lower_string()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,11 +1,24 @@
+"""Basic integration tests for the FastAPI application."""
+
 import json
-import pytest
 
-pytest.skip("App tests not implemented", allow_module_level=True)
+from fastapi.testclient import TestClient
 
-def test_get_users(test_app):
-    response = test_app.get("/users")
+
+def test_homepage_returns_html(test_app: TestClient) -> None:
+    """The root endpoint should return the index page."""
+    response = test_app.get("/")
     assert response.status_code == 200
-    users = json.loads(response.text)
-    assert isinstance(users, list)
-    assert len(users) > 0
+    assert "text/html" in response.headers.get("content-type", "")
+
+
+def test_get_bot_messages_empty(test_app: TestClient) -> None:
+    """The messages endpoint should return an empty list for a new bot."""
+    payload = {"name": "test bot", "description": "desc", "gpt_model": "gpt-4"}
+    create = test_app.post("/api/bots/create", json=payload)
+    assert create.status_code == 200
+    bot_id = create.json()["id"]
+
+    response = test_app.get(f"/api/bots/{bot_id}/messages")
+    assert response.status_code == 200
+    assert json.loads(response.text) == []

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -1,29 +1,26 @@
-import pytest
+"""CRUD tests for the Bot helpers."""
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app import crud, models
-from app.core.config import settings
+from app import crud
 from app.schemas.bot import BotCreate
 from app.tests.utils.utils import random_lower_string
-import pytest
-
-pytest.skip("Bot tests not implemented", allow_module_level=True)
 
 def test_create_bot(test_app: TestClient, db: Session) -> None:
     gpt_model = "gpt-4"
     name = random_lower_string()
-    bot_in = BotCreate(gpt_model=gpt_model, name=name)
-    bot = crud.bot.create(db, obj_in=bot_in)
+    bot_in = BotCreate(gpt_model=gpt_model, name=name, description="desc")
+    bot = crud.bot.create_bot(db, bot_create=bot_in)
     assert bot.gpt_model == gpt_model
     assert bot.name == name
 
 def test_get_bot(test_app: TestClient, db: Session) -> None:
     gpt_model = "gpt-4"
     name = random_lower_string()
-    bot_in = BotCreate(gpt_model=gpt_model, name=name)
-    bot = crud.bot.create(db, obj_in=bot_in)
-    bot_2 = crud.bot.get(db, bot.id)
+    bot_in = BotCreate(gpt_model=gpt_model, name=name, description="desc")
+    bot = crud.bot.create_bot(db, bot_create=bot_in)
+    bot_2 = crud.bot.get_bot_by_id(db, bot.id)
     assert bot_2
     assert bot.gpt_model == bot_2.gpt_model
     assert bot.name == bot_2.name

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,14 +1,11 @@
-import pytest
+"""Simple CRUD tests for connectors."""
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app import crud, models
-from app.core.config import settings
+from app import crud
 from app.schemas.connector import ConnectorCreate
 from app.tests.utils.utils import random_lower_string
-import pytest
-
-pytest.skip("Connector tests not implemented", allow_module_level=True)
 
 def test_create_connector(test_app: TestClient, db: Session) -> None:
     connector_type = "irc"

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,28 +1,26 @@
-import pytest
+"""CRUD tests for user helpers."""
+
+import app.crud.user  # ensure submodule is loaded
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app import crud, models
-from app.core.config import settings
+from app import crud
 from app.schemas.user import UserCreate
 from app.tests.utils.utils import random_email, random_lower_string
-import pytest
-
-pytest.skip("User tests not implemented", allow_module_level=True)
 
 def test_create_user(test_app: TestClient, db: Session) -> None:
     email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=email, password=password)
-    user = crud.user.create(db, obj_in=user_in)
+    user_in = UserCreate(username=random_lower_string(), email=email, password=password)
+    user = crud.user.create_user(db, user=user_in)
     assert user.email == email
 
 def test_get_user(test_app: TestClient, db: Session) -> None:
     email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=email, password=password)
-    user = crud.user.create(db, obj_in=user_in)
-    user_2 = crud.user.get(db, user.id)
+    user_in = UserCreate(username=random_lower_string(), email=email, password=password)
+    user = crud.user.create_user(db, user=user_in)
+    user_2 = crud.user.get_user_by_id(db, user.id)
     assert user_2
     assert user.email == user_2.email
     assert user.id == user_2.id

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -1,10 +1,8 @@
 from app.api.api_v1.routers.connectors.webhook import get_webhook_connector
 from app.core.test_settings import test_settings
-import pytest
-
-pytest.skip("Webhook router tests not implemented", allow_module_level=True)
 
 
-def test_get_webhook_connector_uses_settings():
+def test_get_webhook_connector_uses_settings() -> None:
+    """The dependency should build the connector using the provided settings."""
     connector = get_webhook_connector(test_settings)
     assert connector.webhook_url == test_settings.webhook_secret


### PR DESCRIPTION
## Summary
- add functional tests for homepage and bot messages
- enable webhook router test
- fix missing traceback import in app routes
- implement CRUD tests for remaining modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b2f86fb548333a3b5371fde8d7d07