### PR TITLE
Improve connector UI feedback

### DIFF
--- a/app/static/js/connectors.js
+++ b/app/static/js/connectors.js
@@ -10,25 +10,33 @@ document.addEventListener('DOMContentLoaded', () => {
       const nameInput = document.getElementById('connector-name');
       const typeInput = document.getElementById('connector-type');
       const configInput = document.getElementById('connector-config');
+      const feedback = document.getElementById('connector-feedback');
+      feedback.innerHTML = '';
+      feedback.className = '';
       let config = {};
       if (configInput.value.trim()) {
         try {
           config = JSON.parse(configInput.value);
         } catch (e) {
-          alert('Config must be valid JSON');
+          showFeedback('Config must be valid JSON', true);
           return;
         }
       }
-      const connector = await createConnector({
-        name: nameInput.value.trim(),
-        connector_type: typeInput.value.trim(),
-        config: config
-      });
-      document.querySelector('.connectors-container')
-        .appendChild(createConnectorElement(connector));
-      nameInput.value = '';
-      typeInput.value = '';
-      configInput.value = '';
+      try {
+        const connector = await createConnector({
+          name: nameInput.value.trim(),
+          connector_type: typeInput.value.trim(),
+          config: config
+        });
+        document.querySelector('.connectors-container')
+          .appendChild(createConnectorElement(connector));
+        nameInput.value = '';
+        typeInput.value = '';
+        configInput.value = '';
+        showFeedback('Connector added successfully', false);
+      } catch (err) {
+        showFeedback(err.message || 'Failed to add connector', true);
+      }
     });
   }
 });
@@ -61,7 +69,11 @@ async function createConnector(data) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
   });
-  return await resp.json();
+  const result = await resp.json();
+  if (!resp.ok) {
+    throw new Error(result.detail || 'Error creating connector');
+  }
+  return result;
 }
 
 async function updateConnector(id, data) {
@@ -70,21 +82,37 @@ async function updateConnector(id, data) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
   });
-  return await resp.json();
+  const result = await resp.json();
+  if (!resp.ok) {
+    throw new Error(result.detail || 'Error updating connector');
+  }
+  return result;
 }
 
 async function deleteConnector(id) {
-  await fetch(`/api/connectors/${id}`, { method: 'DELETE' });
+  const resp = await fetch(`/api/connectors/${id}`, { method: 'DELETE' });
+  if (!resp.ok) {
+    const result = await resp.json();
+    throw new Error(result.detail || 'Error deleting connector');
+  }
 }
 
 async function testConnector(id) {
   const resp = await fetch(`/api/connectors/${id}/test`, { method: 'POST' });
-  return await resp.json();
+  const result = await resp.json();
+  if (!resp.ok) {
+    throw new Error(result.detail || 'Error testing connector');
+  }
+  return result;
 }
 
 async function getConnectorStatus(id) {
   const resp = await fetch(`/api/connectors/${id}/status`);
-  return await resp.json();
+  const result = await resp.json();
+  if (!resp.ok) {
+    throw new Error(result.detail || 'Error fetching status');
+  }
+  return result;
 }
 
 function createConnectorElement(connector) {
@@ -111,18 +139,23 @@ function createConnectorElement(connector) {
       try {
         newConfig = JSON.parse(newConfig);
       } catch (e) {
-        alert('Config must be valid JSON');
+        showFeedback('Config must be valid JSON', true);
         return;
       }
-      const updated = await updateConnector(connector.id, {
-        name: newName,
-        connector_type: newType,
-        config: newConfig
-      });
-      connector.name = updated.name;
-      connector.connector_type = updated.connector_type;
-      connector.config = updated.config;
-      header.childNodes[0].nodeValue = `${updated.name} (${updated.connector_type})`;
+      try {
+        const updated = await updateConnector(connector.id, {
+          name: newName,
+          connector_type: newType,
+          config: newConfig
+        });
+        connector.name = updated.name;
+        connector.connector_type = updated.connector_type;
+        connector.config = updated.config;
+        header.childNodes[0].nodeValue = `${updated.name} (${updated.connector_type})`;
+        showFeedback('Connector updated successfully', false);
+      } catch (err) {
+        showFeedback(err.message || 'Failed to update connector', true);
+      }
     }
   });
 
@@ -130,16 +163,26 @@ function createConnectorElement(connector) {
   deleteBtn.className = 'btn btn-sm btn-danger me-2';
   deleteBtn.textContent = 'Delete';
   deleteBtn.addEventListener('click', async () => {
-    await deleteConnector(connector.id);
-    card.remove();
+    try {
+      await deleteConnector(connector.id);
+      card.remove();
+      showFeedback('Connector deleted', false);
+    } catch (err) {
+      showFeedback(err.message || 'Failed to delete connector', true);
+    }
   });
 
   const testBtn = document.createElement('button');
   testBtn.className = 'btn btn-sm btn-outline-primary';
   testBtn.textContent = 'Test';
   testBtn.addEventListener('click', async () => {
-    const result = await testConnector(connector.id);
-    statusSpan.textContent = result.status;
+    try {
+      const result = await testConnector(connector.id);
+      statusSpan.textContent = result.status;
+      showFeedback('Test completed: ' + result.status, false);
+    } catch (err) {
+      showFeedback(err.message || 'Failed to test connector', true);
+    }
   });
 
   body.appendChild(editBtn);
@@ -147,4 +190,11 @@ function createConnectorElement(connector) {
   body.appendChild(testBtn);
   card.appendChild(body);
   return card;
+}
+
+function showFeedback(message, isError) {
+  const feedback = document.getElementById('connector-feedback');
+  if (!feedback) return;
+  feedback.textContent = message;
+  feedback.className = isError ? 'alert alert-danger' : 'alert alert-success';
 }

--- a/app/templates/connectors.html
+++ b/app/templates/connectors.html
@@ -21,6 +21,7 @@
       <button type="submit" class="btn btn-primary">Add Connector</button>
     </div>
   </div>
+  <div id="connector-feedback" class="mt-2"></div>
 </form>
 
 <div class="connectors-container"></div>


### PR DESCRIPTION
## Summary
- show frontend error/success messages near the connector form
- handle backend errors in `connectors.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8269af9c8333b357ae72990c2b9d