### PR TITLE
Add streaming placeholder for GPT responses

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -156,3 +156,27 @@ body.dark-mode .card {
     background-color: #1e1e1e;
     color: #f8f9fa;
 }
+
+/* Placeholder shimmer effect */
+.placeholder-message {
+  position: relative;
+  overflow: hidden;
+  background-color: #e0e0e0;
+  border-radius: 0.25rem;
+  margin-bottom: 1rem;
+}
+.placeholder-message::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -150px;
+  width: 150px;
+  height: 100%;
+  background: linear-gradient(90deg, rgba(255,255,255,0), rgba(255,255,255,0.4), rgba(255,255,255,0));
+  animation: placeholder-shimmer 1.2s infinite;
+}
+@keyframes placeholder-shimmer {
+  0% { left: -150px; }
+  100% { left: 100%; }
+}
+

--- a/app/static/js/bots.js
+++ b/app/static/js/bots.js
@@ -70,6 +70,12 @@ document.addEventListener('DOMContentLoaded', () => {
     spinner.style.display = 'inline-block';
 
     if (selectedBotNameElement.innerText !== 'None' && content) {
+      const messagesContainer = document.querySelector('.messages-container');
+      const placeholder = document.createElement('div');
+      placeholder.className = 'message assistant placeholder-message';
+      placeholder.style.height = textarea.scrollHeight + 'px';
+      messagesContainer.appendChild(placeholder);
+      messagesContainer.scrollTop = messagesContainer.scrollHeight;
       const bot_id = selectedBotNameElement.dataset.botId;
       await sendMessage(bot_id, content);
       textarea.value = '';


### PR DESCRIPTION
## Summary
- show skeleton placeholder while waiting for a streamed GPT reply
- style placeholder with shimmering animation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d74fca5b88333b8f45877fcb2c0ab