### PR TITLE
Improve logging configuration

### DIFF
--- a/app/TODO.md
+++ b/app/TODO.md
@@ -5,7 +5,7 @@ This document outlines the remaining tasks to complete and improve the Norman pr
 ## Core
 
 - [x] Add additional exception classes in `app/core/exceptions.py` to handle specific error scenarios.
-- [ ] Improve logging configuration and log messages in `app/core/logging.py`.
+- [x] Improve logging configuration and log messages in `app/core/logging.py`.
 - [x] Review and optimize the configuration loading in `app/core/config.py`.
 
 ## Database

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,12 +1,14 @@
 
 from typing import Any, Dict, Optional, List
 from pydantic import BaseSettings, validator
+import logging
 
 # should this move to schemas?
 class Settings(BaseSettings):
     secret_key: str
     app_name: str
     debug: bool
+    log_level: str = "INFO"
     api_version: str
     api_prefix: str
 
@@ -237,6 +239,15 @@ class Settings(BaseSettings):
         assert v != "admin", (
             "You must set an admin username in the config.yaml!"
         )
+        return v
+
+    @validator("log_level", pre=True)
+    def validate_log_level(cls, v):
+        if isinstance(v, str):
+            level = v.upper()
+            if level not in logging._nameToLevel:
+                raise ValueError(f"Invalid log level: {v}")
+            return level
         return v
 
     class Config:

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -1,6 +1,9 @@
 import logging
+from typing import Optional, Union
 
-def setup_logger(name: str) -> logging.Logger:
+from .config import settings
+
+def setup_logger(name: str, level: Optional[Union[int, str]] = None) -> logging.Logger:
     """Return a configured :class:`logging.Logger` instance.
 
     The function is safe to call multiple times for the same ``name``. A
@@ -9,12 +12,16 @@ def setup_logger(name: str) -> logging.Logger:
     """
 
     logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
+    if level is None:
+        level = settings.log_level
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+    logger.setLevel(level)
 
     has_stream = any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
     if not has_stream:
         handler = logging.StreamHandler()
-        handler.setLevel(logging.DEBUG)
+        handler.setLevel(level)
         formatter = logging.Formatter(
             '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
         )

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -4,6 +4,7 @@ initial_admin_email: "admin@example.com"
 initial_admin_username: "admin"
 app_name: "norman"
 debug: false
+log_level: INFO
 api_version: "v1"
 api_prefix: "/api"
 

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ def main() -> None:
         host=settings.host,
         port=settings.port,
         reload=settings.debug,
-        log_level="debug" if settings.debug else "info",
+        log_level=settings.log_level.lower(),
     )
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -16,3 +16,26 @@ def test_setup_logger_idempotent():
     # cleanup
     for handler in list(logger1.handlers):
         logger1.removeHandler(handler)
+
+
+def test_setup_logger_level_from_settings(monkeypatch):
+    name = "test_setup_logger_level_from_settings"
+    from app.core import config
+
+    old_level = config.settings.log_level
+    monkeypatch.setattr(config.settings, "log_level", "WARNING")
+    try:
+        logger = setup_logger(name)
+        assert logger.level == logging.WARNING
+    finally:
+        monkeypatch.setattr(config.settings, "log_level", old_level)
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+
+
+def test_setup_logger_explicit_level():
+    name = "test_setup_logger_explicit_level"
+    logger = setup_logger(name, level="ERROR")
+    assert logger.level == logging.ERROR
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)


### PR DESCRIPTION
## Summary
- support configurable log levels
- validate log levels in settings
- use custom log level in Uvicorn server
- add tests for new logging config
- mark logging TODO as complete

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_683cff3c748083339f434ecb7c343774