### PR TITLE
Fix channel filter variable name

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -197,7 +197,7 @@ async def process_webhook(request: Request, payload: dict = Body(...)):
             # If the filter has a reply, send the reply to the specified channel
             if lfilter.reply:
                 connector = get_connector(lfilter.reply_channel.connector)
-                await connector.send_message(filter.reply)
+                await connector.send_message(lfilter.reply)
 
 @app_routes.post("/token", response_model=Token)
 async def token(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_async_db)):


### PR DESCRIPTION
## Summary
- fix variable name when sending filtered webhook replies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb2e48eb883339a277ded837f3c94