### PR TITLE
Add pooled DB sessions

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -187,6 +187,8 @@ class Settings(BaseSettings):
 
     # Database
     database_url: str
+    database_pool_size: int = 5
+    database_max_overflow: int = 10
 
     # Server
     host: str

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -2,10 +2,19 @@
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from app.core.config import settings
 
-engine = create_engine(settings.database_url)
+engine = create_engine(
+    settings.database_url,
+    poolclass=QueuePool,
+    pool_size=settings.database_pool_size,
+    max_overflow=settings.database_max_overflow,
+    connect_args={"check_same_thread": False}
+    if settings.database_url.startswith("sqlite")
+    else {},
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 from app.db.base import Base

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,7 +1,16 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 
 from app.core.config import settings
 
-engine = create_engine(settings.database_url)
+engine = create_engine(
+    settings.database_url,
+    poolclass=QueuePool,
+    pool_size=settings.database_pool_size,
+    max_overflow=settings.database_max_overflow,
+    connect_args={"check_same_thread": False}
+    if settings.database_url.startswith("sqlite")
+    else {},
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -175,6 +175,8 @@ microsoft_client_secret: "your_microsoft_client_secret"
 
 # Database
 database_url: "sqlite:///./db/norman.db"
+database_pool_size: 5
+database_max_overflow: 10
 
 # Server
 host: "0.0.0.0"

--- a/tests/test_db_session.py
+++ b/tests/test_db_session.py
@@ -1,0 +1,23 @@
+import importlib.util
+import os
+from app.core.config import settings
+
+
+def test_engine_pool_settings():
+    old_size = settings.database_pool_size
+    old_overflow = settings.database_max_overflow
+    settings.database_pool_size = 7
+    settings.database_max_overflow = 3
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "temp_db_session", os.path.join("app", "db", "session.py")
+        )
+        db_session = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(db_session)
+        assert db_session.engine.pool.size() == 7
+        assert db_session.engine.pool._max_overflow == 3
+        assert db_session.SessionLocal.kw["bind"] is db_session.engine
+    finally:
+        settings.database_pool_size = old_size
+        settings.database_max_overflow = old_overflow
+


### PR DESCRIPTION
## Summary
- create pooled DB engine with queue pool
- expose pool settings in config
- apply same engine pooling in core database module
- adjust tests to use pooled engine
- test database session creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cf8c79d908333867e96029ad4d6d2