### PR TITLE
Enable WAL mode for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ source env/bin/activate
 pip install -r requirements.txt
 ```
 
+Norman automatically enables [WAL](https://www.sqlite.org/wal.html) mode when using SQLite for improved concurrency.
+
 4. Run Norman once to automatically generate `config.yaml` with secure defaults.
    Afterwards edit this file to configure connectors and add your OpenAI API key.
 

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,4 +1,5 @@
-from sqlalchemy import create_engine
+import os
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
@@ -15,4 +16,13 @@ engine = create_engine(
     if settings.database_url.startswith("sqlite")
     else {},
 )
+
+if settings.database_url.startswith("sqlite"):
+    # Ensure the SQLite database directory exists before connecting
+    db_path = engine.url.database
+    if db_path and db_path != ":memory:":
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    with engine.connect() as conn:
+        conn.execute(text("PRAGMA journal_mode=WAL"))
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/tests/test_db_session.py
+++ b/tests/test_db_session.py
@@ -33,6 +33,18 @@ def test_sqlite_check_same_thread():
         assert connect_args.get("check_same_thread") is False
 
 
+def test_sqlite_wal_enabled():
+    spec = importlib.util.spec_from_file_location(
+        "temp_db_session", os.path.join("app", "db", "session.py")
+    )
+    db_session = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(db_session)
+    if settings.database_url.startswith("sqlite"):
+        with db_session.engine.connect() as conn:
+            mode = conn.execute(db_session.text("PRAGMA journal_mode")).scalar().lower()
+        assert mode == "wal"
+
+
 def test_session_connection_cleanup():
     spec = importlib.util.spec_from_file_location(
         "temp_db_session", os.path.join("app", "db", "session.py")


### PR DESCRIPTION
## Summary
- enable SQLite WAL mode for improved concurrency
- verify WAL is enabled in db session tests
- mention WAL optimization in README
- ensure DB directory exists before connecting

## Testing
- `coverage run -m pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_683d57af0f7083338c5d66f1b7718452