### PR TITLE
Add is_connected checks for additional connectors

### DIFF
--- a/app/connectors/mastodon_connector.py
+++ b/app/connectors/mastodon_connector.py
@@ -52,3 +52,14 @@ class MastodonConnector(BaseConnector):
 
     async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
         return message
+
+    def is_connected(self) -> bool:
+        """Return ``True`` if the access token is valid."""
+
+        url = f"{self.base_url}/api/v1/accounts/verify_credentials"
+        try:
+            resp = requests.get(url, headers=self._headers())
+            resp.raise_for_status()
+            return True
+        except requests.RequestException:
+            return False

--- a/app/connectors/matrix_connector.py
+++ b/app/connectors/matrix_connector.py
@@ -38,3 +38,15 @@ class MatrixConnector(BaseConnector):
     async def process_incoming(self, message):
         """Return the incoming ``message`` payload."""
         return message
+
+    def is_connected(self) -> bool:
+        """Return ``True`` if the access token is valid."""
+
+        url = f"{self.homeserver}/_matrix/client/v3/account/whoami"
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        try:
+            resp = httpx.get(url, headers=headers)
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            return False

--- a/app/connectors/mattermost_connector.py
+++ b/app/connectors/mattermost_connector.py
@@ -1,3 +1,6 @@
+import httpx
+from typing import Any, Dict, Optional
+
 from .base_connector import BaseConnector
 
 
@@ -7,22 +10,45 @@ class MattermostConnector(BaseConnector):
     id = "mattermost"
     name = "Mattermost"
 
-    def __init__(self, url: str, token: str, channel_id: str, config=None):
+    def __init__(self, url: str, token: str, channel_id: str, config: Optional[dict] = None):
         super().__init__(config)
         self.url = url.rstrip("/")
         self.token = token
         self.channel_id = channel_id
         self.sent_messages = []
 
-    async def send_message(self, message) -> str:
-        """Record ``message`` locally and return a confirmation string."""
-        self.sent_messages.append(message)
-        return "sent"
+    async def send_message(self, message: str) -> Optional[str]:
+        """Send ``message`` to the configured channel."""
+
+        api_url = f"{self.url}/api/v4/posts"
+        headers = {"Authorization": f"Bearer {self.token}"}
+        payload = {"channel_id": self.channel_id, "message": message}
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(api_url, json=payload, headers=headers)
+                resp.raise_for_status()
+                self.sent_messages.append(message)
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                print(f"Error sending Mattermost message: {exc}")
+                return None
 
     async def listen_and_process(self):
         """Listening for Mattermost messages is not implemented."""
         return None
 
-    async def process_incoming(self, message):
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
         """Return the incoming ``message`` payload."""
         return message
+
+    def is_connected(self) -> bool:
+        """Return ``True`` if the token appears valid."""
+
+        api_url = f"{self.url}/api/v4/users/me"
+        headers = {"Authorization": f"Bearer {self.token}"}
+        try:
+            resp = httpx.get(api_url, headers=headers)
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            return False

--- a/app/connectors/rocketchat_connector.py
+++ b/app/connectors/rocketchat_connector.py
@@ -38,3 +38,15 @@ class RocketChatConnector(BaseConnector):
     async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
         """Return the raw ``message`` payload."""
         return message
+
+    def is_connected(self) -> bool:
+        """Return ``True`` if the API token appears valid."""
+
+        api_url = f"{self.url}/api/v1/me"
+        headers = {"X-Auth-Token": self.token, "X-User-Id": self.user_id}
+        try:
+            resp = httpx.get(api_url, headers=headers)
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            return False

--- a/tests/connectors/test_mastodon.py
+++ b/tests/connectors/test_mastodon.py
@@ -23,3 +23,21 @@ def test_send_message_error(monkeypatch):
     monkeypatch.setattr(requests, "post", fake_post)
     connector = MastodonConnector("http://host", "TOKEN")
     assert connector.send_message("hi") is None
+
+
+def test_is_connected_success(monkeypatch):
+    def fake_get(url, headers=None):
+        return DummyResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    connector = MastodonConnector("http://host", "TOKEN")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    def fake_get(url, headers=None):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    connector = MastodonConnector("http://host", "TOKEN")
+    assert not connector.is_connected()

--- a/tests/connectors/test_matrix.py
+++ b/tests/connectors/test_matrix.py
@@ -62,3 +62,27 @@ def test_process_incoming():
         connector.process_incoming(payload)
     )
     assert result == payload
+
+
+class DummyGetResponse:
+    def __init__(self, status=200):
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+def test_is_connected_success(monkeypatch):
+    monkeypatch.setattr(httpx, "get", lambda url, headers=None: DummyGetResponse())
+    connector = MatrixConnector("https://hs", "@u:hs", "TOK", "!room")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    def raise_err(url, headers=None):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "get", raise_err)
+    connector = MatrixConnector("https://hs", "@u:hs", "TOK", "!room")
+    assert not connector.is_connected()

--- a/tests/connectors/test_mattermost.py
+++ b/tests/connectors/test_mattermost.py
@@ -1,12 +1,56 @@
 import asyncio
+import httpx
 from app.connectors.mattermost_connector import MattermostConnector
 
 
-def test_send_message():
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, headers=None):
+        self.sent = (url, json, headers)
+        return self.response
+
+
+def test_send_message(monkeypatch):
+    resp = DummyResponse("sent")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(resp))
     connector = MattermostConnector("http://mm", "tok", "chan")
-    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
     assert result == "sent"
     assert connector.sent_messages == ["hi"]
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None, headers=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = MattermostConnector("http://mm", "tok", "chan")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result is None
 
 
 def test_process_incoming():
@@ -15,3 +59,27 @@ def test_process_incoming():
         connector.process_incoming({"foo": "bar"})
     )
     assert result == {"foo": "bar"}
+
+
+class DummyGetResponse:
+    def __init__(self, status=200):
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+def test_is_connected_success(monkeypatch):
+    monkeypatch.setattr(httpx, "get", lambda url, headers=None: DummyGetResponse())
+    connector = MattermostConnector("http://mm", "tok", "chan")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    def raise_err(url, headers=None):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "get", raise_err)
+    connector = MattermostConnector("http://mm", "tok", "chan")
+    assert not connector.is_connected()


### PR DESCRIPTION
## Summary
- add `is_connected` to Mastodon, Rocket.Chat, Matrix, and Mattermost connectors
- implement real Mattermost send behaviour
- extend tests for the new methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c6f78e7e88333a4f5b3bc7b388ff2