### PR TITLE
Improve secret handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ cp config.yaml.dist config.yaml
 
 5. Edit `config.yaml` to configure the application, connectors, and API keys.
 
-6. Run the `generate_key.sh` script to set a secret key, along with the
+6. *(Recommended)* Create a `.env` file and place sensitive values there. Any
+   environment variables defined will override the settings from `config.yaml`,
+   keeping secrets out of source control.
+
+7. Run the `generate_key.sh` script to set a secret key, along with the
    `encryption_key` and `encryption_salt` values for your application:
 
 ```

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -250,8 +250,20 @@ def load_config():
     # If the config.yaml file exists, merge its contents with the dist config
     if os.path.exists("config.yaml"):
         with open("config.yaml", "r") as custom_file:
-            custom_config = yaml.safe_load(custom_file)
+            custom_config = yaml.safe_load(custom_file) or {}
             config.update(custom_config)
+
+    # Environment variables should override YAML configuration
+    for field in Settings.__fields__.values():
+        env_value = os.getenv(field.name.upper())
+        if env_value is not None:
+            # Cast the value to the appropriate type
+            if field.type_ is bool:
+                config[field.name] = env_value.lower() in {"1", "true", "yes"}
+            elif field.type_ is int:
+                config[field.name] = int(env_value)
+            else:
+                config[field.name] = env_value
 
     return config
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,15 +67,19 @@ slack_token: "xoxb-your-slack-token"
 slack_channel_id: "C01234567"
 ```
 
-2. Set your `openai_api_key` in the same file and run the key generator:
+2. Set your `openai_api_key` in the same file or provide it via an environment
+   variable. Values in the environment (or a `.env` file) take precedence over
+   `config.yaml`.
+
+3. Run the key generator:
 
 ```bash
 chmod +x generate_key.sh
 ./generate_key.sh
 ```
 
-3. Start Norman with `python main.py` and open `http://localhost:8000` in your browser.
-4. Log in with the admin credentials from `config.yaml`, create a chatbot and select the Slack connector. Messages posted in the configured channel will be processed by the bot.
+4. Start Norman with `python main.py` and open `http://localhost:8000` in your browser.
+5. Log in with the admin credentials from `config.yaml`, create a chatbot and select the Slack connector. Messages posted in the configured channel will be processed by the bot.
 
 ## API Examples
 


### PR DESCRIPTION
## Summary
- allow environment variables to override `config.yaml`
- document using a `.env` file for secrets
- clarify env variable precedence in usage guide

## Testing
- `coverage run -m pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_683ca99716b08333bc6a344cb0de1765