### PR TITLE
Add tests for remaining connectors

### DIFF
--- a/tests/connectors/test_amqp.py
+++ b/tests/connectors/test_amqp.py
@@ -1,0 +1,38 @@
+import types
+import pytest
+import app.connectors.amqp_connector as mod
+
+class DummyChannel:
+    def __init__(self):
+        self.published = []
+    def queue_declare(self, queue, durable=True):
+        self.queue = queue
+    def basic_publish(self, exchange="", routing_key=None, body=None):
+        self.published.append((routing_key, body))
+
+class DummyConnection:
+    def __init__(self):
+        self.channel_obj = DummyChannel()
+    def channel(self):
+        return self.channel_obj
+    def close(self):
+        self.closed = True
+
+
+def test_send_message_success(monkeypatch):
+    dummy = DummyConnection()
+    stub = types.SimpleNamespace(
+        BlockingConnection=lambda params: dummy,
+        URLParameters=lambda url: url,
+    )
+    monkeypatch.setattr(mod, "pika", stub)
+    connector = mod.AMQPConnector("amqp://", "q")
+    connector.send_message("hi")
+    assert dummy.channel_obj.published == [("q", b"hi")]
+
+
+def test_send_message_no_library(monkeypatch):
+    monkeypatch.setattr(mod, "pika", None)
+    connector = mod.AMQPConnector("amqp://", "q")
+    with pytest.raises(RuntimeError):
+        connector.send_message("hi")

--- a/tests/connectors/test_apple_messages_business.py
+++ b/tests/connectors/test_apple_messages_business.py
@@ -1,0 +1,26 @@
+import requests
+from app.connectors.apple_messages_business_connector import AppleMessagesBusinessConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.RequestException("error")
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        assert "api.apple.com" in url
+        assert headers["Authorization"] == "Bearer TOKEN"
+        return DummyResponse("sent")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = AppleMessagesBusinessConnector("TOKEN", "SENDER")
+    assert connector.send_message("hi") == "sent"
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = AppleMessagesBusinessConnector("TOKEN", "SENDER")
+    assert connector.send_message("hi") is None

--- a/tests/connectors/test_aprs.py
+++ b/tests/connectors/test_aprs.py
@@ -1,0 +1,34 @@
+import asyncio
+import types
+import pytest
+import app.connectors.aprs_connector as mod
+
+class DummyIS:
+    def __init__(self):
+        self.sent = []
+        self.closed = False
+    def connect(self):
+        pass
+    def sendall(self, msg):
+        self.sent.append(msg)
+    def close(self):
+        self.closed = True
+    def __iter__(self):
+        return iter([])
+
+
+def test_send_message_success(monkeypatch):
+    dummy = DummyIS()
+    stub = types.SimpleNamespace(IS=lambda *a, **k: dummy)
+    monkeypatch.setattr(mod, "aprslib", stub)
+    connector = mod.APRSConnector("host")
+    asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert dummy.sent == ["hi"]
+    assert dummy.closed
+
+
+def test_send_message_no_library(monkeypatch):
+    monkeypatch.setattr(mod, "aprslib", None)
+    connector = mod.APRSConnector("host")
+    with pytest.raises(RuntimeError):
+        asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))

--- a/tests/connectors/test_azure_eventgrid.py
+++ b/tests/connectors/test_azure_eventgrid.py
@@ -1,0 +1,38 @@
+import asyncio
+import types
+import pytest
+import app.connectors.azure_eventgrid_connector as mod
+
+class DummyClient:
+    def __init__(self, endpoint, credential):
+        self.sent = []
+    def send(self, events):
+        self.sent.append(events)
+
+class DummyEvent:
+    def __init__(self, subject=None, event_type=None, data=None, data_version=None):
+        self.data = data
+
+
+def test_send_message_success(monkeypatch):
+    stub = types.SimpleNamespace(
+        EventGridPublisherClient=DummyClient,
+        EventGridEvent=DummyEvent,
+        AzureKeyCredential=lambda key: object(),
+    )
+    monkeypatch.setattr(mod, "EventGridPublisherClient", stub.EventGridPublisherClient)
+    monkeypatch.setattr(mod, "EventGridEvent", stub.EventGridEvent)
+    monkeypatch.setattr(mod, "AzureKeyCredential", stub.AzureKeyCredential)
+    connector = mod.AzureEventGridConnector("https://e", "KEY")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message({"a":1}))
+    assert result == "ok"
+    assert connector.client.sent[0][0].data == {"a":1}
+
+
+def test_send_message_no_library(monkeypatch):
+    monkeypatch.setattr(mod, "EventGridPublisherClient", None)
+    monkeypatch.setattr(mod, "EventGridEvent", None)
+    monkeypatch.setattr(mod, "AzureKeyCredential", None)
+    connector = mod.AzureEventGridConnector("https://e", "KEY")
+    with pytest.raises(RuntimeError):
+        asyncio.get_event_loop().run_until_complete(connector.send_message({}))

--- a/tests/connectors/test_base_connector.py
+++ b/tests/connectors/test_base_connector.py
@@ -1,0 +1,26 @@
+import asyncio
+import contextlib
+from app.connectors.base_connector import BaseConnector
+
+class DummyConnector(BaseConnector):
+    def __init__(self):
+        super().__init__()
+        self.sent = []
+    def send_message(self, message):
+        self.sent.append(message)
+    async def listen_and_process(self):
+        return None
+    async def process_incoming(self, message):
+        return message
+
+
+def test_queue_and_dispatcher():
+    connector = DummyConnector()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(connector.queue_message("hi"))
+    task = loop.create_task(connector._dispatcher())
+    loop.run_until_complete(asyncio.sleep(0))
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        loop.run_until_complete(task)
+    assert connector.sent == ["hi"]

--- a/tests/connectors/test_github.py
+++ b/tests/connectors/test_github.py
@@ -1,0 +1,25 @@
+import requests
+from app.connectors.github_connector import GitHubConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.RequestException("error")
+
+def test_send_message_issue(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        assert "/issues" in url
+        return DummyResponse("sent")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = GitHubConnector("TOKEN", "repo")
+    assert connector.send_message({"title": "hi"}) == "sent"
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = GitHubConnector("TOKEN", "repo")
+    assert connector.send_message({"title": "hi"}) is None

--- a/tests/connectors/test_google_pubsub.py
+++ b/tests/connectors/test_google_pubsub.py
@@ -1,0 +1,32 @@
+import asyncio
+import types
+import pytest
+import app.connectors.google_pubsub_connector as mod
+
+class DummyFuture:
+    def result(self):
+        return "id"
+
+class DummyPublisher:
+    def __init__(self):
+        self.published = []
+    def topic_path(self, project_id, topic_id):
+        return f"{project_id}/{topic_id}"
+    def publish(self, topic_path, message):
+        self.published.append((topic_path, message))
+        return DummyFuture()
+
+
+def test_send_message_success(monkeypatch):
+    stub = types.SimpleNamespace(PublisherClient=lambda *a, **k: DummyPublisher())
+    monkeypatch.setattr(mod, "pubsub_v1", stub)
+    connector = mod.GooglePubSubConnector("p", "t")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "id"
+
+
+def test_send_message_no_library(monkeypatch):
+    monkeypatch.setattr(mod, "pubsub_v1", None)
+    connector = mod.GooglePubSubConnector("p", "t")
+    with pytest.raises(RuntimeError):
+        asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))

--- a/tests/connectors/test_ifttt.py
+++ b/tests/connectors/test_ifttt.py
@@ -1,0 +1,41 @@
+import asyncio
+import httpx
+from app.connectors.ifttt_connector import IFTTTConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+class DummyClient:
+    def __init__(self, resp):
+        self.resp = resp
+        self.sent = None
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def post(self, url, json=None):
+        self.sent = (url, json)
+        return self.resp
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(resp))
+    connector = IFTTTConnector("http://webhook")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message({"a":1}))
+    assert result == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None):
+            raise httpx.HTTPError("boom")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = IFTTTConnector("http://webhook")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message({"a":1}))
+    assert result is None

--- a/tests/connectors/test_intercom.py
+++ b/tests/connectors/test_intercom.py
@@ -1,0 +1,25 @@
+import requests
+from app.connectors.intercom_connector import IntercomConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.RequestException("error")
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        assert "api.intercom.io" in url
+        return DummyResponse("sent")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = IntercomConnector("TOKEN", "APP")
+    assert connector.send_message("hi") == "sent"
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = IntercomConnector("TOKEN", "APP")
+    assert connector.send_message("hi") is None

--- a/tests/connectors/test_jira_service_desk.py
+++ b/tests/connectors/test_jira_service_desk.py
@@ -1,0 +1,25 @@
+import requests
+from app.connectors.jira_service_desk_connector import JiraServiceDeskConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.RequestException("error")
+
+def test_send_message_issue(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        assert "issue" in url
+        return DummyResponse("sent")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = JiraServiceDeskConnector("http://s", "e", "t", "PROJ")
+    assert connector.send_message({"summary": "hi"}) == "sent"
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = JiraServiceDeskConnector("http://s", "e", "t", "PROJ")
+    assert connector.send_message({"summary": "hi"}) is None

--- a/tests/connectors/test_kafka.py
+++ b/tests/connectors/test_kafka.py
@@ -1,0 +1,24 @@
+import types
+import pytest
+import app.connectors.kafka_connector as mod
+
+class DummyProducer:
+    def __init__(self):
+        self.messages = []
+    def produce(self, topic, value=None):
+        self.messages.append((topic, value))
+    def flush(self):
+        pass
+
+
+def test_send_message_success(monkeypatch):
+    monkeypatch.setattr(mod, "Producer", lambda conf: DummyProducer())
+    connector = mod.KafkaConnector(bootstrap_servers="s", topic="t")
+    assert connector.send_message("hi") == "ok"
+
+
+def test_send_message_no_library(monkeypatch):
+    monkeypatch.setattr(mod, "Producer", None)
+    connector = mod.KafkaConnector()
+    with pytest.raises(RuntimeError):
+        connector.send_message("hi")

--- a/tests/connectors/test_mastodon.py
+++ b/tests/connectors/test_mastodon.py
@@ -1,0 +1,25 @@
+import requests
+from app.connectors.mastodon_connector import MastodonConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.RequestException("error")
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, headers=None, data=None):
+        assert "/api/v1/statuses" in url
+        return DummyResponse("sent")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = MastodonConnector("http://host", "TOKEN")
+    assert connector.send_message("hi") == "sent"
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, headers=None, data=None):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = MastodonConnector("http://host", "TOKEN")
+    assert connector.send_message("hi") is None

--- a/tests/connectors/test_pagerduty.py
+++ b/tests/connectors/test_pagerduty.py
@@ -1,0 +1,25 @@
+import requests
+from app.connectors.pagerduty_connector import PagerDutyConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.RequestException("error")
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, json=None):
+        assert "events.pagerduty.com" in url
+        return DummyResponse("sent")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = PagerDutyConnector("KEY")
+    assert connector.send_message({"summary": "hi"}) == "sent"
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, json=None):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = PagerDutyConnector("KEY")
+    assert connector.send_message({"summary": "hi"}) is None

--- a/tests/connectors/test_redis_pubsub.py
+++ b/tests/connectors/test_redis_pubsub.py
@@ -1,0 +1,23 @@
+import app.connectors.redis_pubsub_connector as mod
+import types
+import pytest
+
+class DummyRedis:
+    def __init__(self):
+        self.published = []
+    def publish(self, channel, message):
+        self.published.append((channel, message))
+
+
+def test_send_message_success(monkeypatch):
+    monkeypatch.setattr(mod, "redis", types.SimpleNamespace(Redis=lambda host=None, port=None: DummyRedis()))
+    connector = mod.RedisPubSubConnector(host="h", port=1, channel="c")
+    connector.send_message("hi")
+    assert connector._client.published == [("c", "hi")]
+
+
+def test_send_message_no_library(monkeypatch):
+    monkeypatch.setattr(mod, "redis", None)
+    connector = mod.RedisPubSubConnector()
+    with pytest.raises(RuntimeError):
+        connector.send_message("hi")

--- a/tests/connectors/test_rfc5425.py
+++ b/tests/connectors/test_rfc5425.py
@@ -1,0 +1,24 @@
+import socket
+import ssl
+import app.connectors.rfc5425_connector as mod
+
+class DummySocket:
+    def __init__(self):
+        self.sent = []
+    def sendall(self, data):
+        self.sent.append(data)
+    def close(self):
+        pass
+
+class DummyContext:
+    def wrap_socket(self, sock, server_hostname=None):
+        return sock
+
+
+def test_send_message(monkeypatch):
+    dummy = DummySocket()
+    monkeypatch.setattr(socket, "create_connection", lambda addr: dummy)
+    monkeypatch.setattr(ssl, "create_default_context", lambda: DummyContext())
+    connector = mod.RFC5425Connector("host")
+    connector.send_message("hi")
+    assert dummy.sent[0].endswith(b"hi")

--- a/tests/connectors/test_salesforce.py
+++ b/tests/connectors/test_salesforce.py
@@ -1,0 +1,25 @@
+import requests
+from app.connectors.salesforce_connector import SalesforceConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.RequestException("error")
+
+def test_send_message_success(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        assert "instance" not in url or True
+        return DummyResponse("sent")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = SalesforceConnector("http://host", "TOKEN", "endpoint")
+    assert connector.send_message({"a":1}) == "sent"
+
+def test_send_message_error(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "post", fake_post)
+    connector = SalesforceConnector("http://host", "TOKEN", "endpoint")
+    assert connector.send_message({"a":1}) is None

--- a/tests/connectors/test_snmp.py
+++ b/tests/connectors/test_snmp.py
@@ -1,0 +1,19 @@
+import socket
+from app.connectors.snmp_connector import SNMPConnector
+
+class DummySocket:
+    def __init__(self):
+        self.sent = []
+    def sendto(self, data, addr):
+        self.sent.append((data, addr))
+    def close(self):
+        pass
+
+
+def test_send_message(monkeypatch):
+    dummy = DummySocket()
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: dummy)
+    connector = SNMPConnector("host", port=162)
+    connector.connect()
+    connector.send_message("hi")
+    assert dummy.sent == [(b"hi", ("host", 162))]

--- a/tests/connectors/test_zapier.py
+++ b/tests/connectors/test_zapier.py
@@ -1,0 +1,41 @@
+import asyncio
+import httpx
+from app.connectors.zapier_connector import ZapierConnector
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+class DummyClient:
+    def __init__(self, resp):
+        self.resp = resp
+        self.sent = None
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def post(self, url, json=None):
+        self.sent = (url, json)
+        return self.resp
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(resp))
+    connector = ZapierConnector("http://hook")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message({"a":1}))
+    assert result == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None):
+            raise httpx.HTTPError("boom")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = ZapierConnector("http://hook")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message({"a":1}))
+    assert result is None


### PR DESCRIPTION
## Summary
- extend test coverage for connectors
- add base connector dispatcher test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bdc72dd4c83339512f64f2e3e34be