### PR TITLE
Add dark mode toggle

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -139,3 +139,15 @@ textarea {
   float: right;
 }
 
+
+body.dark-mode {
+    background-color: #121212;
+    color: #f8f9fa;
+}
+body.dark-mode a { color: #f8f9fa; }
+body.dark-mode .navbar,
+body.dark-mode footer,
+body.dark-mode .card {
+    background-color: #1e1e1e;
+    color: #f8f9fa;
+}

--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('themeToggle');
+  if (!toggle) return;
+  const darkPref = localStorage.getItem('darkMode') === 'true';
+  setTheme(darkPref);
+  toggle.checked = darkPref;
+  toggle.addEventListener('change', () => setTheme(toggle.checked));
+});
+
+function setTheme(dark) {
+  if (dark) {
+    document.body.classList.add('dark-mode');
+  } else {
+    document.body.classList.remove('dark-mode');
+  }
+  localStorage.setItem('darkMode', dark);
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,6 +23,10 @@
                     <li class="nav-item"><a class="nav-link" href="/filters.html">Filters</a></li>
                     <li class="nav-item"><a class="nav-link" href="/messages_log.html">Messages</a></li>
                 </ul>
+                <div class="form-check form-switch text-light">
+                    <input class="form-check-input" type="checkbox" id="themeToggle">
+                    <label class="form-check-label" for="themeToggle">Dark Mode</label>
+                </div>
             </div>
         </div>
     </header>
@@ -36,5 +40,6 @@
         &copy; Norman {{ year }}
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoKMJQ0Z6D9F6EU2ygSABR03SuhDL7z8Zef3CJXTgq1Q0Q" crossorigin="anonymous"></script>
+    <script src="/static/js/theme.js"></script>
 </body>
 </html>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -22,7 +22,12 @@
             <a href="/auth/microsoft/login" class="btn btn-outline-primary w-100">Sign in with Microsoft</a>
         </form>
     </div>
+    <div class="form-check form-switch text-end mt-3">
+        <input class="form-check-input" type="checkbox" id="themeToggle">
+        <label class="form-check-label" for="themeToggle">Dark Mode</label>
+    </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoKMJQ0Z6D9F6EU2ygSABR03SuhDL7z8Zef3CJXTgq1Q0Q" crossorigin="anonymous"></script>
+    <script src="/static/js/theme.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- support dark mode via a toggle in the navbar and login page
- include theme.js to keep preference in localStorage
- style dark mode in styles.css

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cdba821288333bb38e84e1a668759