### PR TITLE
Add session pool comment and cleanup test

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -9,6 +9,8 @@ engine = create_engine(
     poolclass=QueuePool,
     pool_size=settings.database_pool_size,
     max_overflow=settings.database_max_overflow,
+    pool_pre_ping=True,
+    # TODO: explore enabling WAL mode or other SQLite optimizations
     connect_args={"check_same_thread": False}
     if settings.database_url.startswith("sqlite")
     else {},

--- a/tests/test_db_session.py
+++ b/tests/test_db_session.py
@@ -32,3 +32,18 @@ def test_sqlite_check_same_thread():
         connect_args = db_session.engine.pool._creator.__closure__[1].cell_contents
         assert connect_args.get("check_same_thread") is False
 
+
+def test_session_connection_cleanup():
+    spec = importlib.util.spec_from_file_location(
+        "temp_db_session", os.path.join("app", "db", "session.py")
+    )
+    db_session = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(db_session)
+    engine = db_session.engine
+    start_checked_out = engine.pool.checkedout()
+    session = db_session.SessionLocal()
+    session.execute("SELECT 1")
+    assert engine.pool.checkedout() == start_checked_out + 1
+    session.close()
+    assert engine.pool.checkedout() == start_checked_out
+


### PR DESCRIPTION
## Summary
- add `pool_pre_ping` and note about future SQLite WAL mode
- test that sessions release connections back to the pool

## Testing
- `pytest -k db_session -q`

------
https://chatgpt.com/codex/tasks/task_e_683d4ea3c30483339713426915bd2d2b