### PR TITLE
Add usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ For more information, refer to the [documentation](docs/) and the [contributing 
 
 ## Usage
 
-For detailed information on how to use Norman, please refer to the [Usage](./docs/usage.md) section in the documentation.
+For detailed information on how to use Norman, see the [Usage](./docs/usage.md) guide.
+Practical walkthroughs and API calls can be found in the [Examples](./docs/examples.md) document.
 
 ## Deployment
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,54 @@
+# Examples
+
+This page walks through a small end‑to‑end example and shows how to interact with the REST API.
+
+## Slack Bot Quick Start
+
+1. Copy `config.yaml.dist` to `config.yaml` and edit the Slack section:
+
+```yaml
+slack_token: "xoxb-your-slack-token"
+slack_channel_id: "C01234567"
+```
+
+2. Set your `openai_api_key` in `config.yaml` and generate the application secret:
+
+```bash
+chmod +x generate_key.sh
+./generate_key.sh
+```
+
+3. Start Norman:
+
+```bash
+python main.py
+```
+
+4. Visit `http://localhost:8000` and log in with the admin credentials from `config.yaml`.
+5. Create a chatbot in the Web UI and select the Slack connector. Messages sent to the configured channel will be processed by the bot.
+
+## API Examples
+
+Norman exposes a REST API under `/api/v1`. Below are some quick examples using `curl`.
+
+Create a bot:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/bots/ \
+  -H "Content-Type: application/json" \
+  -d '{"name": "demo", "description": "example bot", "gpt_model": "gpt-4"}'
+```
+
+List existing bots:
+
+```bash
+curl http://localhost:8000/api/v1/bots/
+```
+
+Delete a bot:
+
+```bash
+curl -X DELETE http://localhost:8000/api/v1/bots/1
+```
+
+Authentication headers may be required depending on your configuration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Welcome to the Norman documentation! Here you'll find everything you need to kno
 ## Table of Contents
 
 - [Usage](usage.md) - Learn how to set up and use Norman.
+- [Examples](examples.md) - Step-by-step usage examples and API calls.
 - [Deployment](deployment.md) - Instructions on how to deploy Norman on various platforms.
 - [Extending Norman](extending.md) - A guide on how to extend Norman with new connectors, actions, and filters.
 - [Architecture](architecture.md) - An explanation of Norman's architecture and design principles.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,6 +8,8 @@ This document provides an overview of how to interact with Norman, including cre
 - [Configuring a Chatbot](#configuring-a-chatbot)
 - [Channel Filters and Actions](#channel-filters-and-actions)
 - [Examples](#examples)
+- [Slack Quick Start](#slack-bot-quick-start)
+- [API Examples](#api-examples)
 
 ## Creating a Chatbot
 
@@ -53,3 +55,50 @@ Here are some example use-cases for Norman:
 3. **Automated Code Review:** Create a channel filter that detects when users submit pull requests. Norman can then analyze the code, provide suggestions or corrections, and post a review comment on the pull request.
 
 Remember to expand on these sections and provide more detailed information based on your project's specific features and requirements.
+
+## Slack Bot Quick Start
+
+This example demonstrates how to connect Norman to Slack and create a simple bot.
+
+1. Copy `config.yaml.dist` to `config.yaml` and edit the Slack section:
+
+```yaml
+slack_token: "xoxb-your-slack-token"
+slack_channel_id: "C01234567"
+```
+
+2. Set your `openai_api_key` in the same file and run the key generator:
+
+```bash
+chmod +x generate_key.sh
+./generate_key.sh
+```
+
+3. Start Norman with `python main.py` and open `http://localhost:8000` in your browser.
+4. Log in with the admin credentials from `config.yaml`, create a chatbot and select the Slack connector. Messages posted in the configured channel will be processed by the bot.
+
+## API Examples
+
+You can also interact with Norman programmatically. The API is available under `/api/v1`. The following `curl` commands illustrate common operations:
+
+Create a bot:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/bots/ \
+  -H "Content-Type: application/json" \
+  -d '{"name": "demo", "description": "example bot", "gpt_model": "gpt-4"}'
+```
+
+List existing bots:
+
+```bash
+curl http://localhost:8000/api/v1/bots/
+```
+
+Delete a bot:
+
+```bash
+curl -X DELETE http://localhost:8000/api/v1/bots/1
+```
+
+Authentication headers may be required depending on your configuration.


### PR DESCRIPTION
## Summary
- extend documentation with new examples
- document Slack quick start and curl-based API usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c3ceaca8c8333853c4abb9808b9b2