### PR TITLE
Remove debug argument from uvicorn run

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,7 +48,13 @@ app.include_router(app_routes)
 
 def main() -> None:
     """Run the FastAPI application using Uvicorn."""
-    uvicorn.run(app, host=settings.host, port=settings.port, debug=settings.debug)
+    uvicorn.run(
+        app,
+        host=settings.host,
+        port=settings.port,
+        reload=settings.debug,
+        log_level="debug" if settings.debug else "info",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove deprecated `debug` argument when starting Uvicorn
- enable reload mode and adjust log level when debug mode is active

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c3fc0f2cc833385747c2faba0b7f3