### PR TITLE
Disable debug mode by default

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -3,7 +3,7 @@ initial_admin_password: "change_me_too"
 initial_admin_email: "admin@example.com"
 initial_admin_username: "admin"
 app_name: "norman"
-debug: true
+debug: false
 api_version: "v1"
 api_prefix: "/api"
 


### PR DESCRIPTION
## Summary
- disable debug mode in the default configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cac2155fc8333b55b0dcebb173f0a