### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: python
-          package-name: norman


### PR DESCRIPTION
## Summary
- fix release workflow: remove old action and package-name input
- add required permissions for release PR creation

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_683d5a5cd200833383b4444214d64ad2