### PR TITLE
Improve connector status detection

### DIFF
--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -2,19 +2,21 @@ import sys
 import types
 
 # Provide a minimal slack_sdk stub if the real package isn't installed
-if 'slack_sdk' not in sys.modules:
-    slack_sdk = types.ModuleType('slack_sdk')
+if "slack_sdk" not in sys.modules:
+    slack_sdk = types.ModuleType("slack_sdk")
 
     class DummyClient:
         def __init__(self, token=None):
             self.token = token
+
         def auth_test(self):
-            return {'ok': True}
+            return {"ok": True}
+
     slack_sdk.WebClient = DummyClient
-    errors_mod = types.ModuleType('slack_sdk.errors')
+    errors_mod = types.ModuleType("slack_sdk.errors")
     slack_sdk.errors = errors_mod
-    sys.modules['slack_sdk'] = slack_sdk
-    sys.modules['slack_sdk.errors'] = errors_mod
+    sys.modules["slack_sdk"] = slack_sdk
+    sys.modules["slack_sdk.errors"] = errors_mod
 
 from app.connectors.connector_utils import get_connector, get_connectors_data
 from app.connectors.slack_connector import SlackConnector
@@ -56,306 +58,440 @@ from app.core.test_settings import test_settings
 
 
 def test_get_connector_returns_slack(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('slack')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("slack")
     assert isinstance(connector, SlackConnector)
 
 
 def test_get_connector_returns_signal(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('signal')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("signal")
     assert isinstance(connector, SignalConnector)
 
 
 def test_get_connector_returns_rest_callback(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('rest_callback')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("rest_callback")
     assert isinstance(connector, RESTCallbackConnector)
 
+
 def test_get_connector_returns_mcp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('mcp')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("mcp")
     assert isinstance(connector, MCPConnector)
+
+
 def test_get_connector_returns_smtp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('smtp')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("smtp")
     assert isinstance(connector, SMTPConnector)
 
 
 def test_get_connector_returns_mqtt(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('mqtt')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("mqtt")
     assert isinstance(connector, MQTTConnector)
 
 
 def test_get_connector_returns_mastodon(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('mastodon')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("mastodon")
     assert isinstance(connector, MastodonConnector)
 
 
 def test_get_connector_returns_sms(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('sms')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("sms")
     assert isinstance(connector, SMSConnector)
 
 
 def test_get_connector_returns_steam_chat(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('steam_chat')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("steam_chat")
     assert isinstance(connector, SteamChatConnector)
 
 
 def test_get_connector_returns_xmpp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('xmpp')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("xmpp")
     assert isinstance(connector, XMPPConnector)
 
 
 def test_get_connector_returns_bluesky(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('bluesky')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("bluesky")
     assert isinstance(connector, BlueskyConnector)
 
 
 def test_get_connector_returns_facebook_messenger(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('facebook_messenger')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("facebook_messenger")
     assert isinstance(connector, FacebookMessengerConnector)
 
 
 def test_get_connector_returns_linkedin(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('linkedin')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("linkedin")
     assert isinstance(connector, LinkedInConnector)
 
 
 def test_get_connector_returns_skype(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('skype')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("skype")
     assert isinstance(connector, SkypeConnector)
 
 
 def test_get_connector_returns_rocketchat(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('rocketchat')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("rocketchat")
     assert isinstance(connector, RocketChatConnector)
 
 
 def test_get_connector_returns_mattermost(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('mattermost')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("mattermost")
     assert isinstance(connector, MattermostConnector)
 
 
 def test_get_connector_returns_wechat(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('wechat')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("wechat")
     assert isinstance(connector, WeChatConnector)
 
 
 def test_get_connector_returns_reddit_chat(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('reddit_chat')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("reddit_chat")
     assert isinstance(connector, RedditChatConnector)
 
 
 def test_get_connector_returns_instagram_dm(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('instagram_dm')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("instagram_dm")
     assert isinstance(connector, InstagramDMConnector)
 
 
 def test_get_connector_returns_twitter(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('twitter')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("twitter")
     assert isinstance(connector, TwitterConnector)
 
 
 def test_get_connector_returns_imessage(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('imessage')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("imessage")
     assert isinstance(connector, IMessageConnector)
 
 
 def test_get_connector_returns_aprs(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('aprs')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("aprs")
     from app.connectors.aprs_connector import APRSConnector
+
     assert isinstance(connector, APRSConnector)
 
 
 def test_get_connector_returns_ax25(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('ax25')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("ax25")
     from app.connectors.ax25_connector import AX25Connector
+
     assert isinstance(connector, AX25Connector)
 
 
 def test_get_connector_returns_zapier(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('zapier')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("zapier")
     from app.connectors.zapier_connector import ZapierConnector
+
     assert isinstance(connector, ZapierConnector)
 
 
 def test_get_connector_returns_ifttt(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('ifttt')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("ifttt")
     from app.connectors.ifttt_connector import IFTTTConnector
+
     assert isinstance(connector, IFTTTConnector)
 
 
 def test_get_connector_returns_salesforce(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('salesforce')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("salesforce")
     from app.connectors.salesforce_connector import SalesforceConnector
+
     assert isinstance(connector, SalesforceConnector)
 
 
 def test_get_connector_returns_github(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('github')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("github")
     from app.connectors.github_connector import GitHubConnector
+
     assert isinstance(connector, GitHubConnector)
 
 
 def test_get_connector_returns_jira_service_desk(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('jira_service_desk')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("jira_service_desk")
     from app.connectors.jira_service_desk_connector import JiraServiceDeskConnector
+
     assert isinstance(connector, JiraServiceDeskConnector)
 
 
 def test_get_connector_returns_tap_snpp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('tap_snpp')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("tap_snpp")
     from app.connectors.tap_snpp_connector import TAPSNPPConnector
+
     assert isinstance(connector, TAPSNPPConnector)
 
 
 def test_get_connector_returns_acars(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('acars')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("acars")
     from app.connectors.acars_connector import ACARSConnector
+
     assert isinstance(connector, ACARSConnector)
 
 
 def test_get_connector_returns_rfc5425(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('rfc5425')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("rfc5425")
     assert isinstance(connector, RFC5425Connector)
 
 
 def test_get_connectors_data_missing_config(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
     data = get_connectors_data()
-    assert all(item['status'] == 'missing_config' for item in data)
-    slack_data = next(item for item in data if item['id'] == 'slack')
-    assert slack_data['status'] == 'missing_config'
+    assert all(item["status"] == "missing_config" for item in data)
+    slack_data = next(item for item in data if item["id"] == "slack")
+    assert slack_data["status"] == "missing_config"
+
+
+def test_get_connectors_data_status_up(monkeypatch):
+    from app.core.config import load_config, Settings
+
+    config = load_config()
+    config["connectors"] = [
+        {"type": "slack", "token": "x", "channel_id": "C1", "config": {}}
+    ]
+    settings = Settings(**config)
+
+    monkeypatch.setattr("app.connectors.connector_utils.get_settings", lambda: settings)
+    monkeypatch.setattr(
+        "app.connectors.slack_connector.SlackConnector.is_connected", lambda self: True
+    )
+
+    data = get_connectors_data()
+    slack_data = next(item for item in data if item["id"] == "slack")
+    assert slack_data["status"] == "up"
+
 
 def test_get_connector_returns_aws_iot_core(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('aws_iot_core')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("aws_iot_core")
     assert isinstance(connector, AWSIoTCoreConnector)
 
 
 def test_get_connector_returns_aws_eventbridge(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('aws_eventbridge')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("aws_eventbridge")
     assert isinstance(connector, AWSEventBridgeConnector)
 
 
 def test_get_connector_returns_google_pubsub(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('google_pubsub')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("google_pubsub")
     assert isinstance(connector, GooglePubSubConnector)
 
 
 def test_get_connector_returns_azure_eventgrid(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('azure_eventgrid')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("azure_eventgrid")
     assert isinstance(connector, AzureEventGridConnector)
 
 
 def test_get_connector_returns_amqp(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('amqp')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("amqp")
     from app.connectors.amqp_connector import AMQPConnector
+
     assert isinstance(connector, AMQPConnector)
 
 
 def test_get_connector_returns_redis_pubsub(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('redis_pubsub')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("redis_pubsub")
     from app.connectors.redis_pubsub_connector import RedisPubSubConnector
+
     assert isinstance(connector, RedisPubSubConnector)
 
 
 def test_get_connector_returns_kafka(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('kafka')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("kafka")
     assert isinstance(connector, KafkaConnector)
 
 
 def test_get_connector_returns_nats(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('nats')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("nats")
     assert isinstance(connector, NATSConnector)
 
 
 def test_get_connector_returns_pagerduty(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('pagerduty')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("pagerduty")
     assert isinstance(connector, PagerDutyConnector)
 
 
 def test_get_connector_returns_line(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('line')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("line")
     assert isinstance(connector, LineConnector)
 
 
 def test_get_connector_returns_viber(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('viber')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("viber")
     assert isinstance(connector, ViberConnector)
 
 
 def test_get_connector_returns_coap_oscore(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('coap_oscore')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("coap_oscore")
     assert isinstance(connector, CoAPOSCOREConnector)
 
 
 def test_get_connector_returns_opcua_pubsub(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('opcua_pubsub')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("opcua_pubsub")
     assert isinstance(connector, OPCUAPubSubConnector)
 
 
 def test_get_connector_returns_ais_safety_text(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('ais_safety_text')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("ais_safety_text")
     assert isinstance(connector, AISSafetyTextConnector)
 
 
 def test_get_connector_returns_cap(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('cap')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("cap")
     assert isinstance(connector, CAPConnector)
 
 
 def test_get_connector_returns_zulip(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
-    connector = get_connector('zulip')
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
+    connector = get_connector("zulip")
     from app.connectors.zulip_connector import ZulipConnector
+
     assert isinstance(connector, ZulipConnector)
 
 
 def test_get_configured_connectors_none(monkeypatch):
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: test_settings)
+    monkeypatch.setattr(
+        "app.connectors.connector_utils.get_settings", lambda: test_settings
+    )
     from app.connectors.connector_utils import get_configured_connectors
+
     assert get_configured_connectors() == {}
 
 
@@ -364,10 +500,10 @@ def test_get_configured_connectors_with_slack(monkeypatch):
     from app.connectors.connector_utils import get_configured_connectors
 
     config = load_config()
-    config['connectors'] = [{"type": "slack", "token": 'x', "channel_id": 'C1'}]
+    config["connectors"] = [{"type": "slack", "token": "x", "channel_id": "C1"}]
     settings = Settings(**config)
 
-    monkeypatch.setattr('app.connectors.connector_utils.get_settings', lambda: settings)
+    monkeypatch.setattr("app.connectors.connector_utils.get_settings", lambda: settings)
     connectors = get_configured_connectors()
-    assert 'slack' in connectors
-    assert isinstance(connectors['slack'][0], SlackConnector)
+    assert "slack" in connectors
+    assert isinstance(connectors["slack"][0], SlackConnector)


### PR DESCRIPTION
## Summary
- check connector health in `get_connectors_data`
- add regression test for configured connector status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d660062fc833396b9cb2960a3e652