### PR TITLE
Implement persisted dark mode

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -145,13 +145,18 @@ textarea {
 }
 
 
+html.dark-mode,
 body.dark-mode {
     background-color: #121212;
     color: #f8f9fa;
 }
+html.dark-mode a,
 body.dark-mode a { color: #f8f9fa; }
+html.dark-mode .navbar,
 body.dark-mode .navbar,
+html.dark-mode footer,
 body.dark-mode footer,
+html.dark-mode .card,
 body.dark-mode .card {
     background-color: #1e1e1e;
     color: #f8f9fa;

--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -1,17 +1,19 @@
 document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.getElementById('themeToggle');
   if (!toggle) return;
-  const darkPref = localStorage.getItem('darkMode') === 'true';
-  setTheme(darkPref);
-  toggle.checked = darkPref;
+  const storedTheme = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const isDark = storedTheme ? storedTheme === 'dark' : prefersDark;
+  setTheme(isDark);
+  toggle.checked = isDark;
   toggle.addEventListener('change', () => setTheme(toggle.checked));
 });
 
 function setTheme(dark) {
   if (dark) {
-    document.body.classList.add('dark-mode');
+    document.documentElement.classList.add('dark-mode');
   } else {
-    document.body.classList.remove('dark-mode');
+    document.documentElement.classList.remove('dark-mode');
   }
-  localStorage.setItem('darkMode', dark);
+  localStorage.setItem('theme', dark ? 'dark' : 'light');
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Norman</title>
+    <script>
+        (function() {
+            var theme = localStorage.getItem('theme');
+            if (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                theme = 'dark';
+            }
+            if (theme === 'dark') {
+                document.documentElement.classList.add('dark-mode');
+            }
+        })();
+    </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/css/styles.css">
 </head>


### PR DESCRIPTION
## Summary
- store theme choice in `localStorage` as `theme`
- apply theme before CSS loads so there's no flash of unstyled content
- fall back to `prefers-color-scheme` when no theme is set
- update styles to support applying `.dark-mode` to `<html>`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d75040f888333bf9e0ff171887c55