### PR TITLE
Add missing cloud connector docs

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -63,6 +63,11 @@ The following connectors are soon to be supported:
 54. [SNMP](./connectors/snmp.md)
 55. [Tox](./connectors/tox.md)
 56. [Zulip](./connectors/zulip.md)
+57. [AWS IoT Core](./connectors/aws_iot_core.md)
+58. [AWS EventBridge](./connectors/aws_eventbridge.md)
+59. [Google Pub/Sub](./connectors/google_pubsub.md)
+60. [Azure Event Grid](./connectors/azure_eventgrid.md)
+61. [SMS](./connectors/sms.md)
 
 
 ## Usage
@@ -124,5 +129,10 @@ For more detailed information on each connector, please refer to the platform-sp
 - [SNMP Connector](./connectors/snmp.md)
 - [Tox Connector](./connectors/tox.md)
 - [Zulip Connector](./connectors/zulip.md)
+- [AWS IoT Core Connector](./connectors/aws_iot_core.md)
+- [AWS EventBridge Connector](./connectors/aws_eventbridge.md)
+- [Google Pub/Sub Connector](./connectors/google_pubsub.md)
+- [Azure Event Grid Connector](./connectors/azure_eventgrid.md)
+- [SMS Connector](./connectors/sms.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/aws_eventbridge.md
+++ b/docs/connectors/aws_eventbridge.md
@@ -1,0 +1,21 @@
+# AWS EventBridge Connector
+
+The AWS EventBridge connector sends events to Amazon EventBridge using `boto3`.
+
+## Requirements
+
+- An AWS account with an EventBridge event bus
+- The `boto3` Python package installed
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+aws_eventbridge_region: "us-east-1"
+aws_eventbridge_event_bus_name: "default"
+```
+
+## Usage
+
+Incoming messages are not supported. The connector only publishes events.

--- a/docs/connectors/aws_iot_core.md
+++ b/docs/connectors/aws_iot_core.md
@@ -1,0 +1,22 @@
+# AWS IoT Core Connector
+
+The AWS IoT Core connector publishes MQTT messages using the `boto3` IoT Data client.
+
+## Requirements
+
+- An AWS account with IoT Core enabled
+- The `boto3` Python package installed
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+aws_iot_core_region: "us-east-1"
+aws_iot_core_topic: "norman"
+aws_iot_core_endpoint: "https://your-endpoint.amazonaws.com"  # optional
+```
+
+## Usage
+
+This connector currently only supports publishing messages. Listening for inbound MQTT traffic is not implemented.

--- a/docs/connectors/azure_eventgrid.md
+++ b/docs/connectors/azure_eventgrid.md
@@ -1,0 +1,21 @@
+# Azure Event Grid Connector
+
+The Azure Event Grid connector posts events to an Event Grid topic.
+
+## Requirements
+
+- An Azure subscription with Event Grid enabled
+- The `azure-eventgrid` Python package installed
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+azure_eventgrid_endpoint: "https://<topic>.<region>.eventgrid.azure.net/api/events"
+azure_eventgrid_key: "your-access-key"
+```
+
+## Usage
+
+This connector only sends events and does not listen for incoming messages.

--- a/docs/connectors/google_pubsub.md
+++ b/docs/connectors/google_pubsub.md
@@ -1,0 +1,22 @@
+# Google Pub/Sub Connector
+
+The Google Pub/Sub connector publishes messages to a Pub/Sub topic.
+
+## Requirements
+
+- A Google Cloud project with Pub/Sub enabled
+- The `google-cloud-pubsub` Python package installed
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+google_pubsub_project_id: "your-project"
+google_pubsub_topic_id: "norman"
+google_pubsub_credentials_path: "/path/to/credentials.json"  # optional
+```
+
+## Usage
+
+Currently this connector only publishes messages to the specified topic.

--- a/docs/connectors/sms.md
+++ b/docs/connectors/sms.md
@@ -1,0 +1,23 @@
+# SMS Connector
+
+The SMS connector uses Twilio to send text messages.
+
+## Requirements
+
+- A Twilio account with an SMS-capable number
+- The `requests` Python package installed
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+sms_account_sid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+sms_auth_token: "your_token"
+sms_from_number: "+15555555555"
+sms_to_number: "+15555555556"
+```
+
+## Usage
+
+Incoming SMS messages are delivered via webhooks and are not handled directly by this connector.


### PR DESCRIPTION
## Summary
- document the remaining connector types
- list them in the main connectors catalog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c67fbae208333b5490d8985dc1974