### PR TITLE
Add paginated messages and React infinite scroll

### DIFF
--- a/alembic/versions/7ef8edb950cb_add_created_at_index.py
+++ b/alembic/versions/7ef8edb950cb_add_created_at_index.py
@@ -1,0 +1,23 @@
+"""add created_at index
+
+Revision ID: 7ef8edb950cb
+Revises: fdfa37da0489
+Create Date: 2024-08-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '7ef8edb950cb'
+down_revision = 'fdfa37da0489'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('ix_messages_created_at', 'messages', ['created_at'])
+
+
+def downgrade():
+    op.drop_index('ix_messages_created_at', table_name='messages')

--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -109,11 +109,13 @@ async def get_messages_endpoint(
     bot_id: int,
     limit: int = 100,
     offset: int = 0,
+    cursor: int | None = None,
     db: Session = Depends(get_async_db),
 ):
     """Return messages for a bot with optional pagination."""
     try:
-        messages = get_messages_by_bot_id(db=db, bot_id=bot_id, limit=limit, offset=offset)
+        cursor_int = cursor
+        messages = get_messages_by_bot_id(db=db, bot_id=bot_id, limit=limit, offset=offset, cursor=cursor_int)
         return [Message.from_orm(message).dict() for message in messages]
     except Exception as e:
         print("Error:", e)

--- a/app/crud/message.py
+++ b/app/crud/message.py
@@ -20,10 +20,13 @@ def get_messages_by_bot_id(
     *,
     limit: Optional[int] = None,
     offset: Optional[int] = None,
+    cursor: Optional[int] = None,
 ) -> List[Message]:
     """Return messages for a bot with optional pagination."""
 
     query = db.query(Message).filter(Message.bot_id == bot_id).order_by(Message.created_at)
+    if cursor is not None:
+        query = query.filter(Message.id > cursor)
     if offset is not None:
         query = query.offset(offset)
     if limit is not None:

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -11,7 +11,7 @@ class Message(Base):
     #user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     source = Column(String, nullable=False, server_default='user')  # 'user', 'assistant', or 'system'
     bot_id = Column(Integer, ForeignKey("bots.id"), nullable=False)
-    created_at = Column(DateTime, default=func.now(), nullable=False)
+    created_at = Column(DateTime, default=func.now(), nullable=False, index=True)
 
 
 

--- a/frontend/InfiniteMessages.jsx
+++ b/frontend/InfiniteMessages.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useInfiniteQuery } from 'react-query';
+
+export default function InfiniteMessages({ botId }) {
+  const fetchMessages = async ({ pageParam = null }) => {
+    const params = new URLSearchParams();
+    if (pageParam) params.set('cursor', pageParam);
+    params.set('limit', 20);
+    const resp = await fetch(`/api/bots/${botId}/messages?` + params.toString());
+    if (!resp.ok) throw new Error('Error fetching messages');
+    return resp.json();
+  };
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    status,
+  } = useInfiniteQuery(['messages', botId], fetchMessages, {
+    getNextPageParam: (lastPage) => {
+      if (lastPage.length === 0) return undefined;
+      return lastPage[lastPage.length - 1].created_at;
+    },
+  });
+
+  const observer = React.useRef();
+  const lastMessageRef = React.useCallback(
+    (node) => {
+      if (isFetchingNextPage) return;
+      if (observer.current) observer.current.disconnect();
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNextPage) {
+          fetchNextPage();
+        }
+      });
+      if (node) observer.current.observe(node);
+    },
+    [isFetchingNextPage, fetchNextPage, hasNextPage]
+  );
+
+  if (status === 'loading') return <p>Loading...</p>;
+  if (status === 'error') return <p>Error loading messages</p>;
+
+  return (
+    <div>
+      {data.pages.map((page, pageIndex) => (
+        <React.Fragment key={pageIndex}>
+          {page.map((msg, i) => {
+            if (pageIndex === data.pages.length - 1 && i === page.length - 1) {
+              return (
+                <div ref={lastMessageRef} key={msg.id} className="message">
+                  {msg.text}
+                </div>
+              );
+            }
+            return (
+              <div key={msg.id} className="message">
+                {msg.text}
+              </div>
+            );
+          })}
+        </React.Fragment>
+      ))}
+      {isFetchingNextPage && <p>Loading more...</p>}
+    </div>
+  );
+}

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -33,3 +33,15 @@ def test_create_message_flow(monkeypatch, test_app: TestClient):
     assert len(messages) == 2
     assert messages[0]["text"] == "hello"
     assert messages[1]["text"] == "assistant reply"
+
+    # pagination with limit and cursor
+    resp = test_app.get(f"/api/bots/{bot_id}/messages?limit=1")
+    assert resp.status_code == 200
+    first_page = resp.json()
+    assert len(first_page) == 1
+    cursor = first_page[0]["id"]
+
+    resp = test_app.get(f"/api/bots/{bot_id}/messages?cursor={cursor}")
+    assert resp.status_code == 200
+    next_page = resp.json()
+    assert len(next_page) == 1


### PR DESCRIPTION
## Summary
- add index to `Message.created_at`
- support `cursor` and `limit` params when fetching messages
- migration for the new index
- infinite scroll example using React Query
- test pagination with cursor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d751ff53c8333a7efb24fb8165ec0