### PR TITLE
Improve AWS EventBridge connector

### DIFF
--- a/app/connectors/aws_eventbridge_connector.py
+++ b/app/connectors/aws_eventbridge_connector.py
@@ -37,6 +37,16 @@ class AWSEventBridgeConnector(BaseConnector):
         }
         return self.client.put_events(Entries=[entry])
 
+    def is_connected(self) -> bool:
+        """Return ``True`` if the configured event bus is reachable."""
+        if not boto3:
+            return False
+        try:
+            self.client.describe_event_bus(Name=self.event_bus_name)
+            return True
+        except Exception:  # pragma: no cover - network/permission issues
+            return False
+
     async def listen_and_process(self) -> None:
         """EventBridge does not support listening for messages."""
         return None

--- a/docs/connectors/aws_eventbridge.md
+++ b/docs/connectors/aws_eventbridge.md
@@ -19,3 +19,7 @@ aws_eventbridge_event_bus_name: "default"
 ## Usage
 
 Incoming messages are not supported. The connector only publishes events.
+
+The connector checks connectivity by calling `DescribeEventBus` on startup when
+`is_connected()` is invoked. If the credentials or event bus are incorrect, this
+method returns `False`.

--- a/tests/connectors/test_aws_eventbridge.py
+++ b/tests/connectors/test_aws_eventbridge.py
@@ -7,9 +7,14 @@ import app.connectors.aws_eventbridge_connector as mod
 class DummyClient:
     def __init__(self):
         self.entries = None
+        self.ok = True
     def put_events(self, Entries=None):
         self.entries = Entries
         return {"ok": True}
+    def describe_event_bus(self, Name=None):
+        if self.ok:
+            return {}
+        raise Exception("error")
 
 
 def test_send_message_success(monkeypatch):
@@ -25,4 +30,21 @@ def test_send_message_no_boto3(monkeypatch):
     connector = mod.AWSEventBridgeConnector(region="us", event_bus_name="bus")
     with pytest.raises(RuntimeError):
         asyncio.get_event_loop().run_until_complete(connector.send_message({}))
+
+
+def test_is_connected_success(monkeypatch):
+    client = DummyClient()
+    stub = types.SimpleNamespace(client=lambda service, region_name=None: client)
+    monkeypatch.setattr(mod, "boto3", stub)
+    connector = mod.AWSEventBridgeConnector(region="us", event_bus_name="bus")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    client = DummyClient()
+    client.ok = False
+    stub = types.SimpleNamespace(client=lambda service, region_name=None: client)
+    monkeypatch.setattr(mod, "boto3", stub)
+    connector = mod.AWSEventBridgeConnector(region="us", event_bus_name="bus")
+    assert not connector.is_connected()
 


### PR DESCRIPTION
## Summary
- implement `is_connected` check in AWS EventBridge connector
- document connectivity check
- test connector connectivity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6f14a5788333ab4829465c07fec1