### PR TITLE
Fix schema and model mismatches

### DIFF
--- a/app/crud/bot.py
+++ b/app/crud/bot.py
@@ -5,7 +5,12 @@ def get_bot_by_id(db: Session, bot_id: int):
     return db.query(models.Bot).filter(models.Bot.id == bot_id).first()
 
 def create_bot(db: Session, bot_create: schemas.BotCreate):
-    bot = models.Bot(name=bot_create.name, description=bot_create.description)
+    bot = models.Bot(
+        name=bot_create.name,
+        description=bot_create.description,
+        gpt_model=bot_create.gpt_model,
+        session_id=bot_create.session_id,
+    )
     db.add(bot)
     db.commit()
     db.refresh(bot)
@@ -28,3 +33,4 @@ def update_bot(db: Session, bot_id: int, bot_data: schemas.BotUpdate):
             setattr(bot, key, value)
     db.commit()
     return bot
+

--- a/app/crud/channel.py
+++ b/app/crud/channel.py
@@ -20,7 +20,7 @@ def get_multi(db: Session, skip: int = 0, limit: int = 100) -> List[ChannelModel
 
 def create(db: Session, obj_in: ChannelCreate) -> ChannelModel:
     """Create a new channel."""
-    db_obj = ChannelModel(name=obj_in.name)
+    db_obj = ChannelModel(name=obj_in.name, connector_id=obj_in.connector_id)
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)
@@ -43,3 +43,4 @@ def remove(db: Session, channel_id: int) -> Optional[ChannelModel]:
         db.delete(obj)
         db.commit()
     return obj
+

--- a/app/models/bot.py
+++ b/app/models/bot.py
@@ -8,10 +8,12 @@ class Bot(Base):
     name = Column(String, nullable=False)
     description = Column(String, nullable=False)
     user_id = Column(Integer, ForeignKey("users.id"))
+    session_id = Column(String, nullable=True)
     gpt_model = Column(String, nullable=False, default="gpt-4")
     system_prompt = Column(String, nullable=False, default="You are a helpful assistant.")
     default_response_tokens = Column(Integer, nullable=False, default=150) # how much to generate
     default_prompt_tokens = Column(Integer, nullable=False, default=1000) # how many messages back
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, onupdate=func.now())
+
 

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.sql import func
 from app.db.base import Base
 
@@ -6,5 +6,7 @@ class Channel(Base):
     __tablename__ = "channels"
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True, nullable=False)
+    connector_id = Column(Integer, ForeignKey("connectors.id"), nullable=False)
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, onupdate=func.now())
+

--- a/app/schemas/bot.py
+++ b/app/schemas/bot.py
@@ -3,13 +3,14 @@ from pydantic import BaseModel
 
 class BotBase(BaseModel):
     name: str
-    session_id: str
+    session_id: Optional[str] = None
     gpt_model: str
 
 class BotCreate(BaseModel):
     name: str
     description: Optional[str] = None
     gpt_model: str
+    session_id: Optional[str] = None
 
 class BotOut(BaseModel):
     id: int
@@ -26,3 +27,4 @@ class Bot(BotBase):
 
     class Config:
         orm_mode = True
+

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -7,20 +7,29 @@ from app.schemas.bot import BotCreate
 from app.tests.utils.utils import random_lower_string
 
 def test_create_bot(test_app: TestClient, db: Session) -> None:
-    gpt_model = "gpt-4"
+    gpt_model = "test-model"
     name = random_lower_string()
-    bot_in = BotCreate(gpt_model=gpt_model, name=name, description="desc")
+    session_id = "session123"
+    bot_in = BotCreate(
+        gpt_model=gpt_model, name=name, description="desc", session_id=session_id
+    )
     bot = crud.create_bot(db, bot_create=bot_in)
     assert bot.gpt_model == gpt_model
     assert bot.name == name
+    assert bot.session_id == session_id
 
 def test_get_bot(test_app: TestClient, db: Session) -> None:
-    gpt_model = "gpt-4"
+    gpt_model = "test-model"
     name = random_lower_string()
-    bot_in = BotCreate(gpt_model=gpt_model, name=name, description="desc")
+    session_id = "session123"
+    bot_in = BotCreate(
+        gpt_model=gpt_model, name=name, description="desc", session_id=session_id
+    )
     bot = crud.create_bot(db, bot_create=bot_in)
     bot_2 = crud.get_bot_by_id(db, bot.id)
     assert bot_2
     assert bot.gpt_model == bot_2.gpt_model
     assert bot.name == bot_2.name
     assert bot.id == bot_2.id
+    assert bot.session_id == bot_2.session_id
+

--- a/tests/test_channel_crud.py
+++ b/tests/test_channel_crud.py
@@ -7,10 +7,12 @@ from app.schemas.channel import ChannelCreate, ChannelUpdate
 def test_channel_crud(db: Session) -> None:
     ch = channel_crud.create(db, obj_in=ChannelCreate(name="test", connector_id=1))
     assert ch.name == "test"
+    assert ch.connector_id == 1
     channel_id = ch.id
 
     fetched = channel_crud.get(db, channel_id)
     assert fetched.id == channel_id
+    assert fetched.connector_id == 1
 
     updated = channel_crud.update(db, db_obj=fetched, obj_in=ChannelUpdate(name="updated", connector_id=1))
     assert updated.name == "updated"
@@ -21,3 +23,4 @@ def test_channel_crud(db: Session) -> None:
     removed = channel_crud.remove(db, channel_id)
     assert removed.id == channel_id
     assert channel_crud.get(db, channel_id) is None
+


### PR DESCRIPTION
## Summary
- add `connector_id` to `Channel` model and persist it when creating channels
- include `session_id` and `gpt_model` when creating bots
- allow optional `session_id` in bot schemas
- update tests to cover new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ca90dd5a0833381e36a013713570c