### PR TITLE
Implement basic listeners for connectors

### DIFF
--- a/app/connectors/rest_callback_connector.py
+++ b/app/connectors/rest_callback_connector.py
@@ -25,9 +25,11 @@ class RESTCallbackConnector(BaseConnector):
                 print(f"Error sending message to {self.callback_url}: {exc}")
                 return None
 
-    async def listen_and_process(self):
+    async def listen_and_process(self) -> None:
         """This connector does not support incoming messages."""
-        pass
+        raise NotImplementedError(
+            "RESTCallbackConnector cannot listen for incoming messages"
+        )
 
     async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
         """Forward an incoming message to the callback URL."""


### PR DESCRIPTION
## Summary
- add streaming support to `MastodonConnector`
- implement Pub/Sub listener in `RedisPubSubConnector`
- make `RESTCallbackConnector.listen_and_process` raise `NotImplementedError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c453623648333abfd7e5108a5cfdb