### PR TITLE
Update default GPT model

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ Norman is an open-source chatbot that leverages OpenAI's GPT models to assist an
 ### Features
 
 - Supports multiple chat platforms (e.g., Slack, IRC) through connectors
-- Allows multiple chatbots with different GPT models (e.g., gpt-3.5-turbo, gpt-4)
+- Allows multiple chatbots with different GPT models (e.g., gpt-4.1-mini, o3)
 - Configurable channel filters and actions for automation
 - Minimal Web UI for configuration and management
 - SQLite database for lightweight deployment
 - Authentication and authorization support
 - Extendable with custom connectors
+
+*Bots default to the `gpt-4.1-mini` model for speed. Use `o3` when you need deeper reasoning and can tolerate more latency.*
 
 ### Project Structure
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -173,7 +173,7 @@ class Settings(BaseSettings):
     connectors: List[Dict[str, Any]] = []
     broadcast_connectors: str = ""
     openai_api_key: Optional[str]
-    openai_default_model: str = "gpt-3.5-turbo"
+    openai_default_model: str = "gpt-4.1-mini"
     openai_max_tokens: int = 150
     google_client_id: str = ""
     google_client_secret: str = ""

--- a/app/models/bot.py
+++ b/app/models/bot.py
@@ -9,7 +9,7 @@ class Bot(Base):
     description = Column(String, nullable=False)
     user_id = Column(Integer, ForeignKey("users.id"))
     session_id = Column(String, nullable=True)
-    gpt_model = Column(String, nullable=False, default="gpt-4")
+    gpt_model = Column(String, nullable=False, default="gpt-4.1-mini")
     system_prompt = Column(String, nullable=False, default="You are a helpful assistant.")
     default_response_tokens = Column(Integer, nullable=False, default=150) # how much to generate
     default_prompt_tokens = Column(Integer, nullable=False, default=1000) # how many messages back

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -166,7 +166,7 @@ connectors: []
 broadcast_connectors: ""
 
 openai_api_key:
-openai_default_model: "gpt-3.5-turbo"
+openai_default_model: "gpt-4.1-mini"
 openai_max_tokens: 150
 google_client_id: "your_google_client_id"
 google_client_secret: "your_google_client_secret"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -36,7 +36,7 @@ Create a bot:
 ```bash
 curl -X POST http://localhost:8000/api/v1/bots/ \
   -H "Content-Type: application/json" \
-  -d '{"name": "demo", "description": "example bot", "gpt_model": "gpt-4"}'
+  -d '{"name": "demo", "description": "example bot", "gpt_model": "gpt-4.1-mini"}'
 ```
 
 List existing bots:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,7 +86,7 @@ Create a bot:
 ```bash
 curl -X POST http://localhost:8000/api/v1/bots/ \
   -H "Content-Type: application/json" \
-  -d '{"name": "demo", "description": "example bot", "gpt_model": "gpt-4"}'
+  -d '{"name": "demo", "description": "example bot", "gpt_model": "gpt-4.1-mini"}'
 ```
 
 List existing bots:

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 
 def test_create_bot_api(test_app: TestClient, db: Session) -> None:
-    payload = {"name": "test bot", "description": "desc", "gpt_model": "gpt-4"}
+    payload = {"name": "test bot", "description": "desc", "gpt_model": "gpt-4.1-mini"}
     response = test_app.post("/api/bots/create", json=payload)
     assert response.status_code == 200
     data = response.json()


### PR DESCRIPTION
## Summary
- use `gpt-4.1-mini` as the default model everywhere
- mention `o3` for heavy reasoning
- update docs and tests to show the new model name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683cf5e8ab708333bc3215af7113adb2