### PR TITLE
Improve connector initialization logic

### DIFF
--- a/app/connectors/__init__.py
+++ b/app/connectors/__init__.py
@@ -1,9 +1,10 @@
 # app/connectors/__init__.py
 
 from fastapi import FastAPI
-from app.core.config import Settings
+from app.core.config import Settings, get_settings
 
-from .connector_utils import connector_classes, get_connector
+from .connector_utils import connector_classes, get_connector, _is_configured
+import logging
 
 def init_connectors(app: FastAPI, _settings: Settings) -> None:
     """Instantiate all connectors defined in :mod:`connector_utils`.
@@ -14,7 +15,17 @@ def init_connectors(app: FastAPI, _settings: Settings) -> None:
     relies on :func:`~app.core.config.get_settings` internally.
     """
 
+    settings = get_settings()
+    logger = logging.getLogger(__name__)
+
     for name in connector_classes:
-        connector = get_connector(name)
+        if not _is_configured(name, settings):
+            setattr(app.state, f"{name}_connector", None)
+            continue
+        try:
+            connector = get_connector(name)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Failed to initialize connector %s", name)
+            connector = None
         setattr(app.state, f"{name}_connector", connector)
 


### PR DESCRIPTION
## Summary
- only initialize connectors with valid configuration
- log and set `None` on failures
- add tests for new behavior

## Testing
- `pytest -q`
- `pytest tests/test_init_connectors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_683c9a96c9688333b60d67c1ffcc218e