### PR TITLE
Add captions page with sortable table

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -33,7 +33,7 @@ import jwt
 from urllib.parse import urlencode
 import traceback
 
-from .views import home, connectors, filters, channels, process_message, bots, messages, login, logout, get_bots
+from .views import home, connectors, filters, channels, process_message, bots, messages, captions, login, logout, get_bots
 from app.connectors.connector_utils import get_connector
 from app.schemas.connector import ConnectorCreate, ConnectorUpdate, Connector
 
@@ -75,6 +75,10 @@ async def bots_endpoint(request: Request):
 @app_routes.get("/messages_log.html")
 async def messages_endpoint(request: Request):
     return await messages(request)
+
+@app_routes.get("/captions.html")
+async def captions_endpoint(request: Request):
+    return await captions(request)
 
 @app_routes.post("/api/bots/create")
 async def create_bot_endpoint(request: Request, db: Session = Depends(get_async_db)):

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -144,6 +144,16 @@ textarea {
   float: right;
 }
 
+.caption-thumb {
+  width: 120px;
+  height: auto;
+  display: block;
+}
+
+#captions-table th {
+  cursor: pointer;
+}
+
 
 html.dark-mode,
 body.dark-mode {

--- a/app/static/js/captions.js
+++ b/app/static/js/captions.js
@@ -1,0 +1,63 @@
+function timeAgo(dateStr) {
+  const date = new Date(dateStr);
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+  const ranges = {
+    year: 31536000,
+    month: 2592000,
+    day: 86400,
+    hour: 3600,
+    minute: 60,
+    second: 1,
+  };
+  for (const [unit, value] of Object.entries(ranges)) {
+    if (Math.abs(seconds) >= value || unit === 'second') {
+      const delta = Math.floor(seconds / value);
+      return rtf.format(-delta, unit);
+    }
+  }
+}
+
+async function fetchCaptions() {
+  const resp = await fetch('/api/captions');
+  if (!resp.ok) return;
+  const captions = await resp.json();
+  const tbody = document.querySelector('#captions-table tbody');
+  tbody.innerHTML = '';
+  captions.forEach(cap => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td><img src="${cap.thumbnail_url}" class="caption-thumb"></td>
+      <td>${cap.text}</td>
+      <td data-time="${cap.created_at}">${timeAgo(cap.created_at)}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function sortTable(th) {
+  const table = th.closest('table');
+  const tbody = table.querySelector('tbody');
+  const index = Array.from(th.parentNode.children).indexOf(th);
+  const type = th.dataset.type || 'string';
+  const asc = !(th.dataset.sort === 'asc');
+  th.dataset.sort = asc ? 'asc' : 'desc';
+  const rows = Array.from(tbody.querySelectorAll('tr'));
+  rows.sort((a, b) => {
+    let aVal = a.children[index].textContent.trim();
+    let bVal = b.children[index].textContent.trim();
+    if (type === 'time') {
+      aVal = new Date(a.children[index].dataset.time).getTime();
+      bVal = new Date(b.children[index].dataset.time).getTime();
+    }
+    return (aVal > bVal ? 1 : aVal < bVal ? -1 : 0) * (asc ? 1 : -1);
+  });
+  tbody.innerHTML = '';
+  rows.forEach(r => tbody.appendChild(r));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchCaptions();
+  document.querySelectorAll('#captions-table th').forEach(th => {
+    th.addEventListener('click', () => sortTable(th));
+  });
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,6 +46,9 @@
                     <li class="nav-item">
                         <a class="nav-link {% if active_page == 'messages' %}active{% endif %}" href="/messages_log.html">Messages</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if active_page == 'captions' %}active{% endif %}" href="/captions.html">Captions</a>
+                    </li>
                 </ul>
                 <div class="form-check form-switch text-light">
                     <input class="form-check-input" type="checkbox" id="themeToggle">

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Captions</h1>
+<table id="captions-table" class="table table-striped">
+  <thead>
+    <tr>
+      <th>Thumbnail</th>
+      <th>Caption</th>
+      <th data-type="time">Created</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<script src="/static/js/captions.js" defer></script>
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -61,6 +61,13 @@ async def bots(request: Request):
         {"request": request, "active_page": "bots"},
     )
 
+async def captions(request: Request):
+    return templates.TemplateResponse(
+        request,
+        "captions.html",
+        {"request": request, "active_page": "captions"},
+    )
+
 async def login(request: Request):
     return templates.TemplateResponse(
         request,


### PR DESCRIPTION
## Summary
- add `/captions.html` route and view
- show Captions link in navigation
- create captions template and script for loading/sorting captions
- display time ago values and fix thumbnail size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d817d541c83339992ad1d92e750ce