### PR TITLE
Cache connector status in Redis

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends, Request, HTTPException
+from fastapi import APIRouter, Depends, Request, HTTPException, BackgroundTasks
 from fastapi import status
 from fastapi.security import OAuth2PasswordRequestForm
 
@@ -25,8 +25,9 @@ from app.crud.interaction import create_interaction
 from app.handlers.openai_handler import create_chat_interaction
 from app.api.deps import get_async_db
 
-from datetime import timedelta
+from datetime import timedelta, datetime
 import os
+import json
 import uuid
 import requests
 import jwt
@@ -36,6 +37,7 @@ import traceback
 from .views import home, connectors, filters, channels, process_message, bots, messages, login, logout, get_bots
 from app.connectors.connector_utils import get_connector
 from app.schemas.connector import ConnectorCreate, ConnectorUpdate, Connector
+from app.core.redis_cache import get_redis_client
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
 app_routes = APIRouter()
@@ -223,13 +225,53 @@ async def test_connector_endpoint(connector_id: int, db: Session = Depends(get_a
 
 
 @app_routes.get("/api/connectors/{connector_id}/status")
-async def connector_status_endpoint(connector_id: int, db: Session = Depends(get_async_db)):
+async def connector_status_endpoint(
+    connector_id: int,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_async_db),
+):
+    key = f"connector_status:{connector_id}"
+    redis_client = get_redis_client()
+    if redis_client:
+        cached = redis_client.get(key)
+        if cached:
+            data = json.loads(cached)
+            background_tasks.add_task(_refresh_status, connector_id)
+            return data
+
     connector = connector_crud.get(db, connector_id)
     if not connector:
         raise HTTPException(status_code=404, detail="Connector not found")
     instance = get_connector(connector.connector_type, connector.config or {})
     status_value = "up" if instance.is_connected() else "down"
-    return {"status": status_value}
+    data = {"status": status_value, "timestamp": datetime.utcnow().isoformat()}
+    if redis_client:
+        redis_client.setex(key, settings.connector_status_cache_ttl, json.dumps(data))
+    return data
+
+
+def _refresh_status(connector_id: int) -> None:
+    """Refresh connector status in the background."""
+    redis_client = get_redis_client()
+    if not redis_client:
+        return
+    from app.db.session import SessionLocal
+
+    db = SessionLocal()
+    try:
+        connector = connector_crud.get(db, connector_id)
+        if not connector:
+            return
+        instance = get_connector(connector.connector_type, connector.config or {})
+        status_value = "up" if instance.is_connected() else "down"
+        data = {"status": status_value, "timestamp": datetime.utcnow().isoformat()}
+        redis_client.setex(
+            f"connector_status:{connector_id}",
+            settings.connector_status_cache_ttl,
+            json.dumps(data),
+        )
+    finally:
+        db.close()
 
 @app_routes.post("/token", response_model=Token)
 async def token(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_async_db)):

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -157,6 +157,7 @@ class Settings(BaseSettings):
     line_user_id: str
     viber_auth_token: str
     viber_receiver: str
+    connector_status_cache_ttl: int = 30
     coap_oscore_host: str
     coap_oscore_port: int
     opcua_pubsub_endpoint: str

--- a/app/core/redis_cache.py
+++ b/app/core/redis_cache.py
@@ -1,0 +1,28 @@
+try:
+    import redis
+except ImportError:  # pragma: no cover - optional dependency
+    redis = None
+
+from app.core.config import settings
+
+_redis_client = None
+
+
+def get_redis_client():
+    """Return a cached Redis client instance or ``None`` if unavailable."""
+    global _redis_client
+    if not redis:
+        return None
+    if _redis_client is None:
+        _redis_client = redis.Redis(
+            host=settings.redis_host,
+            port=settings.redis_port,
+            decode_responses=True,
+        )
+    return _redis_client
+
+
+def set_redis_client(client):
+    """Override the global Redis client (used in tests)."""
+    global _redis_client
+    _redis_client = client

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -138,6 +138,7 @@ amqp_url: "your_amqp_url"
 amqp_queue: "your_amqp_queue"
 redis_host: "your_redis_host"
 redis_port: 6379
+connector_status_cache_ttl: 30
 redis_channel: "your_redis_channel"
 kafka_bootstrap_servers: "your_kafka_bootstrap_servers"
 kafka_topic: "your_kafka_topic"

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ openai
 tiktoken
 paho-mqtt
 pika
+redis

--- a/tests/test_connector_api.py
+++ b/tests/test_connector_api.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from app import crud
 from app.schemas.connector import ConnectorCreate
+from app.core.config import settings
 
 
 def test_test_connector_endpoint(test_app: TestClient, db: Session, monkeypatch) -> None:
@@ -16,3 +17,48 @@ def test_test_connector_endpoint(test_app: TestClient, db: Session, monkeypatch)
     resp = test_app.post(f"/api/connectors/{connector.id}/test")
     assert resp.status_code == 200
     assert resp.json()["status"] == "up"
+
+
+def test_status_endpoint_uses_cache(test_app: TestClient, db: Session, monkeypatch) -> None:
+    connector = crud.connector.create(db, obj_in=ConnectorCreate(name="irc1", connector_type="irc", config={}))
+
+    class DummyConnector:
+        def __init__(self):
+            self.calls = 0
+
+        def is_connected(self):
+            self.calls += 1
+            return True
+
+    dummy_connector = DummyConnector()
+    monkeypatch.setattr("app.app_routes.get_connector", lambda *a, **k: dummy_connector)
+
+    class DummyRedis:
+        def __init__(self):
+            self.store = {}
+            self.ttl = {}
+
+        def get(self, key):
+            return self.store.get(key)
+
+        def setex(self, key, ttl, value):
+            self.store[key] = value
+            self.ttl[key] = ttl
+
+    dummy_redis = DummyRedis()
+    monkeypatch.setattr("app.app_routes.get_redis_client", lambda: dummy_redis)
+    monkeypatch.setattr("app.app_routes._refresh_status", lambda *a, **k: None)
+
+    resp1 = test_app.get(f"/api/connectors/{connector.id}/status")
+    assert resp1.status_code == 200
+    assert resp1.json()["status"] == "up"
+    assert "timestamp" in resp1.json()
+    assert dummy_connector.calls == 1
+
+    resp2 = test_app.get(f"/api/connectors/{connector.id}/status")
+    assert resp2.status_code == 200
+    assert dummy_connector.calls == 1  # second call served from cache
+    assert (
+        dummy_redis.ttl[f"connector_status:{connector.id}"]
+        == settings.connector_status_cache_ttl
+    )


### PR DESCRIPTION
## Summary
- add configurable TTL for connector status cache
- store TTL in config and use in Redis writes
- test TTL setting in the connector status cache

## Testing
- `coverage run -m pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_683d74ed71508333b2163372d7270489