### PR TITLE
Implement Discord polling

### DIFF
--- a/app/connectors/discord_connector.py
+++ b/app/connectors/discord_connector.py
@@ -1,7 +1,8 @@
 """Simple Discord connector using the HTTP API."""
 
+import asyncio
 import httpx
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
@@ -18,6 +19,7 @@ class DiscordConnector(BaseConnector):
         super().__init__(config)
         self.token = token
         self.channel_id = channel_id
+        self._last_message_id: Optional[str] = None
 
     async def send_message(self, message: str) -> Optional[str]:
         """Send ``message`` to the configured Discord channel."""
@@ -34,13 +36,44 @@ class DiscordConnector(BaseConnector):
                 logger.error("Error sending Discord message: %s", exc)
                 return None
 
+    async def _get_messages(self, after: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Return recent messages from the configured Discord channel."""
+        url = f"https://discord.com/api/v9/channels/{self.channel_id}/messages"
+        headers = {"Authorization": f"Bot {self.token}"}
+        params = {"limit": 50}
+        if after:
+            params["after"] = after
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, headers=headers, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
     async def listen_and_process(self) -> None:
-        """Listening for Discord messages is not implemented."""
-        return None
+        """Poll for new Discord messages and process them."""
+        while True:
+            try:
+                messages = await self._get_messages(after=self._last_message_id)
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                logger.error("Error fetching Discord messages: %s", exc)
+                await asyncio.sleep(5)
+                continue
+
+            for msg in reversed(messages):
+                self._last_message_id = msg.get("id", self._last_message_id)
+                result = self.process_incoming(msg)
+                if asyncio.iscoroutine(result):
+                    await result
+
+            await asyncio.sleep(5)
 
     async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
-        """Return the raw ``message`` payload."""
-        return message
+        """Extract basic fields from a Discord message payload."""
+        return {
+            "id": message.get("id"),
+            "text": message.get("content", ""),
+            "user": message.get("author", {}).get("username"),
+            "channel": message.get("channel_id", self.channel_id),
+        }
 
     def is_connected(self) -> bool:
         """Return ``True`` if the API token appears valid."""

--- a/docs/connectors/discord.md
+++ b/docs/connectors/discord.md
@@ -38,7 +38,7 @@ Replace the values with the appropriate information for your Discord server and 
 
 ## Usage
 
-Once you have configured the Discord connector, Norman will connect to the specified Discord server and channels, and start listening for incoming messages. When a message is received, Norman will process it according to the configured channel filters and actions, and send a response back to the Discord channel.
+Once you have configured the Discord connector, Norman will poll the specified Discord channel for new messages. Incoming messages are processed according to your configured filters and actions, and a response is sent back to the channel when appropriate. Polling occurs every few seconds using the Discord HTTP API.
 
 ## Troubleshooting
 

--- a/tests/connectors/test_discord.py
+++ b/tests/connectors/test_discord.py
@@ -51,11 +51,21 @@ def test_send_message_error(monkeypatch):
 
 def test_process_incoming():
     connector = DiscordConnector("TOKEN", "CHAN")
-    payload = {"foo": "bar"}
+    payload = {
+        "id": "1",
+        "content": "hello",
+        "author": {"username": "bob"},
+        "channel_id": "CHAN",
+    }
     result = asyncio.get_event_loop().run_until_complete(
         connector.process_incoming(payload)
     )
-    assert result == payload
+    assert result == {
+        "id": "1",
+        "text": "hello",
+        "user": "bob",
+        "channel": "CHAN",
+    }
 
 
 class DummyGetResponse:


### PR DESCRIPTION
## Summary
- implement message polling in Discord connector
- parse Discord payloads for sender and channel info
- document how Discord polling works
- update Discord connector tests

## Testing
- `pytest tests/connectors/test_discord.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6efa2cfc8333ba4c7e3ca451f7be