### PR TITLE
Add Zulip connector

### DIFF
--- a/app/connectors/connector_utils.py
+++ b/app/connectors/connector_utils.py
@@ -71,6 +71,7 @@ from .apple_messages_business_connector import AppleMessagesBusinessConnector
 from .intercom_connector import IntercomConnector
 from .snmp_connector import SNMPConnector
 from .tox_connector import ToxConnector
+from .zulip_connector import ZulipConnector
 
 from .aws_iot_core_connector import AWSIoTCoreConnector
 from .aws_eventbridge_connector import AWSEventBridgeConnector
@@ -138,6 +139,7 @@ connector_classes: Dict[str, type] = {
     "intercom": IntercomConnector,
     "snmp": SNMPConnector,
     "tox": ToxConnector,
+    "zulip": ZulipConnector,
 }
 
 

--- a/app/connectors/zulip_connector.py
+++ b/app/connectors/zulip_connector.py
@@ -1,0 +1,51 @@
+import requests
+from typing import Any, Dict, Optional
+
+from .base_connector import BaseConnector
+
+
+class ZulipConnector(BaseConnector):
+    """Simple connector for sending messages to Zulip streams."""
+
+    id = "zulip"
+    name = "Zulip"
+
+    def __init__(self, email: str, api_key: str, site_url: str, stream: str, topic: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.email = email
+        self.api_key = api_key
+        self.site_url = site_url.rstrip("/")
+        self.stream = stream
+        self.topic = topic
+
+    def send_message(self, text: str) -> Optional[str]:
+        url = f"{self.site_url}/api/v1/messages"
+        data = {
+            "type": "stream",
+            "to": self.stream,
+            "topic": self.topic,
+            "content": text,
+        }
+        try:
+            resp = requests.post(url, data=data, auth=(self.email, self.api_key))
+            resp.raise_for_status()
+            return resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network
+            print(f"Error sending Zulip message: {exc}")
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Listening for Zulip messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return message
+
+    def is_connected(self) -> bool:
+        url = f"{self.site_url}/api/v1/server_settings"
+        try:
+            resp = requests.get(url, auth=(self.email, self.api_key))
+            resp.raise_for_status()
+            return True
+        except requests.RequestException:
+            return False

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -163,6 +163,11 @@ class Settings(BaseSettings):
     tox_bootstrap_host: str
     tox_bootstrap_port: int
     tox_friend_id: str
+    zulip_email: str
+    zulip_api_key: str
+    zulip_site_url: str
+    zulip_stream: str
+    zulip_topic: str
     openai_api_key: Optional[str]
 
     access_token_expire_minutes: int

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -155,6 +155,11 @@ snmp_community: "public"
 tox_bootstrap_host: "your_tox_bootstrap_host"
 tox_bootstrap_port: 33445
 tox_friend_id: "your_tox_friend_id"
+zulip_email: "your_zulip_email"
+zulip_api_key: "your_zulip_api_key"
+zulip_site_url: "https://zulip.example.com"
+zulip_stream: "your_zulip_stream"
+zulip_topic: "your_zulip_topic"
 
 openai_api_key:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -62,6 +62,7 @@ The following connectors are soon to be supported:
 53. [Intercom](./connectors/intercom.md)
 54. [SNMP](./connectors/snmp.md)
 55. [Tox](./connectors/tox.md)
+56. [Zulip](./connectors/zulip.md)
 
 
 ## Usage
@@ -122,5 +123,6 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Intercom Connector](./connectors/intercom.md)
 - [SNMP Connector](./connectors/snmp.md)
 - [Tox Connector](./connectors/tox.md)
+- [Zulip Connector](./connectors/zulip.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/zulip.md
+++ b/docs/connectors/zulip.md
@@ -1,0 +1,31 @@
+# Zulip Connector
+
+The Zulip connector enables Norman to post messages to a Zulip stream.
+
+## Requirements
+
+- A Zulip account with an API key
+- The URL of your Zulip server
+- The stream and topic where Norman should post messages
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+zulip_email: "bot@example.com"
+zulip_api_key: "your_zulip_api_key"
+zulip_site: "https://zulip.example.com"
+zulip_stream: "general"
+zulip_topic: "Norman"
+```
+
+## Usage
+
+With these values provided, Norman will be able to send messages to the given stream and topic. Receiving messages has not been implemented yet.
+
+## Troubleshooting
+
+1. Verify the email and API key are correct.
+2. Ensure the server URL is reachable from your Norman instance.
+3. Check Zulip server logs if messages fail to send.

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -344,3 +344,10 @@ def test_get_connector_returns_cap(monkeypatch):
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
     connector = get_connector('cap')
     assert isinstance(connector, CAPConnector)
+
+
+def test_get_connector_returns_zulip(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
+    connector = get_connector('zulip')
+    from app.connectors.zulip_connector import ZulipConnector
+    assert isinstance(connector, ZulipConnector)

--- a/tests/connectors/test_zulip.py
+++ b/tests/connectors/test_zulip.py
@@ -1,0 +1,59 @@
+import requests
+import asyncio
+
+from app.connectors.zulip_connector import ZulipConnector
+
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError("error")
+
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, data=None, auth=None):
+        assert "api/v1/messages" in url
+        assert data["content"] == "hi"
+        return DummyResponse("sent")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = ZulipConnector("email", "KEY", "https://zulip.example.com", "stream", "topic")
+    assert connector.send_message("hi") == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, data=None, auth=None):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = ZulipConnector("email", "KEY", "https://zulip.example.com", "stream", "topic")
+    assert connector.send_message("hi") is None
+
+
+def test_process_incoming():
+    connector = ZulipConnector("email", "KEY", "https://zulip.example.com", "stream", "topic")
+    payload = {"foo": "bar"}
+    result = asyncio.get_event_loop().run_until_complete(connector.process_incoming(payload))
+    assert result == payload
+
+
+def test_is_connected_success(monkeypatch):
+    def fake_get(url, auth=None):
+        return DummyResponse(status=200)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    connector = ZulipConnector("email", "KEY", "https://zulip.example.com", "stream", "topic")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    def fake_get(url, auth=None):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    connector = ZulipConnector("email", "KEY", "https://zulip.example.com", "stream", "topic")
+    assert not connector.is_connected()


### PR DESCRIPTION
## Summary
- add new ZulipConnector implementation
- register Zulip connector and configuration settings
- document Zulip connector
- update config defaults
- test Zulip connector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b90ad27708333a5f8e75c445db05d