### PR TITLE
Implement async http checks with retries

### DIFF
--- a/app/connectors/discord_connector.py
+++ b/app/connectors/discord_connector.py
@@ -3,6 +3,7 @@
 import asyncio
 import httpx
 from typing import Any, Dict, Optional, List
+from app.core.http_utils import async_get
 
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
@@ -75,13 +76,12 @@ class DiscordConnector(BaseConnector):
             "channel": message.get("channel_id", self.channel_id),
         }
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         """Return ``True`` if the API token appears valid."""
         url = "https://discord.com/api/v9/users/@me"
         headers = {"Authorization": f"Bot {self.token}"}
         try:
-            resp = httpx.get(url, headers=headers)
-            resp.raise_for_status()
+            await async_get(url, headers=headers)
             return True
         except httpx.HTTPError:
             return False

--- a/app/connectors/intercom_connector.py
+++ b/app/connectors/intercom_connector.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, Optional
 import httpx
+from app.core.http_utils import async_get
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
 
@@ -48,13 +49,12 @@ class IntercomConnector(BaseConnector):
     async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
         return message
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         """Return ``True`` if the API token appears valid."""
 
         url = "https://api.intercom.io/me"
         try:
-            resp = httpx.get(url, headers=self._headers())
-            resp.raise_for_status()
+            await async_get(url, headers=self._headers())
             return True
         except httpx.HTTPError:
             return False

--- a/app/connectors/mastodon_connector.py
+++ b/app/connectors/mastodon_connector.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional
 
 import httpx
+from app.core.http_utils import async_get
 
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
@@ -56,13 +57,12 @@ class MastodonConnector(BaseConnector):
     async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
         return message
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         """Return ``True`` if the access token is valid."""
 
         url = f"{self.base_url}/api/v1/accounts/verify_credentials"
         try:
-            resp = httpx.get(url, headers=self._headers())
-            resp.raise_for_status()
+            await async_get(url, headers=self._headers())
             return True
         except httpx.HTTPError:
             return False

--- a/app/connectors/matrix_connector.py
+++ b/app/connectors/matrix_connector.py
@@ -2,6 +2,7 @@
 
 import httpx
 from typing import Any, Dict, Optional
+from app.core.http_utils import async_get
 
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
@@ -42,14 +43,13 @@ class MatrixConnector(BaseConnector):
         """Return the incoming ``message`` payload."""
         return message
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         """Return ``True`` if the access token is valid."""
 
         url = f"{self.homeserver}/_matrix/client/v3/account/whoami"
         headers = {"Authorization": f"Bearer {self.access_token}"}
         try:
-            resp = httpx.get(url, headers=headers)
-            resp.raise_for_status()
+            await async_get(url, headers=headers)
             return True
         except httpx.HTTPError:
             return False

--- a/app/connectors/mattermost_connector.py
+++ b/app/connectors/mattermost_connector.py
@@ -1,5 +1,6 @@
 import httpx
 from typing import Any, Dict, Optional
+from app.core.http_utils import async_get
 
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
@@ -44,14 +45,13 @@ class MattermostConnector(BaseConnector):
         """Return the incoming ``message`` payload."""
         return message
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         """Return ``True`` if the token appears valid."""
 
         api_url = f"{self.url}/api/v4/users/me"
         headers = {"Authorization": f"Bearer {self.token}"}
         try:
-            resp = httpx.get(api_url, headers=headers)
-            resp.raise_for_status()
+            await async_get(api_url, headers=headers)
             return True
         except httpx.HTTPError:
             return False

--- a/app/connectors/rocketchat_connector.py
+++ b/app/connectors/rocketchat_connector.py
@@ -2,6 +2,7 @@
 
 import httpx
 from typing import Any, Dict, Optional
+from app.core.http_utils import async_get
 
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
@@ -42,14 +43,13 @@ class RocketChatConnector(BaseConnector):
         """Return the raw ``message`` payload."""
         return message
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         """Return ``True`` if the API token appears valid."""
 
         api_url = f"{self.url}/api/v1/me"
         headers = {"X-Auth-Token": self.token, "X-User-Id": self.user_id}
         try:
-            resp = httpx.get(api_url, headers=headers)
-            resp.raise_for_status()
+            await async_get(api_url, headers=headers)
             return True
         except httpx.HTTPError:
             return False

--- a/app/connectors/teams_connector.py
+++ b/app/connectors/teams_connector.py
@@ -2,6 +2,7 @@
 
 import httpx
 from typing import Any, Dict, Optional
+from app.core.http_utils import async_get
 
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
@@ -43,12 +44,11 @@ class TeamsConnector(BaseConnector):
         """Return the raw ``message`` payload."""
         return message
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         """Return ``True`` if the bot endpoint is reachable."""
         headers = {"Authorization": f"Bearer {self.app_password}"}
         try:
-            resp = httpx.get(self.bot_endpoint, headers=headers)
-            resp.raise_for_status()
+            await async_get(self.bot_endpoint, headers=headers)
             return True
         except httpx.HTTPError:
             return False

--- a/app/connectors/telegram_connector.py
+++ b/app/connectors/telegram_connector.py
@@ -1,5 +1,6 @@
 import httpx
 from typing import Any, Dict, Optional
+from app.core.http_utils import async_get
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
 
@@ -54,12 +55,11 @@ class TelegramConnector(BaseConnector):
 
         return True
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         """Return ``True`` if the bot token is valid."""
         url = f"https://api.telegram.org/bot{self.token}/getMe"
         try:
-            response = httpx.get(url)
-            response.raise_for_status()
+            response = await async_get(url)
             data = response.json()
             return bool(data.get("ok"))
         except httpx.HTTPError:

--- a/app/connectors/whatsapp_connector.py
+++ b/app/connectors/whatsapp_connector.py
@@ -2,6 +2,7 @@
 
 import httpx
 from typing import Any, Dict, Optional
+from app.core.http_utils import async_get
 
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
@@ -61,13 +62,12 @@ class WhatsAppConnector(BaseConnector):
         # and calling the appropriate action(s)
         return message
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         """Return ``True`` if the Twilio credentials appear valid."""
 
         url = f"https://api.twilio.com/2010-04-01/Accounts/{self.account_sid}.json"
         try:
-            resp = httpx.get(url, auth=(self.account_sid, self.auth_token))
-            resp.raise_for_status()
+            await async_get(url, auth=(self.account_sid, self.auth_token))
             return True
         except httpx.HTTPError:
             return False

--- a/app/connectors/zulip_connector.py
+++ b/app/connectors/zulip_connector.py
@@ -1,5 +1,6 @@
 import httpx
 from typing import Any, Dict, Optional
+from app.core.http_utils import async_get
 
 from .base_connector import BaseConnector
 from app.core.logging import setup_logger
@@ -45,11 +46,10 @@ class ZulipConnector(BaseConnector):
     async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
         return message
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         url = f"{self.site_url}/api/v1/server_settings"
         try:
-            resp = httpx.get(url, auth=(self.email, self.api_key))
-            resp.raise_for_status()
+            await async_get(url, auth=(self.email, self.api_key))
             return True
         except httpx.HTTPError:
             return False

--- a/app/core/http_utils.py
+++ b/app/core/http_utils.py
@@ -1,0 +1,35 @@
+import asyncio
+from typing import Any
+
+import httpx
+
+
+async def async_request_with_retries(
+    method: str,
+    url: str,
+    retries: int = 2,
+    timeout: float = 3.0,
+    **kwargs: Any,
+) -> httpx.Response:
+    """Perform an HTTP request with retries and exponential backoff."""
+
+    delay = 1.0
+    for attempt in range(retries + 1):
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.request(method, url, **kwargs)
+            response.raise_for_status()
+            return response
+        except httpx.HTTPError:
+            if attempt >= retries:
+                raise
+            await asyncio.sleep(delay)
+            delay *= 2
+
+
+async def async_get(url: str, **kwargs: Any) -> httpx.Response:
+    return await async_request_with_retries("GET", url, **kwargs)
+
+
+async def async_post(url: str, **kwargs: Any) -> httpx.Response:
+    return await async_request_with_retries("POST", url, **kwargs)

--- a/app/views.py
+++ b/app/views.py
@@ -26,7 +26,7 @@ async def home(request: Request):
     )
 
 async def connectors(request: Request):
-    connectors_data = get_connectors_data()
+    connectors_data = await get_connectors_data()
     return templates.TemplateResponse(
         request,
         "connectors.html",

--- a/tests/connectors/test_broadcast.py
+++ b/tests/connectors/test_broadcast.py
@@ -1,3 +1,4 @@
+import asyncio
 from app.connectors.broadcast_connector import BroadcastConnector
 from app.connectors.base_connector import BaseConnector
 
@@ -33,4 +34,5 @@ def test_send_message(monkeypatch):
     connector.send_message("hi")
     assert instances["a"].sent == ["hi"]
     assert instances["b"].sent == ["hi"]
-    assert connector.is_connected() is True
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert result is True

--- a/tests/connectors/test_connector_utils.py
+++ b/tests/connectors/test_connector_utils.py
@@ -1,5 +1,6 @@
 import sys
 import types
+import asyncio
 
 # Provide a minimal slack_sdk stub if the real package isn't installed
 if "slack_sdk" not in sys.modules:
@@ -337,7 +338,7 @@ def test_get_connectors_data_missing_config(monkeypatch):
     monkeypatch.setattr(
         "app.connectors.connector_utils.get_settings", lambda: test_settings
     )
-    data = get_connectors_data()
+    data = asyncio.get_event_loop().run_until_complete(get_connectors_data())
     assert all(item["status"] == "missing_config" for item in data)
     slack_data = next(item for item in data if item["id"] == "slack")
     assert slack_data["status"] == "missing_config"
@@ -357,7 +358,7 @@ def test_get_connectors_data_status_up(monkeypatch):
         "app.connectors.slack_connector.SlackConnector.is_connected", lambda self: True
     )
 
-    data = get_connectors_data()
+    data = asyncio.get_event_loop().run_until_complete(get_connectors_data())
     slack_data = next(item for item in data if item["id"] == "slack")
     assert slack_data["status"] == "up"
 

--- a/tests/connectors/test_discord.py
+++ b/tests/connectors/test_discord.py
@@ -78,15 +78,20 @@ class DummyGetResponse:
 
 
 def test_is_connected_success(monkeypatch):
-    monkeypatch.setattr(httpx, "get", lambda url, headers=None: DummyGetResponse())
+    async def fake_get(url, headers=None):
+        return DummyGetResponse()
+
+    monkeypatch.setattr("app.connectors.discord_connector.async_get", fake_get)
     connector = DiscordConnector("TOKEN", "CHAN")
-    assert connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert result
 
 
 def test_is_connected_error(monkeypatch):
-    def raise_err(url, headers=None):
+    async def raise_err(url, headers=None):
         raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(httpx, "get", raise_err)
+    monkeypatch.setattr("app.connectors.discord_connector.async_get", raise_err)
     connector = DiscordConnector("TOKEN", "CHAN")
-    assert not connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert not result

--- a/tests/connectors/test_intercom.py
+++ b/tests/connectors/test_intercom.py
@@ -58,15 +58,20 @@ class DummyGetResponse:
 
 
 def test_is_connected_success(monkeypatch):
-    monkeypatch.setattr(httpx, "get", lambda url, headers=None: DummyGetResponse())
+    async def fake_get(url, headers=None):
+        return DummyGetResponse()
+
+    monkeypatch.setattr("app.connectors.intercom_connector.async_get", fake_get)
     connector = IntercomConnector("TOKEN", "APP")
-    assert connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert result
 
 
 def test_is_connected_error(monkeypatch):
-    def raise_err(url, headers=None):
+    async def raise_err(url, headers=None):
         raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(httpx, "get", raise_err)
+    monkeypatch.setattr("app.connectors.intercom_connector.async_get", raise_err)
     connector = IntercomConnector("TOKEN", "APP")
-    assert not connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert not result

--- a/tests/connectors/test_mastodon.py
+++ b/tests/connectors/test_mastodon.py
@@ -58,15 +58,20 @@ class DummyGetResponse:
 
 
 def test_is_connected_success(monkeypatch):
-    monkeypatch.setattr(httpx, "get", lambda url, headers=None: DummyGetResponse())
+    async def fake_get(url, headers=None):
+        return DummyGetResponse()
+
+    monkeypatch.setattr("app.connectors.mastodon_connector.async_get", fake_get)
     connector = MastodonConnector("http://host", "TOKEN")
-    assert connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert result
 
 
 def test_is_connected_error(monkeypatch):
-    def raise_err(url, headers=None):
+    async def raise_err(url, headers=None):
         raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(httpx, "get", raise_err)
+    monkeypatch.setattr("app.connectors.mastodon_connector.async_get", raise_err)
     connector = MastodonConnector("http://host", "TOKEN")
-    assert not connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert not result

--- a/tests/connectors/test_mattermost.py
+++ b/tests/connectors/test_mattermost.py
@@ -71,15 +71,20 @@ class DummyGetResponse:
 
 
 def test_is_connected_success(monkeypatch):
-    monkeypatch.setattr(httpx, "get", lambda url, headers=None: DummyGetResponse())
+    async def fake_get(url, headers=None):
+        return DummyGetResponse()
+
+    monkeypatch.setattr("app.connectors.mattermost_connector.async_get", fake_get)
     connector = MattermostConnector("http://mm", "tok", "chan")
-    assert connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert result
 
 
 def test_is_connected_error(monkeypatch):
-    def raise_err(url, headers=None):
+    async def raise_err(url, headers=None):
         raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(httpx, "get", raise_err)
+    monkeypatch.setattr("app.connectors.mattermost_connector.async_get", raise_err)
     connector = MattermostConnector("http://mm", "tok", "chan")
-    assert not connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert not result

--- a/tests/connectors/test_teams.py
+++ b/tests/connectors/test_teams.py
@@ -68,15 +68,20 @@ class DummyGetResponse:
 
 
 def test_is_connected_success(monkeypatch):
-    monkeypatch.setattr(httpx, "get", lambda url, headers=None: DummyGetResponse())
+    async def fake_get(url, headers=None):
+        return DummyGetResponse()
+
+    monkeypatch.setattr("app.connectors.teams_connector.async_get", fake_get)
     connector = TeamsConnector("ID", "PASS", "TEN", "http://bot")
-    assert connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert result
 
 
 def test_is_connected_error(monkeypatch):
-    def raise_err(url, headers=None):
+    async def raise_err(url, headers=None):
         raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(httpx, "get", raise_err)
+    monkeypatch.setattr("app.connectors.teams_connector.async_get", raise_err)
     connector = TeamsConnector("ID", "PASS", "TEN", "http://bot")
-    assert not connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert not result

--- a/tests/connectors/test_whatsapp.py
+++ b/tests/connectors/test_whatsapp.py
@@ -58,15 +58,20 @@ def test_process_incoming():
 
 
 def test_is_connected_success(monkeypatch):
-    monkeypatch.setattr(httpx, "get", lambda url, auth=None: DummyResponse())
+    async def fake_get(url, auth=None):
+        return DummyResponse()
+
+    monkeypatch.setattr("app.connectors.whatsapp_connector.async_get", fake_get)
     connector = WhatsAppConnector("SID", "TOKEN", "+1", "+2")
-    assert connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert result
 
 
 def test_is_connected_error(monkeypatch):
-    def raise_err(url, auth=None):
+    async def raise_err(url, auth=None):
         raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(httpx, "get", raise_err)
+    monkeypatch.setattr("app.connectors.whatsapp_connector.async_get", raise_err)
     connector = WhatsAppConnector("SID", "TOKEN", "+1", "+2")
-    assert not connector.is_connected()
+    result = asyncio.get_event_loop().run_until_complete(connector.is_connected())
+    assert not result

--- a/tests/test_auth_callbacks.py
+++ b/tests/test_auth_callbacks.py
@@ -1,4 +1,4 @@
-import requests
+import httpx
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -16,14 +16,14 @@ class DummyResponse:
 
     def raise_for_status(self):
         if self.status_code >= 400:
-            raise requests.HTTPError("error")
+            raise httpx.HTTPError("error")
 
 
 def test_google_callback_success(monkeypatch, test_app: TestClient, db: Session):
-    def fake_post(url, data=None):
+    async def fake_post(url, data=None):
         return DummyResponse({"id_token": "tok"})
 
-    monkeypatch.setattr(routes.requests, "post", fake_post)
+    monkeypatch.setattr(routes, "async_post", fake_post)
     monkeypatch.setattr(routes.jwt, "decode", lambda token, options=None: {"email": "g@example.com", "name": "GUser"})
     test_app.cookies.clear()
     resp = test_app.get("/auth/google/callback?code=abc", follow_redirects=False)
@@ -33,10 +33,10 @@ def test_google_callback_success(monkeypatch, test_app: TestClient, db: Session)
 
 
 def test_google_callback_missing_email(monkeypatch, test_app: TestClient, db: Session):
-    def fake_post(url, data=None):
+    async def fake_post(url, data=None):
         return DummyResponse({"id_token": "tok"})
 
-    monkeypatch.setattr(routes.requests, "post", fake_post)
+    monkeypatch.setattr(routes, "async_post", fake_post)
     monkeypatch.setattr(routes.jwt, "decode", lambda token, options=None: {})
     test_app.cookies.clear()
     resp = test_app.get("/auth/google/callback?code=abc", follow_redirects=False)
@@ -44,10 +44,10 @@ def test_google_callback_missing_email(monkeypatch, test_app: TestClient, db: Se
 
 
 def test_microsoft_callback_success(monkeypatch, test_app: TestClient, db: Session):
-    def fake_post(url, data=None):
+    async def fake_post(url, data=None):
         return DummyResponse({"id_token": "tok"})
 
-    monkeypatch.setattr(routes.requests, "post", fake_post)
+    monkeypatch.setattr(routes, "async_post", fake_post)
     monkeypatch.setattr(routes.jwt, "decode", lambda token, options=None: {"email": "m@example.com", "name": "MUser"})
     test_app.cookies.clear()
     resp = test_app.get("/auth/microsoft/callback?code=abc", follow_redirects=False)
@@ -57,10 +57,10 @@ def test_microsoft_callback_success(monkeypatch, test_app: TestClient, db: Sessi
 
 
 def test_microsoft_callback_missing_email(monkeypatch, test_app: TestClient, db: Session):
-    def fake_post(url, data=None):
+    async def fake_post(url, data=None):
         return DummyResponse({"id_token": "tok"})
 
-    monkeypatch.setattr(routes.requests, "post", fake_post)
+    monkeypatch.setattr(routes, "async_post", fake_post)
     monkeypatch.setattr(routes.jwt, "decode", lambda token, options=None: {})
     test_app.cookies.clear()
     resp = test_app.get("/auth/microsoft/callback?code=abc", follow_redirects=False)


### PR DESCRIPTION
## Summary
- add async HTTP helper with retries
- parallelize connector checks
- update view and auth routes to use async HTTP helper
- adapt connector `is_connected` methods to async
- update tests for new async behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d74e7e01883338c775e532d5ae5be