### PR TITLE
Cache connector status in Redis

### DIFF
--- a/app/core/redis_cache.py
+++ b/app/core/redis_cache.py
@@ -1,0 +1,28 @@
+try:
+    import redis
+except ImportError:  # pragma: no cover - optional dependency
+    redis = None
+
+from app.core.config import settings
+
+_redis_client = None
+
+
+def get_redis_client():
+    """Return a cached Redis client instance or ``None`` if unavailable."""
+    global _redis_client
+    if not redis:
+        return None
+    if _redis_client is None:
+        _redis_client = redis.Redis(
+            host=settings.redis_host,
+            port=settings.redis_port,
+            decode_responses=True,
+        )
+    return _redis_client
+
+
+def set_redis_client(client):
+    """Override the global Redis client (used in tests)."""
+    global _redis_client
+    _redis_client = client

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ openai
 tiktoken
 paho-mqtt
 pika
+redis

--- a/tests/test_connector_api.py
+++ b/tests/test_connector_api.py
@@ -16,3 +16,42 @@ def test_test_connector_endpoint(test_app: TestClient, db: Session, monkeypatch)
     resp = test_app.post(f"/api/connectors/{connector.id}/test")
     assert resp.status_code == 200
     assert resp.json()["status"] == "up"
+
+
+def test_status_endpoint_uses_cache(test_app: TestClient, db: Session, monkeypatch) -> None:
+    connector = crud.connector.create(db, obj_in=ConnectorCreate(name="irc1", connector_type="irc", config={}))
+
+    class DummyConnector:
+        def __init__(self):
+            self.calls = 0
+
+        def is_connected(self):
+            self.calls += 1
+            return True
+
+    dummy_connector = DummyConnector()
+    monkeypatch.setattr("app.app_routes.get_connector", lambda *a, **k: dummy_connector)
+
+    class DummyRedis:
+        def __init__(self):
+            self.store = {}
+
+        def get(self, key):
+            return self.store.get(key)
+
+        def setex(self, key, ttl, value):
+            self.store[key] = value
+
+    dummy_redis = DummyRedis()
+    monkeypatch.setattr("app.app_routes.get_redis_client", lambda: dummy_redis)
+    monkeypatch.setattr("app.app_routes._refresh_status", lambda *a, **k: None)
+
+    resp1 = test_app.get(f"/api/connectors/{connector.id}/status")
+    assert resp1.status_code == 200
+    assert resp1.json()["status"] == "up"
+    assert "timestamp" in resp1.json()
+    assert dummy_connector.calls == 1
+
+    resp2 = test_app.get(f"/api/connectors/{connector.id}/status")
+    assert resp2.status_code == 200
+    assert dummy_connector.calls == 1  # second call served from cache


### PR DESCRIPTION
## Summary
- add redis dependency
- create a helper for reusable redis clients
- cache connector status with a 30-second TTL and refresh in the background
- test that the status endpoint serves cached results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d74ed71508333b2163372d7270489