### PR TITLE
Implement connector management

### DIFF
--- a/app/static/js/connectors.js
+++ b/app/static/js/connectors.js
@@ -1,0 +1,150 @@
+// connectors.js - dynamic connector management
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchConnectorsAndRender();
+
+  const addForm = document.getElementById('add-connector-form');
+  if (addForm) {
+    addForm.addEventListener('submit', async (evt) => {
+      evt.preventDefault();
+      const nameInput = document.getElementById('connector-name');
+      const typeInput = document.getElementById('connector-type');
+      const configInput = document.getElementById('connector-config');
+      let config = {};
+      if (configInput.value.trim()) {
+        try {
+          config = JSON.parse(configInput.value);
+        } catch (e) {
+          alert('Config must be valid JSON');
+          return;
+        }
+      }
+      const connector = await createConnector({
+        name: nameInput.value.trim(),
+        connector_type: typeInput.value.trim(),
+        config: config
+      });
+      document.querySelector('.connectors-container')
+        .appendChild(createConnectorElement(connector));
+      nameInput.value = '';
+      typeInput.value = '';
+      configInput.value = '';
+    });
+  }
+});
+
+async function fetchConnectorsAndRender() {
+  const connectors = await getConnectors();
+  const container = document.querySelector('.connectors-container');
+  container.innerHTML = '';
+  for (const connector of connectors) {
+    const el = createConnectorElement(connector);
+    container.appendChild(el);
+    // fetch status for each connector
+    try {
+      const status = await getConnectorStatus(connector.id);
+      el.querySelector('.connector-status').textContent = status.status;
+    } catch (e) {
+      el.querySelector('.connector-status').textContent = 'unknown';
+    }
+  }
+}
+
+async function getConnectors() {
+  const resp = await fetch('/api/connectors');
+  return await resp.json();
+}
+
+async function createConnector(data) {
+  const resp = await fetch('/api/connectors/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return await resp.json();
+}
+
+async function updateConnector(id, data) {
+  const resp = await fetch(`/api/connectors/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return await resp.json();
+}
+
+async function deleteConnector(id) {
+  await fetch(`/api/connectors/${id}`, { method: 'DELETE' });
+}
+
+async function testConnector(id) {
+  const resp = await fetch(`/api/connectors/${id}/test`, { method: 'POST' });
+  return await resp.json();
+}
+
+async function getConnectorStatus(id) {
+  const resp = await fetch(`/api/connectors/${id}/status`);
+  return await resp.json();
+}
+
+function createConnectorElement(connector) {
+  const card = document.createElement('div');
+  card.className = 'card mb-3';
+  const body = document.createElement('div');
+  body.className = 'card-body';
+  const header = document.createElement('h5');
+  header.textContent = `${connector.name} (${connector.connector_type})`;
+  const statusSpan = document.createElement('span');
+  statusSpan.className = 'badge bg-secondary ms-2 connector-status';
+  statusSpan.textContent = '...';
+  header.appendChild(statusSpan);
+  body.appendChild(header);
+
+  const editBtn = document.createElement('button');
+  editBtn.className = 'btn btn-sm btn-outline-secondary me-2';
+  editBtn.textContent = 'Edit';
+  editBtn.addEventListener('click', async () => {
+    const newName = prompt('Connector name', connector.name);
+    const newType = prompt('Connector type', connector.connector_type);
+    let newConfig = prompt('Config (JSON)', JSON.stringify(connector.config || {}));
+    if (newName && newType && newConfig != null) {
+      try {
+        newConfig = JSON.parse(newConfig);
+      } catch (e) {
+        alert('Config must be valid JSON');
+        return;
+      }
+      const updated = await updateConnector(connector.id, {
+        name: newName,
+        connector_type: newType,
+        config: newConfig
+      });
+      connector.name = updated.name;
+      connector.connector_type = updated.connector_type;
+      connector.config = updated.config;
+      header.childNodes[0].nodeValue = `${updated.name} (${updated.connector_type})`;
+    }
+  });
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.className = 'btn btn-sm btn-danger me-2';
+  deleteBtn.textContent = 'Delete';
+  deleteBtn.addEventListener('click', async () => {
+    await deleteConnector(connector.id);
+    card.remove();
+  });
+
+  const testBtn = document.createElement('button');
+  testBtn.className = 'btn btn-sm btn-outline-primary';
+  testBtn.textContent = 'Test';
+  testBtn.addEventListener('click', async () => {
+    const result = await testConnector(connector.id);
+    statusSpan.textContent = result.status;
+  });
+
+  body.appendChild(editBtn);
+  body.appendChild(deleteBtn);
+  body.appendChild(testBtn);
+  card.appendChild(body);
+  return card;
+}

--- a/app/templates/connectors.html
+++ b/app/templates/connectors.html
@@ -1,58 +1,29 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <div id="messageDisplay" class="message-display"></div>
+<h1>Connectors</h1>
 
-
-    <h1>Connectors</h1>
-    Here you can configure your connectors<br/>
-    <div class="connectors">
-        {% for connector in connectors %}
-            <div class="card mb-4 connector">
-                <div class="card-header d-flex justify-content-between align-items-center">
-                    <h2 class="h5 mb-0">{{ connector.name }}</h2>
-                    <button class="btn btn-sm btn-outline-secondary test-connector" data-connector-id="{{ connector.id }}">Test</button>
-                </div>
-                <div class="card-body">
-                    <form method="post" action="/update_connector_settings/{{ connector.id }}">
-                        {% for field in connector.fields %}
-                            {% if field.name != 'password' %}
-                                <div class="mb-3">
-                                    <label class="form-label">{{ field.label }}</label>
-                                    <input class="form-control" type="{{ field.type }}" name="{{ field.name }}" value="{{ field.value }}" {% if field.readonly %}readonly{% endif %}>
-                                </div>
-                            {% endif %}
-                        {% endfor %}
-                        <button class="btn btn-primary" type="submit">Save</button>
-                    </form>
-                    <p class="mt-3 mb-0 text-muted">Last message sent: {{ connector.last_message_sent }}</p>
-                    <div class="form-check mt-2">
-                        <input class="form-check-input" type="checkbox" name="enable_connector" {% if connector.enabled %}checked{% endif %}>
-                        <label class="form-check-label">Enable</label>
-                    </div>
-                </div>
-            </div>
-        {% endfor %}
+<form id="add-connector-form" class="card card-body mb-4">
+  <div class="row g-2 align-items-end">
+    <div class="col-sm">
+      <label for="connector-name" class="form-label">Name</label>
+      <input type="text" id="connector-name" class="form-control" required />
     </div>
-
-    <div class="input-container">
-        <input id="messageInput" type="text" placeholder="Test connectivity">
-        <button id="sendButton">Test</button>
+    <div class="col-sm">
+      <label for="connector-type" class="form-label">Type</label>
+      <input type="text" id="connector-type" class="form-control" required />
     </div>
-    <div class="connector-select-container">
-        <label for="connectorSelect">Connector:</label>
-        <select id="connectorSelect">
-            <option value="webhook">Webhook</option>
-            <option value="irc">IRC</option>
-            <option value="slack">Slack</option>
-            <option value="teams">Microsoft Teams</option>
-            <option value="discord">Discord</option>
-            <option value="google_chat">Google Chat</option>
-            <option value="telegram">Telegram</option>
-        </select>
+    <div class="col-sm">
+      <label for="connector-config" class="form-label">Config (JSON)</label>
+      <input type="text" id="connector-config" class="form-control" />
     </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary">Add Connector</button>
+    </div>
+  </div>
+</form>
 
+<div class="connectors-container"></div>
 
-    <script src="/static/js/script.js"></script>
+<script src="/static/js/connectors.js" defer></script>
 {% endblock %}
-

--- a/tests/test_connector_api.py
+++ b/tests/test_connector_api.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from app import crud
+from app.schemas.connector import ConnectorCreate
+
+
+def test_test_connector_endpoint(test_app: TestClient, db: Session, monkeypatch) -> None:
+    connector = crud.connector.create(db, obj_in=ConnectorCreate(name="irc1", connector_type="irc", config={}))
+
+    class DummyConnector:
+        def is_connected(self):
+            return True
+
+    monkeypatch.setattr("app.app_routes.get_connector", lambda *a, **k: DummyConnector())
+
+    resp = test_app.post(f"/api/connectors/{connector.id}/test")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "up"


### PR DESCRIPTION
## Summary
- render connectors dynamically from API data
- add connector CRUD and test endpoints
- display connector status via new JS
- test connector API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d4790cc48833390801ccfbd92f78e