### PR TITLE
Enhance WhatsApp connector

### DIFF
--- a/app/connectors/whatsapp_connector.py
+++ b/app/connectors/whatsapp_connector.py
@@ -60,3 +60,14 @@ class WhatsAppConnector(BaseConnector):
         # Code to process the incoming message, including applying filters
         # and calling the appropriate action(s)
         return message
+
+    def is_connected(self) -> bool:
+        """Return ``True`` if the Twilio credentials appear valid."""
+
+        url = f"https://api.twilio.com/2010-04-01/Accounts/{self.account_sid}.json"
+        try:
+            resp = httpx.get(url, auth=(self.account_sid, self.auth_token))
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            return False

--- a/docs/connectors/whatsapp.md
+++ b/docs/connectors/whatsapp.md
@@ -30,6 +30,10 @@ The fields are:
 
 After configuration, Norman can send messages via Twilio to WhatsApp and process incoming messages.
 
+The connector also checks the Twilio Account API at startup to verify your
+credentials. If the credentials are invalid, the connector will appear as
+"down" in the connectors status list.
+
 ## Troubleshooting
 
 1. Confirm the Twilio credentials are correct.

--- a/tests/connectors/test_whatsapp.py
+++ b/tests/connectors/test_whatsapp.py
@@ -55,3 +55,18 @@ def test_process_incoming():
         connector.process_incoming(payload)
     )
     assert result == payload
+
+
+def test_is_connected_success(monkeypatch):
+    monkeypatch.setattr(httpx, "get", lambda url, auth=None: DummyResponse())
+    connector = WhatsAppConnector("SID", "TOKEN", "+1", "+2")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    def raise_err(url, auth=None):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "get", raise_err)
+    connector = WhatsAppConnector("SID", "TOKEN", "+1", "+2")
+    assert not connector.is_connected()


### PR DESCRIPTION
## Summary
- add `is_connected` implementation to the WhatsApp connector
- document how the connector verifies Twilio credentials
- test health check logic

## Testing
- `pytest -q tests/connectors/test_whatsapp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6f01fea883339ac8466c5e596cde