### PR TITLE
Add configured connector helper

### DIFF
--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -351,3 +351,24 @@ def test_get_connector_returns_zulip(monkeypatch):
     connector = get_connector('zulip')
     from app.connectors.zulip_connector import ZulipConnector
     assert isinstance(connector, ZulipConnector)
+
+
+def test_get_configured_connectors_none(monkeypatch):
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
+    from app.connectors.connector_utils import get_configured_connectors
+    assert get_configured_connectors() == {}
+
+
+def test_get_configured_connectors_with_slack(monkeypatch):
+    from app.core.config import load_config, Settings
+    from app.connectors.connector_utils import get_configured_connectors
+
+    config = load_config()
+    config['slack_token'] = 'x'
+    config['slack_channel_id'] = 'C1'
+    settings = Settings(**config)
+
+    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: settings)
+    connectors = get_configured_connectors()
+    assert 'slack' in connectors
+    assert isinstance(connectors['slack'], SlackConnector)


### PR DESCRIPTION
## Summary
- add `_is_configured` and `get_configured_connectors` utilities
- test configured connector helper logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c8996c8708333831cdafdccc37d23