### PR TITLE
Implement channel and filter management UI

### DIFF
--- a/app/api/api_v1/routers/channels.py
+++ b/app/api/api_v1/routers/channels.py
@@ -13,7 +13,7 @@ router = APIRouter()
 
 # Your endpoints and handlers go here
 
-@router.post("/channels/", response_model=Channel, status_code=status.HTTP_201_CREATED)
+@router.post("/", response_model=Channel, status_code=status.HTTP_201_CREATED)
 async def create_channel(
     channel: ChannelCreate, db: Session = Depends(get_db)
 ):
@@ -23,12 +23,12 @@ async def create_channel(
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-@router.get("/channels/", response_model=List[Channel])
+@router.get("/", response_model=List[Channel])
 async def get_channels(db: Session = Depends(get_db)):
     """Return all channels."""
     return crud.channel.get_multi(db)
 
-@router.get("/channels/{channel_id}", response_model=Channel)
+@router.get("/{channel_id}", response_model=Channel)
 async def get_channel(channel_id: int, db: Session = Depends(get_db)):
     """Return a channel by ID."""
     channel = crud.channel.get(db, channel_id)
@@ -36,7 +36,7 @@ async def get_channel(channel_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Channel not found")
     return channel
 
-@router.put("/channels/{channel_id}", response_model=Channel)
+@router.put("/{channel_id}", response_model=Channel)
 async def update_channel(
     channel_id: int, channel: ChannelUpdate, db: Session = Depends(get_db)
 ):
@@ -46,7 +46,7 @@ async def update_channel(
         raise HTTPException(status_code=404, detail="Channel not found")
     return crud.channel.update(db, db_obj=db_channel, obj_in=channel)
 
-@router.delete("/channels/{channel_id}", response_model=Channel)
+@router.delete("/{channel_id}", response_model=Channel)
 async def delete_channel(channel_id: int, db: Session = Depends(get_db)):
     """Delete a channel."""
     channel = crud.channel.remove(db, channel_id)

--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -1,36 +1,11 @@
 // Add a listener for DOMContentLoaded to make sure the page is fully loaded before running the script
-document.addEventListener("DOMContentLoaded", function () {
-  // Fetch channels and messages from the API
-  fetchChannels();
-  fetchMessages();
-
-  // Add event listeners for channel list items and message form
-  setupChannelList();
-  setupMessageForm();
+document.addEventListener('DOMContentLoaded', () => {
+  fetchChannelsAndRender();
 });
 
-function fetchChannels() {
-  // Fetch the channels from the API and update the UI
-  // ...
-}
-
-function fetchMessages() {
-  // Fetch the messages for the selected channel from the API and update the UI
-  // ...
-}
-
-function setupChannelList() {
-  // Add click event listeners to the channel list items to load messages for the selected channel
-  // ...
-}
-
-function setupMessageForm() {
-  // Add a submit event listener to the message form to send messages through the API
-  // ...
-}
 
 async function fetchChannelsAndRender() {
-  const response = await fetch('/api/v1/channels');
+  const response = await fetch('/api/v1/channels/');
   const channels = await response.json();
 
   const channelsContainer = document.querySelector('.channels-container');
@@ -44,13 +19,13 @@ async function fetchChannelsAndRender() {
 
 
 async function getChannels() {
-  const response = await fetch("/api/v1/channels");
+  const response = await fetch('/api/v1/channels/');
   const channels = await response.json();
   return channels;
 }
 
 async function createChannel(data) {
-  const response = await fetch("/api/v1/channels", {
+  const response = await fetch('/api/v1/channels/', {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -83,22 +58,22 @@ function createChannelElement(channel) {
   const channelElement = document.createElement("div");
   channelElement.classList.add("channel");
 
-  const nameElement = document.createElement("p");
+  const nameElement = document.createElement('p');
   nameElement.textContent = `Name: ${channel.name}`;
 
-  const descriptionElement = document.createElement("p");
-  descriptionElement.textContent = `Description: ${channel.description}`;
+  const connectorElement = document.createElement('p');
+  connectorElement.textContent = `Connector ID: ${channel.connector_id}`;
 
   const editButton = document.createElement("button");
   editButton.textContent = "Edit";
   editButton.addEventListener("click", async () => {
-    const newName = prompt("Enter the new channel name:", channel.name);
-    const newDescription = prompt("Enter the new channel description:", channel.description);
+    const newName = prompt('Enter the new channel name:', channel.name);
+    const newConnector = prompt('Connector ID:', channel.connector_id);
 
-    if (newName && newDescription) {
-      const updatedChannel = await updateChannel(channel.id, { name: newName, description: newDescription });
+    if (newName && newConnector) {
+      const updatedChannel = await updateChannel(channel.id, { name: newName, connector_id: parseInt(newConnector, 10) });
       nameElement.textContent = `Name: ${updatedChannel.name}`;
-      descriptionElement.textContent = `Description: ${updatedChannel.description}`;
+      connectorElement.textContent = `Connector ID: ${updatedChannel.connector_id}`;
     }
   });
 
@@ -110,29 +85,28 @@ function createChannelElement(channel) {
   });
 
   channelElement.appendChild(nameElement);
-  channelElement.appendChild(descriptionElement);
+  channelElement.appendChild(connectorElement);
   channelElement.appendChild(editButton);
   channelElement.appendChild(deleteButton);
 
   return channelElement;
 }
 
-document.getElementById("add-channel-form").addEventListener("submit", async (event) => {
+document.getElementById('add-channel-form').addEventListener('submit', async (event) => {
   event.preventDefault();
 
-  const nameInput = document.getElementById("channel-name");
-  const descriptionInput = document.getElementById("channel-description");
+  const nameInput = document.getElementById('channel-name');
+  const connectorInput = document.getElementById('channel-connector');
 
   const channelData = {
     name: nameInput.value,
-    description: descriptionInput.value,
+    connector_id: parseInt(connectorInput.value, 10),
   };
 
   const newChannel = await createChannel(channelData);
-  document.querySelector(".channels-container").appendChild(createChannelElement(newChannel));
+  document.querySelector('.channels-container').appendChild(createChannelElement(newChannel));
 
-  nameInput.value = "";
-  descriptionInput.value = "";
+  nameInput.value = '';
 });
 
 (async () => {

--- a/app/templates/channels.html
+++ b/app/templates/channels.html
@@ -13,11 +13,11 @@
             <h2 class="h5">Add a Channel</h2>
             <form id="add-channel-form" class="row g-2 align-items-end">
                 <div class="col-sm">
-                    <input type="text" id="channelName" class="form-control" placeholder="Channel name">
+                    <input type="text" id="channel-name" class="form-control" placeholder="Channel name" required>
                 </div>
                 <div class="col-sm">
-                    <label for="connectorSelect" class="form-label">Connector</label>
-                    <select class="form-select" id="connectorSelect">
+                    <label for="channel-connector" class="form-label">Connector</label>
+                    <select class="form-select" id="channel-connector">
                         <option value="webhook">Webhook</option>
                         <option value="irc">IRC</option>
                         <option value="slack">Slack</option>
@@ -34,11 +34,11 @@
         </div>
     </div>
 
-    <div class="channels-list">
-        <!-- Display the list of channels here -->
+    <div class="channels-container">
+        <!-- Channels will be listed here -->
     </div>
 
-    <script src="/static/js/script.js"></script>
+    <script src="{{ url_for('static', filename='js/channels.js') }}" defer></script>
 {% endblock %}
 
 

--- a/app/templates/filters.html
+++ b/app/templates/filters.html
@@ -14,8 +14,12 @@
 <form id="add-filter-form" class="card card-body mb-4">
   <div class="row g-2 align-items-end">
     <div class="col-sm">
-      <label for="filter-name" class="form-label">Filter Name</label>
-      <input type="text" id="filter-name" class="form-control" required />
+      <label for="filter-channel" class="form-label">Channel</label>
+      <select id="filter-channel" class="form-select"></select>
+    </div>
+    <div class="col-sm">
+      <label for="filter-regex" class="form-label">Regex</label>
+      <input type="text" id="filter-regex" class="form-control" required />
     </div>
     <div class="col-sm">
       <label for="filter-description" class="form-label">Description</label>
@@ -30,10 +34,7 @@
 <div class="filters-container">
   <!-- Filters will be dynamically added here -->
 </div>
-{% endblock %}
-
-{% block extra_js %}
-<script src="{{ url_for('static', filename='js/filters.js') }}"></script>
+<script src="{{ url_for('static', filename='js/filters.js') }}" defer></script>
 {% endblock %}
 
 


### PR DESCRIPTION
## Summary
- enable `/api/v1/channels` CRUD routes
- build channel listing and creation UI
- build filter listing and creation UI
- update JS to call new APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d4796a8c48333adb8fe0ecefca9b3