### PR TITLE
Dynamic connector discovery and multi-instance config

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,5 @@
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 from pydantic import BaseSettings, validator
 
 # should this move to schemas?
@@ -170,6 +170,7 @@ class Settings(BaseSettings):
     zulip_site_url: str
     zulip_stream: str
     zulip_topic: str
+    connectors: List[Dict[str, Any]] = []
     broadcast_connectors: str = ""
     openai_api_key: Optional[str]
     openai_default_model: str = "gpt-3.5-turbo"
@@ -271,12 +272,16 @@ def load_config():
     # Read the config from the dist file
     with open("config.yaml.dist", "r") as dist_file:
         config = yaml.safe_load(dist_file)
+    if "connectors" not in config:
+        config["connectors"] = []
 
     # If the config.yaml file exists, merge its contents with the dist config
     if os.path.exists("config.yaml"):
         with open("config.yaml", "r") as custom_file:
             custom_config = yaml.safe_load(custom_file)
             config.update(custom_config)
+    if "connectors" not in config:
+        config["connectors"] = []
 
     return config
 

--- a/app/core/test_settings.py
+++ b/app/core/test_settings.py
@@ -10,6 +10,7 @@ class TestSettings(Settings):
         env_prefix = ""
 
 test_defaults = load_config()
+test_defaults["connectors"] = []
 test_settings = Settings(
     **{**test_defaults, "database_url": "sqlite:///./db/test.db"}
 )

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -162,6 +162,7 @@ zulip_api_key: "your_zulip_api_key"
 zulip_site_url: "https://zulip.example.com"
 zulip_stream: "your_zulip_stream"
 zulip_topic: "your_zulip_topic"
+connectors: []
 broadcast_connectors: ""
 
 openai_api_key:

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -91,7 +91,7 @@ For other connectors, consult the platform-specific documentation for informatio
 
 ### Extending Norman with New Connectors
 
-You can extend Norman with new connectors by creating a new class that inherits from `BaseConnector`. Implement `send_message` and optionally `connect` and `disconnect` for any setup or teardown logic. Messages can be queued with `queue_message` and will be dispatched while `run()` is active. Finally, add the new connector class to the `connector_classes` dictionary in `app/connectors/connector_utils.py` so that it can be used in the application.
+You can extend Norman with new connectors by creating a new class that inherits from `BaseConnector`. Implement `send_message` and optionally `connect` and `disconnect` for any setup or teardown logic. Messages can be queued with `queue_message` and will be dispatched while `run()` is active. Place the new file inside the `app/connectors` package with a name ending in `_connector.py` so it can be auto-discovered.
 
 ## More Information
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -20,8 +20,8 @@ Norman supports various chat platforms through connectors. To create a new conne
    `True`.  Override this if your connector can perform a meaningful health
    check.
 
-3. Register your new connector in `app/connectors/connector_utils.py` by adding
-   it to the `connector_classes` dictionary.
+3. Place the new module inside the `app/connectors` package with a filename
+   ending in `_connector.py`. Norman will automatically discover it.
 
 4. Update the configuration files to include any necessary settings for your connector.
 

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -364,11 +364,10 @@ def test_get_configured_connectors_with_slack(monkeypatch):
     from app.connectors.connector_utils import get_configured_connectors
 
     config = load_config()
-    config['slack_token'] = 'x'
-    config['slack_channel_id'] = 'C1'
+    config['connectors'] = [{"type": "slack", "token": 'x', "channel_id": 'C1'}]
     settings = Settings(**config)
 
     monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: settings)
     connectors = get_configured_connectors()
     assert 'slack' in connectors
-    assert isinstance(connectors['slack'], SlackConnector)
+    assert isinstance(connectors['slack'][0], SlackConnector)

--- a/tests/test_init_connectors.py
+++ b/tests/test_init_connectors.py
@@ -30,16 +30,14 @@ def test_init_connectors_adds_placeholders(monkeypatch):
 
     app = FastAPI()
     init_connectors(app, test_settings)
-    for name in connector_classes:
-        attr = f"{name}_connector"
-        assert hasattr(app.state, attr)
-        assert getattr(app.state, attr) is None
+    assert hasattr(app.state, "connectors")
+    assert set(app.state.connectors) == set(connector_classes)
+    assert all(v == [] for v in app.state.connectors.values())
 
 
 def test_init_connectors_with_slack(monkeypatch):
     config = load_config()
-    config["slack_token"] = "x"
-    config["slack_channel_id"] = "C1"
+    config["connectors"] = [{"type": "slack", "token": "x", "channel_id": "C1"}]
     settings = Settings(**config)
 
     monkeypatch.setattr("app.connectors.get_settings", lambda: settings)
@@ -47,9 +45,7 @@ def test_init_connectors_with_slack(monkeypatch):
 
     app = FastAPI()
     init_connectors(app, settings)
-    for name in connector_classes:
-        attr = f"{name}_connector"
-        assert hasattr(app.state, attr)
-    connector = getattr(app.state, "slack_connector")
+    assert "slack" in app.state.connectors
+    connector = app.state.connectors["slack"][0]
     assert isinstance(connector, SlackConnector)
 


### PR DESCRIPTION
## Summary
- dynamically discover connector classes instead of maintaining a big map
- support new `connectors:` list in configuration so multiple connectors of the same type can be defined
- adjust initialization logic for connectors
- update docs for new discovery approach
- fix and update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cee194ed4833386dc7a63044a35bc