### PR TITLE
Maintenance cleanups

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -176,53 +176,7 @@ async def create_message_endpoint(
     except Exception as e:
         print("Error:", e)
         return {"status": "error", "message": "Failed to create message and interaction"}
-
-
-'''
-@app_routes.delete("/api/messages/{message_id}")
-async def delete_message_endpoint(message_id: int, db: Session = Depends(get_async_db)):
-    try:
-        success = await delete_message(db=db, message_id=message_id)
-        if success:
-            return {"status": "success", "message": "Message deleted successfully"}
-        else:
-            return {"status": "error", "message": "Failed to delete message"}
-    except Exception as e:
-        print("Error:", e)
-        return {"status": "error", "message": "Failed to delete message"}
-'''
-
-
-
-'''
-@app_routes.post("/channels/create")
-async def create_channel(request: Request):
-    if request.method == "POST":
-        form_data = await request.form()
-        name = form_data["name"]
-        connector = form_data["connector"]
-        details = form_data["details"]
-        # Add logic to create channel in the database
-        return RedirectResponse(url="/", status_code=303)
-    return templates.TemplateResponse("add_channel.html", {"request": request})
-
-
-@app_routes.post("/filters/create")
-async def create_filter(request: Request):
-    if request.method == "POST":
-        form_data = await request.form()
-        regex = form_data["regex"]
-        # Add logic to create filter in the database
-        return RedirectResponse(url="/", status_code=303)
-    return templates.TemplateResponse("add_filter.html", {"request": request})
-
-
-@app_routes.post("/api/process_message")
-async def process_message_endpoint(request: Request):
-    return await process_message(request)
-'''
-
-
+# Experimental endpoints removed. Retrieve from version control if needed.
 # TODO: this doesn't seem like it goes here.  
 @app_routes.post("/webhook")
 async def process_webhook(request: Request, payload: dict = Body(...)):

--- a/app/handlers/openai_handler.py
+++ b/app/handlers/openai_handler.py
@@ -33,7 +33,7 @@ async def create_chat_interaction(
     """
 
     try:
-        response = openai.ChatCompletion.create(
+        response = await openai.ChatCompletion.acreate(
             model=model,
             messages=messages,
             max_tokens=max_tokens

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -1,11 +1,10 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
 from sqlalchemy.sql import func
-from sqlalchemy.sql.schema import FetchedValue
 from app.db.base import Base
 
 
 class Message(Base):
-    __tablename__ = "message"
+    __tablename__ = "messages"
 
     id = Column(Integer, primary_key=True, index=True)
     text = Column(String, nullable=False)

--- a/generate_key.sh
+++ b/generate_key.sh
@@ -1,115 +1,32 @@
 #!/bin/bash
 
-# Generate a random 32-character secret key using /dev/urandom
-secret_key=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+# Utility script to generate configuration secrets. Each key is 32 random
+# alphanumeric characters. Existing values can be replaced interactively.
 
-# Check if secret_key is already in the config.yaml file
-grep -q "secret_key:" config.yaml
+generate_and_set() {
+  local name="$1"
+  local value=$(tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 32 | head -n 1)
 
-if [ $? -eq 0 ]; then
-  # If secret_key is found, prompt the user to confirm updating the secret_key
-  echo "A secret_key is already present in the config.yaml file."
-  echo "Note: Updating the secret_key may cause loss of old data."
-  read -p "Are you sure you want to update the secret_key? (y/n): " confirm
+  if grep -q "${name}:" config.yaml; then
+    echo "A ${name} is already present in the config.yaml file."
+    echo "Note: Updating the ${name} may cause loss of old data."
+    read -p "Are you sure you want to update the ${name}? (y/n): " confirm
+    case "${confirm}" in
+      y|Y)
+        sed -i "s/${name}:.*/${name}: \"${value}\"/" config.yaml
+        echo "${name} has been updated in config.yaml"
+        ;;
+      *)
+        echo "${name} update has been cancelled."
+        ;;
+    esac
+  else
+    echo "${name}: \"${value}\"" >> config.yaml
+    echo "${name} has been set in config.yaml"
+  fi
+}
 
-  case "$confirm" in
-    y|Y)
-      # If the user confirms, replace the existing value with the new secret_key
-      sed -i "s/secret_key:.*/secret_key: \"${secret_key}\"/" config.yaml
-      echo "Secret key has been updated in config.yaml"
-      ;;
-    *)
-      echo "Secret key update has been cancelled."
-      ;;
-  esac
-else
-  # If secret_key is not found, append the secret_key to the config.yaml file
-  echo "secret_key: \"${secret_key}\"" >> config.yaml
-  echo "Secret key has been set in config.yaml"
-fi
-
-# Generate a random 32-character secret key using /dev/urandom
-initial_admin_password=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
-
-# Check if initial_admin_passsword is already in the config.yaml file
-grep -q "initial_admin_password:" config.yaml
-
-if [ $? -eq 0 ]; then
-  # If initial_admin_password is found, prompt the user to confirm updating the initial_admin_password
-  echo "A initial_admin_password is already present in the config.yaml file."
-  echo "Note: Updating the initial_admin_password may cause loss of old data."
-  read -p "Are you sure you want to update the initial_admin_password? (y/n): " confirm
-
-  case "$confirm" in
-    y|Y)
-      # If the user confirms, replace the existing value with the new initial_admin_password
-      sed -i "s/initial_admin_password:.*/initial_admin_password: \"${initial_admin_password}\"/" config.yaml
-      echo "Secret key has been updated in config.yaml"
-      ;;
-    *)
-      echo "Secret key update has been cancelled."
-      ;;
-  esac
-else
-  # If initial_admin_password is not found, append the initial_admin_password to the config.yaml file
-  echo "initial_admin_password: \"${initial_admin_password}\"" >> config.yaml
-  echo "Secret key has been set in config.yaml"
-fi
-
-
-# Generate a random 32-character secret key using /dev/urandom
-encryption_key=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
-
-# Check if initial_admin_passsword is already in the config.yaml file
-grep -q "encryption_key:" config.yaml
-
-if [ $? -eq 0 ]; then
-  # If initial_admin_password is found, prompt the user to confirm updating the initial_admin_password
-  echo "A initial encryption_key is already present in the config.yaml file."
-  echo "Note: Updating the encryption key will cause loss of old data."
-  read -p "Are you sure you want to update the encryption_key? (y/n): " confirm
-
-  case "$confirm" in
-    y|Y)
-      # If the user confirms, replace the existing value with the new initial_admin_password
-      sed -i "s/encryption_key:.*/encryption_key: \"${encryption_key}\"/" config.yaml
-      echo "Secret key has been updated in config.yaml"
-      ;;
-    *)
-      echo "Secret key update has been cancelled."
-      ;;
-  esac
-else
-  # If encryption_key is not found, append the encryption_key to the config.yaml file
-  echo "encryption_key: \"${encryption_key}\"" >> config.yaml
-  echo "Secret key has been set in config.yaml"
-fi
-
-# Generate a random 32-character secret key using /dev/urandom
-encryption_salt=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
-
-# Check if initial_admin_passsword is already in the config.yaml file
-grep -q "encryption_salt:" config.yaml
-
-if [ $? -eq 0 ]; then
-  # If initial_admin_password is found, prompt the user to confirm updating the initial_admin_password
-  echo "A initial encryption_salt is already present in the config.yaml file."
-  echo "Note: Updating the encryption key will cause loss of old data."
-  read -p "Are you sure you want to update the encryption_salt? (y/n): " confirm
-
-  case "$confirm" in
-    y|Y)
-      # If the user confirms, replace the existing value with the new initial_admin_password
-      sed -i "s/encryption_salt:.*/encryption_salt: \"${encryption_salt}\"/" config.yaml
-      echo "Secret key has been updated in config.yaml"
-      ;;
-    *)
-      echo "Secret key update has been cancelled."
-      ;;
-  esac
-else
-  # If encryption_salt is not found, append the encryption_salt to the config.yaml file
-  echo "encryption_salt: \"${encryption_salt}\"" >> config.yaml
-  echo "Secret key has been set in config.yaml"
-fi
-
+generate_and_set secret_key
+generate_and_set initial_admin_password
+generate_and_set encryption_key
+generate_and_set encryption_salt


### PR DESCRIPTION
## Summary
- remove unused endpoints commented with triple quotes
- rename `message` table and clean up unused imports
- simplify secret generator script and fix typo
- make OpenAI calls truly async

## Testing
- `flake8 app/handlers/openai_handler.py app/models/message.py app/app_routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cadf1797483339706888bc72774cf