### PR TITLE
Improve Intercom connector status check

### DIFF
--- a/docs/connectors/intercom.md
+++ b/docs/connectors/intercom.md
@@ -12,4 +12,6 @@ intercom_app_id: "your_app_id"
 ## Usage
 
 The connector posts simple in-app messages to Intercom. Incoming
-message support has not been added.
+message support has not been added.  Norman now verifies the access
+token by hitting the `/me` endpoint, so your connector status will
+show **up** only when the credentials are valid.


### PR DESCRIPTION
## Summary
- add helper for Intercom auth headers
- validate Intercom credentials via `/me`
- test connection status logic
- document token verification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6f264a8c8333915379356279a7a4