### PR TITLE
Implement Bluesky connector

### DIFF
--- a/app/connectors/bluesky_connector.py
+++ b/app/connectors/bluesky_connector.py
@@ -1,22 +1,72 @@
+"""Bluesky connector using the AT Protocol APIs."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
+
 from .base_connector import BaseConnector
 
 
 class BlueskyConnector(BaseConnector):
-    """Connector for posting to Bluesky."""
+    """Connector for posting to Bluesky using app passwords."""
 
     id = "bluesky"
     name = "Bluesky"
 
-    def __init__(self, handle: str, app_password: str, config=None):
+    def __init__(
+        self,
+        handle: str,
+        app_password: str,
+        service_url: Optional[str] = "https://bsky.social",
+        config=None,
+    ) -> None:
         super().__init__(config)
         self.handle = handle
         self.app_password = app_password
+        self.service_url = (service_url or "https://bsky.social").rstrip("/")
+        self._access_jwt: Optional[str] = None
         self.sent_messages = []
 
-    async def send_message(self, message) -> str:
-        """Record ``message`` locally and return a confirmation string."""
-        self.sent_messages.append(message)
-        return "sent"
+    async def _login(self) -> Optional[str]:
+        url = f"{self.service_url}/xrpc/com.atproto.server.createSession"
+        payload = {"identifier": self.handle, "password": self.app_password}
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(url, json=payload)
+                resp.raise_for_status()
+                data = resp.json()
+                self._access_jwt = data.get("accessJwt")
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                print(f"Error logging in to Bluesky: {exc}")
+                return None
+        return self._access_jwt
+
+    async def send_message(self, message: str) -> Optional[str]:
+        """Post ``message`` to Bluesky and return the response text."""
+        token = self._access_jwt or await self._login()
+        if not token:
+            return None
+        url = f"{self.service_url}/xrpc/com.atproto.repo.createRecord"
+        payload = {
+            "repo": self.handle,
+            "collection": "app.bsky.feed.post",
+            "record": {
+                "$type": "app.bsky.feed.post",
+                "text": message,
+                "createdAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            },
+        }
+        headers = {"Authorization": f"Bearer {token}"}
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(url, json=payload, headers=headers)
+                resp.raise_for_status()
+                self.sent_messages.append(message)
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                print(f"Error sending Bluesky message: {exc}")
+                return None
 
     async def listen_and_process(self):
         """Listening not implemented for Bluesky yet."""

--- a/docs/connectors/bluesky.md
+++ b/docs/connectors/bluesky.md
@@ -1,10 +1,14 @@
 # Bluesky Connector
 
-Post updates to Bluesky using your app password.
+Post updates to Bluesky using the AT Protocol APIs and an app password.
 
 ## Configuration
 
 ```yaml
 bluesky_handle: "user.bsky.social"
 bluesky_app_password: "your_app_password"
+bluesky_service_url: "https://bsky.social"  # optional
 ```
+
+Once configured, messages queued for the ``bluesky`` connector will be
+published to your feed.

--- a/tests/connectors/test_bluesky.py
+++ b/tests/connectors/test_bluesky.py
@@ -1,12 +1,64 @@
 import asyncio
+import httpx
 from app.connectors.bluesky_connector import BlueskyConnector
 
 
-def test_send_message():
+class DummyResponse:
+    def __init__(self, json_data=None, text="ok", status=200):
+        self._json = json_data or {}
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+    def json(self):
+        return self._json
+
+
+class DummyClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+        self.idx = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, headers=None):
+        self.calls.append((url, json, headers))
+        resp = self.responses[self.idx]
+        self.idx += 1
+        return resp
+
+
+def test_send_message_success(monkeypatch):
+    login_resp = DummyResponse({"accessJwt": "tok"})
+    send_resp = DummyResponse(text="sent")
+    client = DummyClient([login_resp, send_resp])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
     connector = BlueskyConnector("h", "pw")
     result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
     assert result == "sent"
     assert connector.sent_messages == ["hi"]
+    assert client.calls[0][0].endswith("/com.atproto.server.createSession")
+    assert client.calls[1][0].endswith("/com.atproto.repo.createRecord")
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None, headers=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient([]))
+    connector = BlueskyConnector("h", "pw")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result is None
+    assert connector.sent_messages == []
 
 
 def test_process_incoming():


### PR DESCRIPTION
## Summary
- implement BlueskyConnector to send posts via the AT Protocol
- update documentation for Bluesky connector
- add tests for BlueskyConnector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cf340a8508333b090dfd3efa7d006