### PR TITLE
Switch to env-based settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SECRET_KEY=super_secret_key_change_me
+INITIAL_ADMIN_PASSWORD=change_me_too
+INITIAL_ADMIN_EMAIL=admin@example.com
+INITIAL_ADMIN_USERNAME=admin
+DATABASE_URL=sqlite:///./db/norman.db

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -11,9 +11,17 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    env:
+      AWS_SECRET_ID: ${{ secrets.AWS_SECRET_ID }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
+      - name: Load secrets
+        if: env.AWS_SECRET_ID != ''
+        run: |
+          aws secretsmanager get-secret-value --secret-id "$AWS_SECRET_ID" --query SecretString --output text > .env
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -73,17 +73,16 @@ pip install -r requirements.txt
 
 Norman automatically enables [WAL](https://www.sqlite.org/wal.html) mode when using SQLite for improved concurrency.
 
-4. Run Norman once to automatically generate `config.yaml` with secure defaults.
-   Afterwards edit this file to configure connectors and add your OpenAI API key.
+4. Copy `.env.example` to `.env` and adjust the values for your environment.
 
-5. (Optional) Regenerate the secrets in `config.yaml` using the provided script:
+5. (Optional) Regenerate the secrets in `.env` using the provided script:
 
 ```
 chmod +x generate_key.sh
 ./generate_key.sh
 ```
 
-You can also edit `config.yaml` manually to provide your own values. Be sure to add your OpenAI key under `openai_api_key`.
+You can also edit `.env` manually to provide your own values. Be sure to add your OpenAI key under `OPENAI_API_KEY`.
 
 6. Run the application:
 ```
@@ -93,6 +92,13 @@ python main.py
 7. Open the API documentation in your browser: [http://localhost:8000/docs](http://localhost:8000/docs)
 
 For more information, refer to the [documentation](docs/) and the [contributing guidelines](CONTRIBUTING.md).
+
+### Using AWS Secrets Manager
+
+When deploying with Docker or GitHub Actions you can provide `AWS_SECRET_ID` and
+`AWS_REGION` environment variables. The provided `docker-compose.yml` and CI
+workflow will fetch secrets from AWS Secrets Manager and write them to `.env` at
+runtime.
 
 ## Usage
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,12 +5,12 @@ import logging
 
 # should this move to schemas?
 class Settings(BaseSettings):
-    secret_key: str
-    app_name: str
-    debug: bool
+    secret_key: Optional[str] = "super_secret_key_change_me"
+    app_name: Optional[str] = None
+    debug: bool = False
     log_level: str = "INFO"
-    api_version: str
-    api_prefix: str
+    api_version: Optional[str] = None
+    api_prefix: Optional[str] = None
 
     # initial admin
     initial_admin_email: str = "admin@example.com"
@@ -18,168 +18,168 @@ class Settings(BaseSettings):
     initial_admin_username: str = "admin"
 
     # Connectors
-    telegram_token: str
-    telegram_chat_id: str
-    slack_token: str
-    slack_channel_id: str
-    google_chat_service_account_key_path: str
-    google_chat_space: str
-    discord_token: str
-    discord_channel_id: str
-    teams_app_id: str
-    teams_app_password: str
-    teams_tenant_id: str
-    teams_bot_endpoint: str
-    webhook_secret: str
-    whatsapp_account_sid: str
-    whatsapp_auth_token: str
-    whatsapp_from_number: str
-    whatsapp_to_number: str
-    sms_account_sid: str
-    sms_auth_token: str
-    sms_from_number: str
-    sms_to_number: str
-    signal_service_url: str
-    signal_phone_number: str
-    matrix_homeserver: str
-    matrix_user_id: str
-    matrix_access_token: str
-    matrix_room_id: str
-    twitch_token: str
-    twitch_nickname: str
-    twitch_channel: str
-    twitch_server: str
-    twitch_port: int
-    rest_callback_url: str
-    mcp_api_url: str
-    mcp_api_key: str
-    smtp_host: str
-    smtp_port: int
-    smtp_username: str
-    smtp_password: str
-    smtp_from_address: str
-    smtp_to_address: str
-    mqtt_host: str
+    telegram_token: Optional[str] = None
+    telegram_chat_id: Optional[str] = None
+    slack_token: Optional[str] = None
+    slack_channel_id: Optional[str] = None
+    google_chat_service_account_key_path: Optional[str] = None
+    google_chat_space: Optional[str] = None
+    discord_token: Optional[str] = None
+    discord_channel_id: Optional[str] = None
+    teams_app_id: Optional[str] = None
+    teams_app_password: Optional[str] = None
+    teams_tenant_id: Optional[str] = None
+    teams_bot_endpoint: Optional[str] = None
+    webhook_secret: Optional[str] = None
+    whatsapp_account_sid: Optional[str] = None
+    whatsapp_auth_token: Optional[str] = None
+    whatsapp_from_number: Optional[str] = None
+    whatsapp_to_number: Optional[str] = None
+    sms_account_sid: Optional[str] = None
+    sms_auth_token: Optional[str] = None
+    sms_from_number: Optional[str] = None
+    sms_to_number: Optional[str] = None
+    signal_service_url: Optional[str] = None
+    signal_phone_number: Optional[str] = None
+    matrix_homeserver: Optional[str] = None
+    matrix_user_id: Optional[str] = None
+    matrix_access_token: Optional[str] = None
+    matrix_room_id: Optional[str] = None
+    twitch_token: Optional[str] = None
+    twitch_nickname: Optional[str] = None
+    twitch_channel: Optional[str] = None
+    twitch_server: Optional[str] = None
+    twitch_port: Optional[int] = None
+    rest_callback_url: Optional[str] = None
+    mcp_api_url: Optional[str] = "your_mcp_api_url"
+    mcp_api_key: Optional[str] = "your_mcp_api_key"
+    smtp_host: Optional[str] = None
+    smtp_port: Optional[int] = None
+    smtp_username: Optional[str] = None
+    smtp_password: Optional[str] = None
+    smtp_from_address: Optional[str] = None
+    smtp_to_address: Optional[str] = None
+    mqtt_host: Optional[str] = None
     mqtt_port: int = 1883
-    mqtt_topic: str
-    mqtt_username: str
-    mqtt_password: str
-    mastodon_base_url: str
-    mastodon_access_token: str
-    steam_chat_token: str
-    steam_chat_id: str
-    xmpp_jid: str
-    xmpp_password: str
-    xmpp_server: str
-    bluesky_handle: str
-    bluesky_app_password: str
-    facebook_page_token: str
-    facebook_verify_token: str
-    linkedin_access_token: str
-    skype_app_id: str
-    skype_app_password: str
-    rocketchat_url: str
-    rocketchat_token: str
-    rocketchat_user_id: str
-    mattermost_url: str
-    mattermost_token: str
-    mattermost_channel_id: str
-    wechat_app_id: str
-    wechat_app_secret: str
-    reddit_client_id: str
-    reddit_client_secret: str
-    reddit_username: str
-    reddit_password: str
-    reddit_user_agent: str
-    instagram_access_token: str
-    instagram_user_id: str
-    twitter_api_key: str
-    twitter_api_secret: str
-    twitter_access_token: str
-    twitter_access_token_secret: str
-    xcom_api_key: str
-    xcom_api_secret: str
-    xcom_access_token: str
-    xcom_access_token_secret: str
-    imessage_service_url: str
-    imessage_phone_number: str
-    aprs_host: str
-    aprs_port: int
-    aprs_callsign: str
-    aprs_passcode: str
-    ax25_port: str
-    ax25_callsign: str
-    zapier_webhook_url: str
-    ifttt_webhook_url: str
-    salesforce_instance_url: str
-    salesforce_access_token: str
-    salesforce_endpoint: str
-    github_token: str
-    github_repo: str
-    gitter_token: str
-    gitter_room_id: str
-    jira_service_desk_url: str
-    jira_service_desk_email: str
-    jira_service_desk_api_token: str
-    jira_service_desk_project_key: str
-    tap_snpp_host: str
-    tap_snpp_port: int
-    tap_snpp_password: str
-    acars_host: str
-    acars_port: int
-    rfc5425_host: str
-    rfc5425_port: int
-    aws_eventbridge_region: str
-    aws_eventbridge_event_bus_name: str
-    aws_iot_core_region: str
-    aws_iot_core_topic: str
-    aws_iot_core_endpoint: str
-    aws_iot_core_client_id: str
-    aws_iot_core_cert_path: str
-    aws_iot_core_key_path: str
-    aws_iot_core_ca_path: str
-    azure_eventgrid_endpoint: str
-    azure_eventgrid_key: str
-    google_pubsub_project_id: str
-    google_pubsub_topic_id: str
-    google_pubsub_credentials_path: str
-    amqp_url: str
-    amqp_queue: str
-    redis_host: str
-    redis_port: int
-    redis_channel: str
-    kafka_bootstrap_servers: str
-    kafka_topic: str
-    nats_servers: str
-    nats_subject: str
-    pagerduty_routing_key: str
-    line_channel_access_token: str
-    line_user_id: str
-    viber_auth_token: str
-    viber_receiver: str
-    coap_oscore_host: str
-    coap_oscore_port: int
-    opcua_pubsub_endpoint: str
-    ais_host: str
-    ais_port: int
-    cap_endpoint: str
-    google_business_access_token: str
-    google_business_phone_number: str
-    apple_business_access_token: str
-    apple_business_sender_id: str
-    intercom_access_token: str
-    intercom_app_id: str
-    snmp_host: str
-    snmp_port: int
-    snmp_community: str
-    tox_bootstrap_host: str
-    tox_bootstrap_port: int
-    tox_friend_id: str
-    zulip_email: str
-    zulip_api_key: str
-    zulip_site_url: str
-    zulip_stream: str
-    zulip_topic: str
+    mqtt_topic: Optional[str] = None
+    mqtt_username: Optional[str] = None
+    mqtt_password: Optional[str] = None
+    mastodon_base_url: Optional[str] = "https://mastodon.example.com"
+    mastodon_access_token: Optional[str] = "your_mastodon_token"
+    steam_chat_token: Optional[str] = None
+    steam_chat_id: Optional[str] = None
+    xmpp_jid: Optional[str] = None
+    xmpp_password: Optional[str] = None
+    xmpp_server: Optional[str] = None
+    bluesky_handle: Optional[str] = None
+    bluesky_app_password: Optional[str] = None
+    facebook_page_token: Optional[str] = None
+    facebook_verify_token: Optional[str] = None
+    linkedin_access_token: Optional[str] = None
+    skype_app_id: Optional[str] = None
+    skype_app_password: Optional[str] = None
+    rocketchat_url: Optional[str] = "your_rocketchat_url"
+    rocketchat_token: Optional[str] = "your_rocketchat_token"
+    rocketchat_user_id: Optional[str] = "your_rocketchat_user_id"
+    mattermost_url: Optional[str] = "your_mattermost_url"
+    mattermost_token: Optional[str] = "your_mattermost_token"
+    mattermost_channel_id: Optional[str] = "your_mattermost_channel_id"
+    wechat_app_id: Optional[str] = None
+    wechat_app_secret: Optional[str] = None
+    reddit_client_id: Optional[str] = None
+    reddit_client_secret: Optional[str] = None
+    reddit_username: Optional[str] = None
+    reddit_password: Optional[str] = None
+    reddit_user_agent: Optional[str] = None
+    instagram_access_token: Optional[str] = None
+    instagram_user_id: Optional[str] = None
+    twitter_api_key: Optional[str] = None
+    twitter_api_secret: Optional[str] = None
+    twitter_access_token: Optional[str] = None
+    twitter_access_token_secret: Optional[str] = None
+    xcom_api_key: Optional[str] = None
+    xcom_api_secret: Optional[str] = None
+    xcom_access_token: Optional[str] = None
+    xcom_access_token_secret: Optional[str] = None
+    imessage_service_url: Optional[str] = None
+    imessage_phone_number: Optional[str] = None
+    aprs_host: Optional[str] = None
+    aprs_port: Optional[int] = None
+    aprs_callsign: Optional[str] = None
+    aprs_passcode: Optional[str] = None
+    ax25_port: Optional[str] = None
+    ax25_callsign: Optional[str] = None
+    zapier_webhook_url: Optional[str] = None
+    ifttt_webhook_url: Optional[str] = None
+    salesforce_instance_url: Optional[str] = "your_salesforce_instance_url"
+    salesforce_access_token: Optional[str] = "your_salesforce_access_token"
+    salesforce_endpoint: Optional[str] = "your_salesforce_endpoint"
+    github_token: Optional[str] = None
+    github_repo: Optional[str] = None
+    gitter_token: Optional[str] = None
+    gitter_room_id: Optional[str] = None
+    jira_service_desk_url: Optional[str] = "https://your-domain.atlassian.net"
+    jira_service_desk_email: Optional[str] = "your_email@example.com"
+    jira_service_desk_api_token: Optional[str] = "your_jira_api_token"
+    jira_service_desk_project_key: Optional[str] = "PROJ"
+    tap_snpp_host: Optional[str] = None
+    tap_snpp_port: Optional[int] = None
+    tap_snpp_password: Optional[str] = None
+    acars_host: Optional[str] = None
+    acars_port: Optional[int] = None
+    rfc5425_host: Optional[str] = None
+    rfc5425_port: Optional[int] = None
+    aws_eventbridge_region: Optional[str] = None
+    aws_eventbridge_event_bus_name: Optional[str] = None
+    aws_iot_core_region: Optional[str] = None
+    aws_iot_core_topic: Optional[str] = None
+    aws_iot_core_endpoint: Optional[str] = None
+    aws_iot_core_client_id: Optional[str] = None
+    aws_iot_core_cert_path: Optional[str] = None
+    aws_iot_core_key_path: Optional[str] = None
+    aws_iot_core_ca_path: Optional[str] = None
+    azure_eventgrid_endpoint: Optional[str] = None
+    azure_eventgrid_key: Optional[str] = None
+    google_pubsub_project_id: Optional[str] = None
+    google_pubsub_topic_id: Optional[str] = None
+    google_pubsub_credentials_path: Optional[str] = None
+    amqp_url: Optional[str] = None
+    amqp_queue: Optional[str] = None
+    redis_host: Optional[str] = None
+    redis_port: Optional[int] = None
+    redis_channel: Optional[str] = None
+    kafka_bootstrap_servers: Optional[str] = None
+    kafka_topic: Optional[str] = None
+    nats_servers: Optional[str] = None
+    nats_subject: Optional[str] = None
+    pagerduty_routing_key: Optional[str] = None
+    line_channel_access_token: Optional[str] = None
+    line_user_id: Optional[str] = None
+    viber_auth_token: Optional[str] = None
+    viber_receiver: Optional[str] = None
+    coap_oscore_host: Optional[str] = None
+    coap_oscore_port: Optional[int] = None
+    opcua_pubsub_endpoint: Optional[str] = None
+    ais_host: Optional[str] = None
+    ais_port: Optional[int] = None
+    cap_endpoint: Optional[str] = None
+    google_business_access_token: Optional[str] = None
+    google_business_phone_number: Optional[str] = None
+    apple_business_access_token: Optional[str] = None
+    apple_business_sender_id: Optional[str] = None
+    intercom_access_token: Optional[str] = None
+    intercom_app_id: Optional[str] = None
+    snmp_host: Optional[str] = None
+    snmp_port: Optional[int] = None
+    snmp_community: Optional[str] = None
+    tox_bootstrap_host: Optional[str] = None
+    tox_bootstrap_port: Optional[int] = None
+    tox_friend_id: Optional[str] = None
+    zulip_email: Optional[str] = "your_zulip_email"
+    zulip_api_key: Optional[str] = "your_zulip_api_key"
+    zulip_site_url: Optional[str] = "https://zulip.example.com"
+    zulip_stream: Optional[str] = "your_zulip_stream"
+    zulip_topic: Optional[str] = "your_zulip_topic"
     connectors: List[Dict[str, Any]] = []
     broadcast_connectors: str = ""
     openai_api_key: Optional[str]
@@ -190,19 +190,19 @@ class Settings(BaseSettings):
     microsoft_client_id: str = ""
     microsoft_client_secret: str = ""
 
-    access_token_expire_minutes: int
+    access_token_expire_minutes: Optional[int] = 1440
     algorithm: str = "HS256"
-    encryption_key: str
-    encryption_salt: str
+    encryption_key: Optional[str] = "your_encryption_key"
+    encryption_salt: Optional[str] = "your_encryption_salt"
 
     # Database
-    database_url: str
+    database_url: Optional[str] = "sqlite:///./db/norman.db"
     database_pool_size: int = 5
     database_max_overflow: int = 10
 
     # Server
-    host: str
-    port: int
+    host: Optional[str] = "0.0.0.0"
+    port: Optional[int] = 8000
 
     @validator("secret_key", pre=True)
     def validate_secret_key(cls, v):
@@ -223,7 +223,7 @@ class Settings(BaseSettings):
         if "pytest" in sys.modules:
             return v
         assert v != "change_me_too", (
-            "You must set an admin password in the config.yaml!"
+            "You must set an admin password via environment variables!"
         )
         return v
 
@@ -234,7 +234,7 @@ class Settings(BaseSettings):
         if "pytest" in sys.modules:
             return v
         assert v != "admin@example.com", (
-            "You must set an admin email in the config.yaml!"
+            "You must set an admin email via environment variables!"
         )
         return v
 
@@ -245,7 +245,7 @@ class Settings(BaseSettings):
         if "pytest" in sys.modules:
             return v
         assert v != "admin", (
-            "You must set an admin username in the config.yaml!"
+            "You must set an admin username via environment variables!"
         )
         return v
 
@@ -262,52 +262,8 @@ class Settings(BaseSettings):
         env_file = ".env"
         env_file_encoding = "utf-8"
 
-import os
-import shutil
-import secrets
-import yaml
 
-
-def ensure_user_config():
-    """Create config.yaml with random credentials on first run."""
-    if not os.path.exists("config.yaml"):
-        shutil.copyfile("config.yaml.dist", "config.yaml")
-        with open("config.yaml", "r") as f:
-            cfg = yaml.safe_load(f)
-        cfg["secret_key"] = secrets.token_urlsafe(32)
-        cfg["initial_admin_password"] = secrets.token_urlsafe(12)
-        cfg["initial_admin_email"] = f"admin+{secrets.token_hex(4)}@example.com"
-        cfg["initial_admin_username"] = f"admin_{secrets.token_hex(4)}"
-        cfg["encryption_key"] = secrets.token_urlsafe(32)
-        cfg["encryption_salt"] = secrets.token_urlsafe(16)
-        with open("config.yaml", "w") as f:
-            yaml.safe_dump(cfg, f)
-        print("Generated config.yaml with admin credentials:")
-        print(f"  username: {cfg['initial_admin_username']}")
-        print(f"  email: {cfg['initial_admin_email']}")
-        print(f"  password: {cfg['initial_admin_password']}")
-        print("Edit config.yaml to customize settings, including your OpenAI API key.")
-
-def load_config():
-    ensure_user_config()
-    # Read the config from the dist file
-    with open("config.yaml.dist", "r") as dist_file:
-        config = yaml.safe_load(dist_file)
-    if "connectors" not in config:
-        config["connectors"] = []
-
-    # If the config.yaml file exists, merge its contents with the dist config
-    if os.path.exists("config.yaml"):
-        with open("config.yaml", "r") as custom_file:
-            custom_config = yaml.safe_load(custom_file)
-            config.update(custom_config)
-    if "connectors" not in config:
-        config["connectors"] = []
-
-    return config
-
-config_data = load_config()
-settings = Settings(**config_data)
+settings = Settings()
 
 def get_settings() -> Settings:
     return settings

--- a/app/core/test_settings.py
+++ b/app/core/test_settings.py
@@ -1,5 +1,5 @@
 # app/core/test_settings.py
-from app.core.config import Settings, load_config
+from app.core.config import Settings
 
 __all__ = ["TestSettings", "test_settings"]
 __test__ = False
@@ -9,9 +9,5 @@ class TestSettings(Settings):
     class Config(Settings.Config):
         env_prefix = ""
 
-test_defaults = load_config()
-test_defaults["connectors"] = []
-test_settings = Settings(
-    **{**test_defaults, "database_url": "sqlite:///./db/test.db"}
-)
+test_settings = TestSettings(database_url="sqlite:///./db/test.db")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  norman:
+    image: python:3.8
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: bash -c "if [ -n \"$AWS_SECRET_ID\" ]; then aws secretsmanager get-secret-value --secret-id $AWS_SECRET_ID --query SecretString --output text > .env; fi && python main.py"
+    env_file:
+      - .env
+    environment:
+      - AWS_SECRET_ID
+      - AWS_REGION

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -79,13 +79,10 @@ To use a specific connector, you'll need to provide the necessary configuration 
 
 ### Configuration
 
-You'll need to update the `config.yaml` file with the appropriate settings for the connector you want to use. The required settings may vary depending on the platform. Here's an example of what the configuration for a Slack connector might look like:
+You'll need to update your environment variables with the appropriate settings for the connector you want to use. The required settings may vary depending on the platform. Here's an example of what the configuration for a Slack connector might look like in `.env`:
 
-```yaml
-connectors:
-  - type: "slack"
-    token: "your-slack-bot-token"
-    channel: "your-slack-channel"
+```bash
+CONNECTORS='[{"type": "slack", "token": "your-slack-bot-token", "channel_id": "your-slack-channel"}]'
 ```
 
 For other connectors, consult the platform-specific documentation for information on obtaining the necessary credentials and configuring the connector.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,8 +53,11 @@ Before deploying Norman, ensure that your server meets the following requirement
 
 ## Configuration
 
-1. Run Norman once to automatically create `config.yaml` with secure defaults.
-   Edit this file to configure the required settings, such as the database connection string and API keys.
+1. Copy `.env.example` to `.env` and adjust the values for your deployment.
+   You can manage these variables with AWS Secrets Manager in production.
+
+2. The included `docker-compose.yml` will automatically pull secrets from AWS if
+   `AWS_SECRET_ID` and `AWS_REGION` are provided in the environment.
 
 ## Running the Application
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,14 +4,14 @@ This page walks through a small end‑to‑end example and shows how to interact
 
 ## Slack Bot Quick Start
 
-1. Run Norman once to generate `config.yaml` and edit the Slack section:
+1. Copy `.env.example` to `.env` and edit the Slack variables:
 
 ```yaml
 slack_token: "xoxb-your-slack-token"
 slack_channel_id: "C01234567"
 ```
 
-2. Set your `openai_api_key` in `config.yaml` and optionally regenerate the secrets:
+2. Set your `OPENAI_API_KEY` in `.env` and optionally regenerate the secrets:
 
 ```bash
 chmod +x generate_key.sh
@@ -24,7 +24,7 @@ chmod +x generate_key.sh
 python main.py
 ```
 
-4. Visit `http://localhost:8000` and log in with the admin credentials from `config.yaml`.
+4. Visit `http://localhost:8000` and log in with the admin credentials from `.env`.
 5. Create a chatbot in the Web UI and select the Slack connector. Messages sent to the configured channel will be processed by the bot.
 
 ## API Examples

--- a/generate_key.sh
+++ b/generate_key.sh
@@ -1,28 +1,29 @@
 #!/bin/bash
 
-# Utility script to generate configuration secrets. Each key is 32 random
-# alphanumeric characters. Existing values can be replaced interactively.
+# Utility script to generate configuration secrets in the .env file. Each key is
+# 32 random alphanumeric characters. Existing values can be replaced
+# interactively.
 
 generate_and_set() {
   local name="$1"
   local value=$(tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 32 | head -n 1)
 
-  if grep -q "${name}:" config.yaml; then
-    echo "A ${name} is already present in the config.yaml file."
+  if grep -q "^${name}=" .env; then
+    echo "${name} already exists in .env"
     echo "Note: Updating the ${name} may cause loss of old data."
     read -p "Are you sure you want to update the ${name}? (y/n): " confirm
     case "${confirm}" in
       y|Y)
-        sed -i "s/${name}:.*/${name}: \"${value}\"/" config.yaml
-        echo "${name} has been updated in config.yaml"
+        sed -i "s/^${name}=.*$/${name}=${value}/" .env
+        echo "${name} updated in .env"
         ;;
       *)
         echo "${name} update has been cancelled."
         ;;
     esac
   else
-    echo "${name}: \"${value}\"" >> config.yaml
-    echo "${name} has been set in config.yaml"
+    echo "${name}=${value}" >> .env
+    echo "${name} added to .env"
   fi
 }
 

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -344,13 +344,11 @@ def test_get_connectors_data_missing_config(monkeypatch):
 
 
 def test_get_connectors_data_status_up(monkeypatch):
-    from app.core.config import load_config, Settings
+    from app.core.config import Settings
 
-    config = load_config()
-    config["connectors"] = [
+    settings = Settings(connectors=[
         {"type": "slack", "token": "x", "channel_id": "C1", "config": {}}
-    ]
-    settings = Settings(**config)
+    ])
 
     monkeypatch.setattr("app.connectors.connector_utils.get_settings", lambda: settings)
     monkeypatch.setattr(
@@ -506,12 +504,10 @@ def test_get_configured_connectors_none(monkeypatch):
 
 
 def test_get_configured_connectors_with_slack(monkeypatch):
-    from app.core.config import load_config, Settings
+    from app.core.config import Settings
     from app.connectors.connector_utils import get_configured_connectors
 
-    config = load_config()
-    config["connectors"] = [{"type": "slack", "token": "x", "channel_id": "C1"}]
-    settings = Settings(**config)
+    settings = Settings(connectors=[{"type": "slack", "token": "x", "channel_id": "C1"}])
 
     monkeypatch.setattr("app.connectors.connector_utils.get_settings", lambda: settings)
     connectors = get_configured_connectors()

--- a/tests/test_init_connectors.py
+++ b/tests/test_init_connectors.py
@@ -6,7 +6,7 @@ from app.connectors import init_connectors
 from app.connectors.connector_utils import connector_classes
 from app.core.test_settings import test_settings
 from app.connectors.slack_connector import SlackConnector
-from app.core.config import Settings, load_config
+from app.core.config import Settings
 
 # Provide a minimal slack_sdk stub if the real package isn't installed
 if 'slack_sdk' not in sys.modules:
@@ -36,9 +36,7 @@ def test_init_connectors_adds_placeholders(monkeypatch):
 
 
 def test_init_connectors_with_slack(monkeypatch):
-    config = load_config()
-    config["connectors"] = [{"type": "slack", "token": "x", "channel_id": "C1"}]
-    settings = Settings(**config)
+    settings = Settings(connectors=[{"type": "slack", "token": "x", "channel_id": "C1"}])
 
     monkeypatch.setattr("app.connectors.get_settings", lambda: settings)
     monkeypatch.setattr("app.connectors.connector_utils.get_settings", lambda: settings)


### PR DESCRIPTION
## Summary
- load configuration from environment rather than YAML
- adjust test helpers to use new settings
- update docs for `.env` usage
- update GitHub Actions and provide docker-compose example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7508678c83339791b811a99eeadd