### PR TITLE
Store message id in interactions

### DIFF
--- a/alembic/versions/fdfa37da0489_add_message_id_to_interaction.py
+++ b/alembic/versions/fdfa37da0489_add_message_id_to_interaction.py
@@ -1,0 +1,25 @@
+"""add message_id to Interaction
+
+Revision ID: fdfa37da0489
+Revises: eacd88a5c06d
+Create Date: 2024-08-21 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "fdfa37da0489"
+down_revision = "eacd88a5c06d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("interactions", sa.Column("message_id", sa.Integer(), nullable=False))
+    op.create_foreign_key(None, "interactions", "messages", ["message_id"], ["id"])
+
+
+def downgrade():
+    op.drop_constraint(None, "interactions", type_="foreignkey")
+    op.drop_column("interactions", "message_id")

--- a/app/models/interaction.py
+++ b/app/models/interaction.py
@@ -2,9 +2,11 @@ from sqlalchemy import Column, Integer, Text, DateTime, ForeignKey, String
 from sqlalchemy.sql import func
 from app.db.base import Base
 
+
 class Interaction(Base):
     __tablename__ = "interactions"
     id = Column(Integer, primary_key=True)
+    message_id = Column(Integer, ForeignKey("messages.id"), nullable=False)
     bot_id = Column(Integer, ForeignKey("bots.id"))
     input_data = Column(Text, nullable=False)
     output_data = Column(Text, nullable=False)

--- a/app/schemas/interaction.py
+++ b/app/schemas/interaction.py
@@ -2,7 +2,9 @@ from typing import List
 from pydantic import BaseModel
 from datetime import datetime
 
+
 class InteractionBase(BaseModel):
+    message_id: int
     bot_id: int
     input_data: str
     output_data: str
@@ -12,11 +14,14 @@ class InteractionBase(BaseModel):
     status_code: int
     headers: str
 
+
 class InteractionCreate(InteractionBase):
     pass
 
+
 class InteractionUpdate(InteractionBase):
     pass
+
 
 class Interaction(InteractionBase):
     id: int

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1,5 +1,8 @@
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+from app.models import Interaction, Message
+from app import crud
+from app.schemas.bot import BotCreate
 
 
 def test_create_bot_api(test_app: TestClient, db: Session) -> None:
@@ -10,3 +13,34 @@ def test_create_bot_api(test_app: TestClient, db: Session) -> None:
     assert data["name"] == payload["name"]
     assert data["description"] == payload["description"]
     assert "id" in data
+
+
+def test_create_message_endpoint_stores_interaction(
+    test_app: TestClient, db: Session, monkeypatch
+) -> None:
+    bot = crud.create_bot(
+        db, BotCreate(name="bot", description="desc", gpt_model="gpt-4")
+    )
+
+    async def dummy_create_chat_interaction(*args, **kwargs):
+        return {
+            "model": "gpt-4",
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            "headers": {},
+        }
+
+    monkeypatch.setattr(
+        "app.app_routes.create_chat_interaction", dummy_create_chat_interaction
+    )
+
+    resp = test_app.post(f"/api/bots/{bot.id}/messages", json={"content": "hello"})
+    assert resp.status_code == 200
+
+    interaction = db.query(Interaction).filter(Interaction.bot_id == bot.id).first()
+    assert interaction is not None
+    user_message = (
+        db.query(Message).filter(Message.id == interaction.message_id).first()
+    )
+    assert user_message is not None
+    assert user_message.source == "user"


### PR DESCRIPTION
## Summary
- track originating message in interactions
- expose the field in Interaction schemas
- add Alembic migration for the new column
- test that the message endpoint records the message id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d09f6db4883339835dafd5d218bfb