### PR TITLE
Implement openai customization and channel dropdown

### DIFF
--- a/app/crud/channel_filter.py
+++ b/app/crud/channel_filter.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from typing import List
 from sqlalchemy.orm import Session
 
 from app import models
@@ -30,4 +31,13 @@ def update(db: Session, filter_id: int, obj_in: FilterUpdate) -> Optional[models
     db.commit()
     db.refresh(filter_)
     return filter_
+
+
+def get_filters_for_channel(db: Session, channel_id: int) -> List[models.Filter]:
+    """Return all filters associated with ``channel_id``."""
+    return (
+        db.query(models.Filter)
+        .filter(models.Filter.channel_id == channel_id)
+        .all()
+    )
 

--- a/app/handlers/openai_handler.py
+++ b/app/handlers/openai_handler.py
@@ -7,32 +7,51 @@ logger = setup_logger(__name__)
 
 openai.api_key = settings.openai_api_key
 
-'''
-# TODO: all users to specify token length, number of tokens, etc. 
-async def get_bot_response(prompt: str, model: str = 'gpt-3.5-turbo') -> Tuple[str, int]:
+
+async def get_bot_response(
+    prompt: str,
+    *,
+    model: str = "gpt-3.5-turbo",
+    max_tokens: int = 150,
+    n: int = 1,
+    stop: List[str] | None = None,
+    temperature: float = 0.7,
+) -> Tuple[str | None, int]:
+    """Return a completion for ``prompt`` using OpenAI's completion API.
+
+    This helper exposes common parameters so callers can control the length of
+    the generated text and other generation options.
+    """
+
     try:
         completions = openai.Completion.create(
             engine=model,
             prompt=prompt,
-            max_tokens=150,
-            n=1,
-            stop=None,
-            temperature=0.7,
+            max_tokens=max_tokens,
+            n=n,
+            stop=stop,
+            temperature=temperature,
         )
 
         choice = completions.choices[0]
         response_text = choice.text.strip()
-        tokens_used = choice.usage['total_tokens']
-
+        tokens_used = completions.usage.get("total_tokens", 0)
         return response_text, tokens_used
 
-    except Exception as e:
-        print(f"Error in OpenAI handler: {e}")
+    except Exception as e:  # pragma: no cover - network issues
+        logger.error("Error in OpenAI handler: %s", e)
         return None, 0
-'''
 
 
-async def create_chat_interaction(messages: List[Dict[str, str]], max_tokens: int=150, model: str = 'gpt-3.5-turbo') -> Dict[str, str]:
+async def create_chat_interaction(
+    messages: List[Dict[str, str]],
+    *,
+    max_tokens: int = 150,
+    model: str = "gpt-3.5-turbo",
+    n: int = 1,
+    stop: List[str] | None = None,
+    temperature: float = 0.7,
+) -> Dict[str, str]:
     """
     Function to create a new chat interaction with OpenAI API.
 
@@ -53,7 +72,10 @@ async def create_chat_interaction(messages: List[Dict[str, str]], max_tokens: in
         response = openai.ChatCompletion.create(
             model=model,
             messages=messages,
-            max_tokens=max_tokens
+            max_tokens=max_tokens,
+            n=n,
+            stop=stop,
+            temperature=temperature,
         )
 
         return response

--- a/app/static/js/messages_log.js
+++ b/app/static/js/messages_log.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   // Fetch messages and render them in the messages container
   fetchMessagesAndRender();
+  populateChannels();
 });
 
 function fetchMessagesAndRender() {
@@ -10,12 +11,32 @@ function fetchMessagesAndRender() {
     { id: 2, content: 'Message 2', timestamp: '2023-01-01 10:05:00' },
   ];
 
-  const messagesContainer = document.querySelector('.messages-container');
+  const messagesContainer = document.getElementById('messages-log');
   messagesContainer.innerHTML = '';
 
   for (const message of fakeMessages) {
     const messageElement = createMessageElement(message);
     messagesContainer.appendChild(messageElement);
+  }
+}
+
+async function populateChannels() {
+  try {
+    const resp = await fetch('/api/v1/channels/');
+    if (!resp.ok) {
+      throw new Error('Failed to fetch channels');
+    }
+    const channels = await resp.json();
+    const select = document.getElementById('channelSelect');
+    select.innerHTML = '';
+    for (const channel of channels) {
+      const option = document.createElement('option');
+      option.value = channel.id;
+      option.textContent = channel.name;
+      select.appendChild(option);
+    }
+  } catch (err) {
+    console.error('Error loading channels', err);
   }
 }
 

--- a/app/templates/messages_log.html
+++ b/app/templates/messages_log.html
@@ -12,8 +12,6 @@
     <div class="search-container">
       <input type="text" placeholder="Search messages..." class="search-input">
     </div>
-     TODO: add a list of channels to send to as a dropdown, autocomplete
-
     <div class="card mt-4">
         <div class="card-body messages-log" id="messages-log">
             <!-- Messages will be displayed here -->

--- a/tests/test_openai_handler.py
+++ b/tests/test_openai_handler.py
@@ -1,0 +1,49 @@
+import asyncio
+import openai
+from app.handlers.openai_handler import create_chat_interaction
+
+
+def test_create_chat_interaction_custom_params(monkeypatch):
+    captured = {}
+
+    def dummy_create(**kwargs):
+        captured.update(kwargs)
+        return {
+            "model": kwargs.get("model"),
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", dummy_create)
+
+    messages = [{"role": "user", "content": "hi"}]
+    result = asyncio.get_event_loop().run_until_complete(
+        create_chat_interaction(
+            messages,
+            max_tokens=42,
+            model="test-model",
+            n=2,
+            stop=["END"],
+            temperature=0.5,
+        )
+    )
+
+    assert captured["max_tokens"] == 42
+    assert captured["n"] == 2
+    assert captured["stop"] == ["END"]
+    assert captured["temperature"] == 0.5
+    assert result["choices"][0]["message"]["content"] == "hi"
+
+
+def test_create_chat_interaction_missing_key(monkeypatch):
+    def dummy_create(**kwargs):
+        raise Exception("No API key provided")
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", dummy_create)
+    openai.api_key = None
+    messages = [{"role": "user", "content": "hello"}]
+    result = asyncio.get_event_loop().run_until_complete(
+        create_chat_interaction(messages)
+    )
+    assert result["error"] is True
+


### PR DESCRIPTION
## Summary
- extend OpenAI helper with configurable parameters
- allow chat interactions to accept temperature, stop and n
- add CRUD helper to fetch filters by channel
- populate channel dropdown on messages log page
- test OpenAI handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c759be47c8333b00cc4c9ffcc82ba