### PR TITLE
Add UI thinking indicator

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -144,6 +144,12 @@ textarea {
   float: right;
 }
 
+/* Typing indicator style */
+#thinking-indicator {
+  font-style: italic;
+  opacity: 0.7;
+}
+
 
 html.dark-mode,
 body.dark-mode {

--- a/app/static/js/bots.js
+++ b/app/static/js/bots.js
@@ -73,6 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const messagesContainer = document.querySelector('.messages-container');
       const placeholder = document.createElement('div');
       placeholder.className = 'message assistant placeholder-message';
+      placeholder.textContent = 'Thinking...';
       placeholder.style.height = textarea.scrollHeight + 'px';
       messagesContainer.appendChild(placeholder);
       messagesContainer.scrollTop = messagesContainer.scrollHeight;

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -13,6 +13,13 @@ sendButton.addEventListener('click', () => {
     // Display sent message
     messageDisplay.innerHTML += `<p><strong>You:</strong> ${message}</p>`;
 
+    // Show thinking indicator while waiting for response
+    const thinking = document.createElement('p');
+    thinking.id = 'thinking-indicator';
+    thinking.innerHTML = '<em>Norman is thinking...</em>';
+    messageDisplay.appendChild(thinking);
+    messageDisplay.scrollTop = messageDisplay.scrollHeight;
+
     // Send message to the backend (replace with the appropriate API endpoint)
     fetch('/api/process_message', {
         method: 'POST',
@@ -21,10 +28,13 @@ sendButton.addEventListener('click', () => {
     })
         .then(response => response.json())
         .then(data => {
-            // Display received message
+            // Remove thinking indicator and display received message
+            thinking.remove();
             messageDisplay.innerHTML += `<p><strong>Norman:</strong> ${data.response}</p>`;
+            messageDisplay.scrollTop = messageDisplay.scrollHeight;
         })
         .catch(error => {
+            thinking.remove();
             console.error('Error:', error);
         });
 });

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,6 +76,7 @@ chmod +x generate_key.sh
 
 3. Start Norman with `python main.py` and open `http://localhost:8000` in your browser.
 4. Log in with the admin credentials from `config.yaml`, create a chatbot and select the Slack connector. Messages posted in the configured channel will be processed by the bot.
+5. When a bot is generating a reply, the interface displays a *Thinking...* indicator so you know it's working.
 
 ## API Examples
 


### PR DESCRIPTION
## Summary
- show thinking indicator in script.js while waiting for responses
- display "Thinking..." placeholder when sending bot messages
- style the thinking indicator in CSS
- document the new feedback behavior in usage docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d82592d7c8333b8cf29b573b13962