### PR TITLE
Improve connector base health check

### DIFF
--- a/app/connectors/base_connector.py
+++ b/app/connectors/base_connector.py
@@ -72,3 +72,8 @@ class BaseConnector(ABC):
             if asyncio.iscoroutine(disconnect_result):
                 await disconnect_result
 
+    def is_connected(self) -> bool:  # pragma: no cover - default implementation
+        """Return ``True`` if the connector appears to be healthy."""
+
+        return True
+

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -16,6 +16,9 @@ Norman supports various chat platforms through connectors. To create a new conne
 1. Create a new Python file in the `app/connectors` directory with a descriptive name, e.g., `custom_connector.py`.
 
 2. Inherit from the `BaseConnector` class and implement the required methods.  At a minimum you should provide `send_message` as well as optional `connect` and `disconnect` hooks.  You can also override `listen_and_process` and `process_incoming` to handle incoming data.
+   The base class includes a default `is_connected` method that simply returns
+   `True`.  Override this if your connector can perform a meaningful health
+   check.
 
 3. Register your new connector in `app/connectors/connector_utils.py` by adding
    it to the `connector_classes` dictionary.

--- a/tests/connectors/test_base_connector.py
+++ b/tests/connectors/test_base_connector.py
@@ -24,3 +24,8 @@ def test_queue_and_dispatcher():
     with contextlib.suppress(asyncio.CancelledError):
         loop.run_until_complete(task)
     assert connector.sent == ["hi"]
+
+
+def test_default_is_connected():
+    connector = DummyConnector()
+    assert connector.is_connected()


### PR DESCRIPTION
## Summary
- add `is_connected` default implementation on BaseConnector
- document base `is_connected` method
- test default `is_connected`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cd8d855588333ad0fb320294e576c