### PR TITLE
Improve bot UI with edit modal and sliders

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from fastapi import APIRouter, Depends, Request, HTTPException
 from fastapi import status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -121,6 +121,7 @@ async def create_message_endpoint(
     bot_id: int,
     request: Request,
     history_limit: int = 10,
+    response_tokens: Optional[int] = None,
     db: Session = Depends(get_async_db),
 ):
     try:
@@ -149,10 +150,11 @@ async def create_message_endpoint(
             # remove the oldest user/assistant message
             messages.pop(1)
 
+        max_tokens = response_tokens or bot.default_response_tokens
         interaction_response = await create_chat_interaction(
             model=bot.gpt_model,
             messages=messages,
-            max_tokens=bot.default_response_tokens
+            max_tokens=max_tokens
         )
 
         # Create an interaction schema

--- a/app/templates/TODO.md
+++ b/app/templates/TODO.md
@@ -3,15 +3,15 @@
 ## bots.html
 
 1. Implement markdown for UI screens. Currently facing a library include issue.
-2. Make the input box multiline and more like the openai chatgpt window.
+2. ~~Make the input box multiline and more like the openai chatgpt window.~~
 3. Make bots on the left side smaller and easily identifiable, including some kind of highlight on click.
-4. Disable the send button until a bot is selected.
-5. Add edit mode from the same area as delete. Edit mode should pop up a modal with the bot details.
-6. Add a warning alert when the delete bot is clicked.
+4. ~~Disable the send button until a bot is selected.~~
+5. ~~Add edit mode from the same area as delete. Edit mode should pop up a modal with the bot details.~~
+6. ~~Add a warning alert when the delete bot is clicked.~~
 7. Make the "search bots" dialog functional and collapsible by default.
-8. Add sliders for controlling:
-   - The number of messages of history used for the prompt.
-   - The amount of response to generate.
+8. ~~Add sliders for controlling:~~
+   - ~~The number of messages of history used for the prompt.~~
+   - ~~The amount of response to generate.~~
 
 ## connectors.html
 

--- a/app/templates/bots.html
+++ b/app/templates/bots.html
@@ -37,45 +37,50 @@
     <div class="messages-container">
       <!-- Messages will be dynamically added here -->
     </div>
-    <div class="input-message-container">
-  <textarea id="input-message" rows="1" placeholder="Pick a bot..." disabled></textarea>
 
-  <button id="send-message" disabled>Send</button>
-  <div id="spinner" class="spinner" style="display: none;"></div>
-</div>
+    <div class="controls my-3">
+      <label for="history-depth" class="form-label">History Depth: <span id="history-depth-value">10</span></label>
+      <input type="range" class="form-range" id="history-depth" min="1" max="50" value="10">
+      <label for="response-length" class="form-label mt-2">Response Length: <span id="response-length-value">150</span></label>
+      <input type="range" class="form-range" id="response-length" min="50" max="500" value="150">
+    </div>
+
+    <div class="input-message-container">
+      <textarea id="input-message" rows="1" placeholder="Pick a bot..." disabled></textarea>
+      <button id="send-message" disabled>Send</button>
+      <div id="spinner" class="spinner" style="display: none;"></div>
+    </div>
 
   </div>
 </div>
 
-<script>
-
-
-var textarea = document.getElementById('input-message');
-
-textarea.addEventListener('input', () => {
-  // Temporarily set the height to 'auto' so the scrollHeight property will give us the full height of the content
-  textarea.style.height = 'auto';
-
-  // Now set the height to the content's full height (but not more than max-height)
-  // The 'Math.min' part is not necessary if you don't have a max-height
-  textarea.style.height = Math.min(textarea.scrollHeight, 300) + 'px';
-});
-textarea.dispatchEvent(new Event('input'));
-
-
-var sendButton = document.getElementById("send-message");
-    textarea.oninput = function() {
-        var lines = textarea.value.split('\n');
-        for (var i = 0; i < lines.length; i++) {
-            if (lines[i] === "" && lines[i+1] === "") {
-                textarea.value = lines.slice(0, i+1).join('\n');
-		    sendButton.click();
-            }
-        }
-    };
-
-
-</script>
+<!-- Edit Bot Modal -->
+<div class="modal fade" id="editBotModal" tabindex="-1" aria-labelledby="editBotModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="editBotModalLabel">Edit Bot</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="edit-bot-form">
+          <div class="mb-3">
+            <label for="edit-bot-name" class="form-label">Name</label>
+            <input type="text" class="form-control" id="edit-bot-name" required>
+          </div>
+          <div class="mb-3">
+            <label for="edit-bot-description" class="form-label">Description</label>
+            <input type="text" class="form-control" id="edit-bot-description">
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="save-edit-bot">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 <script src="/static/js/marked.min.js" defer></script>
 <script src="/static/js/bots.js" defer></script>


### PR DESCRIPTION
## Summary
- allow multiline chat input with Enter-to-send behavior
- disable Send until a bot is chosen
- add edit modal and deletion confirmation
- add sliders to control prompt history depth and response length
- expose response token slider via API
- mark completed tasks in TODO
- fix send button initialization and move UI handlers to `bots.js`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d4795a4f88333ae356f917f89d952