### PR TITLE
Fix logging for openai handler

### DIFF
--- a/app/handlers/openai_handler.py
+++ b/app/handlers/openai_handler.py
@@ -42,7 +42,7 @@ async def create_chat_interaction(
         return response
 
     except Exception as e:
-        print(f"Failed to create chat interaction: {e}")
+        logger.error("Failed to create chat interaction: %s", e)
         # create a fake interaction if we forget to include the handle Key
         '''
         Failed to create chat interaction: No API key provided. You can set your API key in code using 'openai.api_key = <API-KEY>', or you can set the environment variable OPENAI_API_KEY=<API-KEY>). If your API key is stored in a file, you can point the openai module at it with 'openai.api_key_path = <PATH>'. You can generate API keys in the OpenAI web interface. See https://platform.openai.com/account/api-keys for details.


### PR DESCRIPTION
## Summary
- use the configured logger when chat creation fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d4e9e04d48333959120fab7d90413