### PR TITLE
Document unsupported listening for Line and Facebook connectors

### DIFF
--- a/app/connectors/facebook_messenger_connector.py
+++ b/app/connectors/facebook_messenger_connector.py
@@ -1,5 +1,6 @@
 """Simple Facebook Messenger connector using the Graph API."""
 
+import asyncio
 import httpx
 from typing import Any, Dict, Optional
 
@@ -30,9 +31,11 @@ class FacebookMessengerConnector(BaseConnector):
                 print(f"Error sending Facebook message: {exc}")
                 return None
 
-    async def listen_and_process(self):
-        """Listening for Messenger messages is not implemented."""
-        return None
+    async def listen_and_process(self) -> None:
+        """Return immediately as Messenger does not offer a polling API."""
+
+        self.logger.info("Facebook Messenger connector does not support incoming messages")
+        await asyncio.sleep(0)
 
     async def process_incoming(self, message):
         """Return the incoming ``message`` payload."""

--- a/app/connectors/line_connector.py
+++ b/app/connectors/line_connector.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict, Optional
 
+import asyncio
+
 import httpx
 
 from .base_connector import BaseConnector
@@ -32,8 +34,10 @@ class LineConnector(BaseConnector):
             return None
 
     async def listen_and_process(self) -> None:
-        """Listening for LINE messages is not implemented."""
-        return None
+        """Return immediately as LINE does not support polling for messages."""
+
+        self.logger.info("LINE connector does not support incoming messages")
+        await asyncio.sleep(0)
 
     async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
         return message

--- a/tests/connectors/test_facebook_messenger.py
+++ b/tests/connectors/test_facebook_messenger.py
@@ -63,3 +63,11 @@ def test_process_incoming():
         connector.process_incoming(payload)
     )
     assert result == payload
+
+
+def test_listen_and_process():
+    connector = FacebookMessengerConnector("TOKEN", "VERIFY")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.listen_and_process()
+    )
+    assert result is None

--- a/tests/connectors/test_line.py
+++ b/tests/connectors/test_line.py
@@ -55,3 +55,11 @@ def test_process_incoming():
         connector.process_incoming(payload)
     )
     assert result == payload
+
+
+def test_listen_and_process():
+    connector = LineConnector("TOKEN", "USER")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.listen_and_process()
+    )
+    assert result is None


### PR DESCRIPTION
## Summary
- clarify that Line and Facebook connectors don't support incoming messages
- add async placeholders in `listen_and_process`
- cover the new behavior with small tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cf8c9ef20833396d6b98ffbed0d74