### PR TITLE
Add webpack multi-entry build for lazy-loaded views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ config.yaml
 # ignore user databases
 db/*.db
 coverage.xml
+node_modules/
+app/static/dist/

--- a/README.md
+++ b/README.md
@@ -85,12 +85,17 @@ chmod +x generate_key.sh
 
 You can also edit `config.yaml` manually to provide your own values. Be sure to add your OpenAI key under `openai_api_key`.
 
-6. Run the application:
+6. Build the frontend assets with Webpack (requires Node.js):
+```bash
+npm install
+npm run build
+```
+7. Run the application:
 ```
 python main.py
 ````
 
-7. Open the API documentation in your browser: [http://localhost:8000/docs](http://localhost:8000/docs)
+8. Open the API documentation in your browser: [http://localhost:8000/docs](http://localhost:8000/docs)
 
 For more information, refer to the [documentation](docs/) and the [contributing guidelines](CONTRIBUTING.md).
 
@@ -118,6 +123,14 @@ pytest --cov=./ -vv
 ## Deployment
 
 Norman can be deployed on various platforms, such as on a local server or a cloud provider. For detailed deployment instructions, please refer to our [Deployment](docs/deployment.md) guide.
+
+## Frontend Bundling
+
+The web UI assets are built using Webpack. The configuration uses multiple entry
+points so the core layout and authentication code are bundled separately from
+rarely used views. Route-level modules like the Settings page and Audit Log are
+lazily loaded via `import()` to keep the initial bundle under 50 kB when
+gzipped. Run `npm run build` to generate the bundles in `app/static/dist`.
 
 ## Architecture
 

--- a/app/templates/audit_log.html
+++ b/app/templates/audit_log.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Audit Log</h1>
+<p>Placeholder audit log page.</p>
+{% endblock %}
+{% block scripts %}
+<script src="/static/dist/views.bundle.js" defer></script>
+<script>
+  document.body.dataset.view = 'audit';
+</script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -55,5 +55,7 @@
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoKMJQ0Z6D9F6EU2ygSABR03SuhDL7z8Zef3CJXTgq1Q0Q" crossorigin="anonymous"></script>
     <script src="/static/js/theme.js"></script>
+    <script src="/static/dist/core.bundle.js" defer></script>
+    {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Settings</h1>
+<p>Placeholder settings page.</p>
+{% endblock %}
+{% block scripts %}
+<script src="/static/dist/views.bundle.js" defer></script>
+<script>
+  document.body.dataset.view = 'settings';
+</script>
+{% endblock %}

--- a/frontend/core/auth.js
+++ b/frontend/core/auth.js
@@ -1,0 +1,3 @@
+export function initAuth() {
+  console.log('Auth initialized');
+}

--- a/frontend/core/index.js
+++ b/frontend/core/index.js
@@ -1,0 +1,17 @@
+import { initLayout } from './layout';
+import { initAuth } from './auth';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initLayout();
+  initAuth();
+});
+
+// Lazy-load route specific views
+export function loadView(name) {
+  if (name === 'settings') {
+    return import('../views/settings').then(m => m.initSettings());
+  }
+  if (name === 'audit') {
+    return import('../views/audit-log').then(m => m.initAudit());
+  }
+}

--- a/frontend/core/layout.js
+++ b/frontend/core/layout.js
@@ -1,0 +1,3 @@
+export function initLayout() {
+  console.log('Layout initialized');
+}

--- a/frontend/views/audit-log.js
+++ b/frontend/views/audit-log.js
@@ -1,0 +1,3 @@
+export function initAudit() {
+  console.log('Audit log view loaded');
+}

--- a/frontend/views/index.js
+++ b/frontend/views/index.js
@@ -1,0 +1,8 @@
+import { loadView } from '../core/index';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const view = document.body.dataset.view;
+  if (view) {
+    loadView(view);
+  }
+});

--- a/frontend/views/settings.js
+++ b/frontend/views/settings.js
@@ -1,0 +1,3 @@
+export function initSettings() {
+  console.log('Settings view loaded');
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "norman-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "webpack --mode production"
+  },
+  "devDependencies": {
+    "webpack": "^5.91.0",
+    "webpack-cli": "^5.1.4"
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+module.exports = {
+  entry: {
+    core: path.resolve(__dirname, 'frontend/core/index.js'),
+    views: path.resolve(__dirname, 'frontend/views/index.js'),
+  },
+  output: {
+    filename: '[name].bundle.js',
+    path: path.resolve(__dirname, 'app/static/dist'),
+    publicPath: '/static/dist/',
+    clean: true,
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- setup webpack with separate `core` and `views` entries
- add simple frontend modules demonstrating dynamic import
- load the core bundle from the base template
- provide new placeholder pages that lazy load settings and audit log logic
- document how to build the frontend
- ignore build artifacts and node modules

## Testing
- `pytest -q`
- `npm install` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683d74f7356c8333af77cadfd1c2ad75