### PR TITLE
Add tests for new connectors

### DIFF
--- a/tests/connectors/test_aws_eventbridge.py
+++ b/tests/connectors/test_aws_eventbridge.py
@@ -1,0 +1,28 @@
+import asyncio
+import types
+import pytest
+
+import app.connectors.aws_eventbridge_connector as mod
+
+class DummyClient:
+    def __init__(self):
+        self.entries = None
+    def put_events(self, Entries=None):
+        self.entries = Entries
+        return {"ok": True}
+
+
+def test_send_message_success(monkeypatch):
+    stub = types.SimpleNamespace(client=lambda service, region_name=None: DummyClient())
+    monkeypatch.setattr(mod, "boto3", stub)
+    connector = mod.AWSEventBridgeConnector(region="us", event_bus_name="bus")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message({"a":1}))
+    assert result == {"ok": True}
+
+
+def test_send_message_no_boto3(monkeypatch):
+    monkeypatch.setattr(mod, "boto3", None)
+    connector = mod.AWSEventBridgeConnector(region="us", event_bus_name="bus")
+    with pytest.raises(RuntimeError):
+        asyncio.get_event_loop().run_until_complete(connector.send_message({}))
+

--- a/tests/connectors/test_aws_iot_core.py
+++ b/tests/connectors/test_aws_iot_core.py
@@ -1,0 +1,28 @@
+import asyncio
+import types
+import pytest
+
+import app.connectors.aws_iot_core_connector as mod
+
+class DummyClient:
+    def __init__(self):
+        self.published = []
+    def publish(self, topic=None, qos=None, payload=None):
+        self.published.append((topic, qos, payload))
+        return {"ok": True}
+
+
+def test_send_message_success(monkeypatch):
+    stub = types.SimpleNamespace(client=lambda service, region_name=None, endpoint_url=None: DummyClient())
+    monkeypatch.setattr(mod, "boto3", stub)
+    connector = mod.AWSIoTCoreConnector(region="us", topic="t")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == {"ok": True}
+
+
+def test_send_message_no_boto3(monkeypatch):
+    monkeypatch.setattr(mod, "boto3", None)
+    connector = mod.AWSIoTCoreConnector(region="us", topic="t")
+    with pytest.raises(RuntimeError):
+        asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+

--- a/tests/connectors/test_mqtt.py
+++ b/tests/connectors/test_mqtt.py
@@ -1,0 +1,46 @@
+import asyncio
+import types
+import pytest
+
+import app.connectors.mqtt_connector as mqtt_connector
+
+class DummyClient:
+    def __init__(self):
+        self.published = []
+        self.connected = False
+        self.disconnected = False
+    def username_pw_set(self, username, password):
+        self.user = username
+        self.pw = password
+    def connect(self, host, port):
+        self.connected = True
+        self.host = host
+        self.port = port
+    def publish(self, topic, message):
+        self.published.append((topic, message))
+    def disconnect(self):
+        self.disconnected = True
+    def subscribe(self, topic):
+        self.subscribed = topic
+    def loop_start(self):
+        pass
+    def loop_stop(self):
+        pass
+
+
+def test_send_message_success(monkeypatch):
+    dummy = DummyClient()
+    stub = types.SimpleNamespace(Client=lambda: dummy)
+    monkeypatch.setattr(mqtt_connector, "mqtt", stub)
+    connector = mqtt_connector.MQTTConnector(host="h", topic="t")
+    asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert dummy.published == [("t", "hi")]
+    assert dummy.disconnected
+
+
+def test_send_message_no_library(monkeypatch):
+    monkeypatch.setattr(mqtt_connector, "mqtt", None)
+    connector = mqtt_connector.MQTTConnector(host="h")
+    with pytest.raises(RuntimeError):
+        asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+

--- a/tests/connectors/test_nats.py
+++ b/tests/connectors/test_nats.py
@@ -1,0 +1,38 @@
+import asyncio
+import types
+import pytest
+
+import app.connectors.nats_connector as nats_connector
+
+class DummyNATS:
+    def __init__(self):
+        self.published = []
+        self.closed = False
+    async def publish(self, subject, payload):
+        self.published.append((subject, payload))
+    async def drain(self):
+        self.closed = True
+    async def close(self):
+        self.closed = True
+
+async def fake_connect(servers=""):
+    return DummyNATS()
+
+
+def test_send_message(monkeypatch):
+    dummy = DummyNATS()
+    async def connect_stub(servers=""):
+        return dummy
+    monkeypatch.setattr(nats_connector, "nats", types.SimpleNamespace(connect=connect_stub))
+    connector = nats_connector.NATSConnector(servers="nats://s", subject="sub")
+    asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert dummy.published == [("sub", b"hi")]
+    assert connector._nc is dummy
+
+
+def test_no_library(monkeypatch):
+    monkeypatch.setattr(nats_connector, "nats", None)
+    connector = nats_connector.NATSConnector()
+    with pytest.raises(RuntimeError):
+        asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+

--- a/tests/connectors/test_smtp.py
+++ b/tests/connectors/test_smtp.py
@@ -1,0 +1,50 @@
+import asyncio
+import types
+
+import app.connectors.smtp_connector as smtp_connector
+
+class DummySMTP:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.tls = False
+        self.logged_in = False
+        self.sent = None
+        self.quit_called = False
+    def starttls(self):
+        self.tls = True
+    def login(self, user, password):
+        self.logged_in = True
+        self.user = user
+        self.password = password
+    def send_message(self, msg):
+        self.sent = msg
+    def quit(self):
+        self.quit_called = True
+
+
+def test_send_and_disconnect(monkeypatch):
+    monkeypatch.setattr(smtp_connector, "smtplib", types.SimpleNamespace(SMTP=DummySMTP))
+    connector = smtp_connector.SMTPConnector(
+        host="localhost",
+        port=25,
+        username="u",
+        password="p",
+        from_address="a@example.com",
+        to_address="b@example.com",
+    )
+    asyncio.get_event_loop().run_until_complete(connector.send_message("hello"))
+    server = connector.server
+    assert isinstance(server, DummySMTP)
+    assert server.sent.get_content().strip() == "hello"
+    assert connector.is_connected()
+    connector.disconnect()
+    assert server.quit_called
+    assert not connector.is_connected()
+
+
+def test_process_incoming():
+    connector = smtp_connector.SMTPConnector("h")
+    result = asyncio.get_event_loop().run_until_complete(connector.process_incoming("x"))
+    assert result == "x"
+


### PR DESCRIPTION
## Summary
- expand coverage with tests for MQTT, NATS, SMTP, AWS EventBridge and AWS IoT Core connectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bc0f639b08333bc080a2e07e342c4