### PR TITLE
Improve minimal connectors

### DIFF
--- a/docs/connectors/kafka.md
+++ b/docs/connectors/kafka.md
@@ -1,6 +1,6 @@
 # Kafka Connector
 
-The Kafka connector publishes messages to a Kafka or Redpanda cluster using the `confluent-kafka` library.
+The Kafka connector publishes and consumes messages using the `confluent-kafka` library.
 
 ## Requirements
 
@@ -18,4 +18,4 @@ kafka_topic: "norman"
 
 ## Usage
 
-This connector currently only supports publishing messages to the configured topic.
+The connector publishes messages to the configured topic and also listens on the same topic to process incoming messages.

--- a/docs/connectors/nats.md
+++ b/docs/connectors/nats.md
@@ -1,6 +1,6 @@
 # NATS Connector
 
-The NATS connector sends messages over NATS or JetStream using the `nats-py` library.
+The NATS connector sends and receives messages over NATS or JetStream using the `nats-py` library.
 
 ## Requirements
 
@@ -18,4 +18,4 @@ nats_subject: "norman"
 
 ## Usage
 
-The connector currently publishes messages to the specified subject. Listening for messages is not implemented.
+The connector publishes messages to the configured subject and can also subscribe to that subject to process incoming messages.

--- a/docs/connectors/snmp.md
+++ b/docs/connectors/snmp.md
@@ -1,6 +1,6 @@
 # SNMP Connector
 
-The SNMP connector emits simple SNMP traps to a management system.
+The SNMP connector emits and receives SNMP traps to integrate with management systems.
 
 ## Requirements
 - An SNMP manager reachable from Norman
@@ -15,4 +15,4 @@ snmp_community: "public"
 ```
 
 ## Usage
-This implementation sends a basic trap with the message text as payload. Listening for traps is not implemented.
+This implementation sends a basic trap with the message text as payload and can listen for inbound traps to process them.

--- a/tests/connectors/test_kafka.py
+++ b/tests/connectors/test_kafka.py
@@ -1,4 +1,5 @@
 import types
+import asyncio
 import pytest
 import app.connectors.kafka_connector as mod
 
@@ -9,6 +10,30 @@ class DummyProducer:
         self.messages.append((topic, value))
     def flush(self):
         pass
+
+
+class DummyMessage:
+    def __init__(self, value):
+        self._value = value.encode()
+    def error(self):
+        return False
+    def value(self):
+        return self._value
+
+
+class DummyConsumer:
+    def __init__(self, messages):
+        self.messages = messages
+        self.subscribed = []
+        self.closed = False
+    def subscribe(self, topics):
+        self.subscribed = topics
+    def poll(self, timeout=0.1):
+        if self.messages:
+            return self.messages.pop(0)
+        return None
+    def close(self):
+        self.closed = True
 
 
 def test_send_message_success(monkeypatch):
@@ -22,3 +47,25 @@ def test_send_message_no_library(monkeypatch):
     connector = mod.KafkaConnector()
     with pytest.raises(RuntimeError):
         connector.send_message("hi")
+
+
+def test_listen_and_process(monkeypatch):
+    msgs = [DummyMessage("hello")]
+    monkeypatch.setattr(mod, "Consumer", lambda conf: DummyConsumer(msgs))
+
+    processed = []
+    class TestConnector(mod.KafkaConnector):
+        async def process_incoming(self, message):
+            processed.append(message)
+
+    connector = TestConnector(bootstrap_servers="s", topic="t")
+
+    async def fake_sleep(t):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.get_event_loop().run_until_complete(connector.listen_and_process())
+
+    assert processed == ["hello"]

--- a/tests/connectors/test_nats.py
+++ b/tests/connectors/test_nats.py
@@ -14,6 +14,11 @@ class DummyNATS:
         self.closed = True
     async def close(self):
         self.closed = True
+    async def subscribe(self, subject, cb):
+        self.cb = cb
+        return 1
+    async def unsubscribe(self, sid):
+        pass
 
 async def fake_connect(servers=""):
     return DummyNATS()
@@ -35,4 +40,29 @@ def test_no_library(monkeypatch):
     connector = nats_connector.NATSConnector()
     with pytest.raises(RuntimeError):
         asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+
+
+def test_listen_and_process(monkeypatch):
+    dummy = DummyNATS()
+    async def connect_stub(servers=""):
+        return dummy
+    monkeypatch.setattr(nats_connector, "nats", types.SimpleNamespace(connect=connect_stub))
+
+    processed = []
+    class TestConnector(nats_connector.NATSConnector):
+        async def process_incoming(self, message):
+            processed.append(message)
+
+    connector = TestConnector(servers="nats://s", subject="sub")
+
+    async def fake_sleep(t):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.get_event_loop().run_until_complete(connector.listen_and_process())
+
+    asyncio.get_event_loop().run_until_complete(dummy.cb(types.SimpleNamespace(data=b"hello")))
+    assert processed == ["hello"]
 

--- a/tests/connectors/test_snmp.py
+++ b/tests/connectors/test_snmp.py
@@ -1,13 +1,24 @@
 import socket
+import asyncio
+import pytest
 from app.connectors.snmp_connector import SNMPConnector
 
 class DummySocket:
     def __init__(self):
         self.sent = []
+        self.recv = [b"hello"]
     def sendto(self, data, addr):
         self.sent.append((data, addr))
     def close(self):
         pass
+    def bind(self, addr):
+        pass
+    def setblocking(self, flag):
+        pass
+    def recvfrom(self, n):
+        if self.recv:
+            return self.recv.pop(0), ("localhost", 0)
+        raise BlockingIOError
 
 
 def test_send_message(monkeypatch):
@@ -17,3 +28,26 @@ def test_send_message(monkeypatch):
     connector.connect()
     connector.send_message("hi")
     assert dummy.sent == [(b"hi", ("host", 162))]
+
+
+def test_listen_and_process(monkeypatch):
+    dummy = DummySocket()
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: dummy)
+
+    processed = []
+    class TestConnector(SNMPConnector):
+        async def process_incoming(self, message):
+            processed.append(message)
+
+    connector = TestConnector("host", port=162)
+
+    async def fake_sleep(t):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.get_event_loop().run_until_complete(connector.listen_and_process())
+
+    assert processed == ["hello"]
+


### PR DESCRIPTION
## Summary
- enhance NATS connector with a subscription loop
- expand Kafka connector to consume messages
- extend SNMP connector with trap listener
- document new capabilities for NATS/Kafka/SNMP connectors
- test the new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9d20ae388333a824e0a097a3b5a6