### PR TITLE
Improve first run setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,29 +68,24 @@ source env/bin/activate
 pip install -r requirements.txt
 ```
 
-4. Create a `config.yaml` based on the provided `config.yaml.dist`:
-```
-cp config.yaml.dist config.yaml
-```
+4. Run Norman once to automatically generate `config.yaml` with secure defaults.
+   Afterwards edit this file to configure connectors and add your OpenAI API key.
 
-5. Edit `config.yaml` to configure the application, connectors, and API keys.
-
-6. Run the `generate_key.sh` script to set a secret key, along with the
-   `encryption_key` and `encryption_salt` values for your application:
+5. (Optional) Regenerate the secrets in `config.yaml` using the provided script:
 
 ```
 chmod +x generate_key.sh
 ./generate_key.sh
 ```
 
-You can also just edit config.yaml instead and make up your own key. You'll also have to set your OpenAI key in the config.yaml file under the key "openai_api_key" 
+You can also edit `config.yaml` manually to provide your own values. Be sure to add your OpenAI key under `openai_api_key`.
 
-8. Run the application:
+6. Run the application:
 ```
 python main.py
 ````
 
-9. Open the API documentation in your browser: [http://localhost:8000/docs](http://localhost:8000/docs)
+7. Open the API documentation in your browser: [http://localhost:8000/docs](http://localhost:8000/docs)
 
 For more information, refer to the [documentation](docs/) and the [contributing guidelines](CONTRIBUTING.md).
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -240,9 +240,33 @@ class Settings(BaseSettings):
         env_file_encoding = "utf-8"
 
 import os
+import shutil
+import secrets
 import yaml
 
+
+def ensure_user_config():
+    """Create config.yaml with random credentials on first run."""
+    if not os.path.exists("config.yaml"):
+        shutil.copyfile("config.yaml.dist", "config.yaml")
+        with open("config.yaml", "r") as f:
+            cfg = yaml.safe_load(f)
+        cfg["secret_key"] = secrets.token_urlsafe(32)
+        cfg["initial_admin_password"] = secrets.token_urlsafe(12)
+        cfg["initial_admin_email"] = f"admin+{secrets.token_hex(4)}@example.com"
+        cfg["initial_admin_username"] = f"admin_{secrets.token_hex(4)}"
+        cfg["encryption_key"] = secrets.token_urlsafe(32)
+        cfg["encryption_salt"] = secrets.token_urlsafe(16)
+        with open("config.yaml", "w") as f:
+            yaml.safe_dump(cfg, f)
+        print("Generated config.yaml with admin credentials:")
+        print(f"  username: {cfg['initial_admin_username']}")
+        print(f"  email: {cfg['initial_admin_email']}")
+        print(f"  password: {cfg['initial_admin_password']}")
+        print("Edit config.yaml to customize settings, including your OpenAI API key.")
+
 def load_config():
+    ensure_user_config()
     # Read the config from the dist file
     with open("config.yaml.dist", "r") as dist_file:
         config = yaml.safe_load(dist_file)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,15 +53,8 @@ Before deploying Norman, ensure that your server meets the following requirement
 
 ## Configuration
 
-1. Copy the `config.yaml.dist` file to `config.yaml`:
-
-   ```
-   cp config.yaml.dist config.yaml
-   ```
-
-2. Open `config.yaml` in a text editor and configure the required settings, such as the database connection string and API keys.
-
-3. Save and close the `config.yaml` file.
+1. Run Norman once to automatically create `config.yaml` with secure defaults.
+   Edit this file to configure the required settings, such as the database connection string and API keys.
 
 ## Running the Application
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,14 +4,14 @@ This page walks through a small end‑to‑end example and shows how to interact
 
 ## Slack Bot Quick Start
 
-1. Copy `config.yaml.dist` to `config.yaml` and edit the Slack section:
+1. Run Norman once to generate `config.yaml` and edit the Slack section:
 
 ```yaml
 slack_token: "xoxb-your-slack-token"
 slack_channel_id: "C01234567"
 ```
 
-2. Set your `openai_api_key` in `config.yaml` and generate the application secret:
+2. Set your `openai_api_key` in `config.yaml` and optionally regenerate the secrets:
 
 ```bash
 chmod +x generate_key.sh

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,14 +60,14 @@ Remember to expand on these sections and provide more detailed information based
 
 This example demonstrates how to connect Norman to Slack and create a simple bot.
 
-1. Copy `config.yaml.dist` to `config.yaml` and edit the Slack section:
+1. Run Norman once to generate `config.yaml` and edit the Slack section:
 
 ```yaml
 slack_token: "xoxb-your-slack-token"
 slack_channel_id: "C01234567"
 ```
 
-2. Set your `openai_api_key` in the same file and run the key generator:
+2. Set your `openai_api_key` in the same file and optionally regenerate the secrets:
 
 ```bash
 chmod +x generate_key.sh


### PR DESCRIPTION
## Summary
- generate config.yaml with random secrets on first run
- document automatic config creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ca8b6d50c8333b2bfc3b7518ba9aa