### PR TITLE
Improve responsive design

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -185,3 +185,34 @@ body.dark-mode .card {
   100% { left: 100%; }
 }
 
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .main-container {
+    flex-direction: column;
+  }
+
+  .bots-container,
+  .main-chat-container {
+    width: 100%;
+  }
+
+  .messages-container,
+  .messages-log {
+    height: 50vh;
+  }
+
+  textarea {
+    width: 100%;
+    max-width: none;
+  }
+
+  #add-bot-form .btn,
+  #add-channel-form .btn,
+  #add-filter-form .btn,
+  #add-connector-form .btn,
+  .input-message-container .btn,
+  .input-group .btn {
+    width: 100%;
+  }
+}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -20,7 +20,7 @@
 </head>
 <body>
     {% if show_navbar|default(True) %}
-    <header class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
+    <header class="navbar navbar-expand-md navbar-dark bg-primary shadow-sm">
         <div class="container">
             <a class="navbar-brand" href="/index.html">Norman</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/app/templates/bots.html
+++ b/app/templates/bots.html
@@ -35,8 +35,8 @@
     <div class="messages-container flex-grow-1 mb-2">
       <!-- Messages will be dynamically added here -->
     </div>
-    <div class="input-message-container d-flex">
-      <textarea id="input-message" rows="1" class="form-control me-2" placeholder="Pick a bot..." disabled></textarea>
+    <div class="input-message-container d-flex flex-column flex-sm-row">
+      <textarea id="input-message" rows="1" class="form-control me-sm-2 mb-2 mb-sm-0" placeholder="Pick a bot..." disabled></textarea>
       <button id="send-message" class="btn btn-primary" disabled>Send</button>
       <div id="spinner" class="spinner" style="display: none;"></div>
     </div>

--- a/app/templates/channels.html
+++ b/app/templates/channels.html
@@ -27,7 +27,7 @@
                         <option value="telegram">Telegram</option>
                     </select>
                 </div>
-                <div class="col-auto">
+                <div class="col-12 col-sm-auto">
                     <button id="addChannelBtn" class="btn btn-primary">Add Channel</button>
                 </div>
             </form>

--- a/app/templates/connectors.html
+++ b/app/templates/connectors.html
@@ -17,7 +17,7 @@
       <label for="connector-config" class="form-label">Config (JSON)</label>
       <input type="text" id="connector-config" class="form-control" />
     </div>
-    <div class="col-auto">
+    <div class="col-12 col-sm-auto">
       <button type="submit" class="btn btn-primary">Add Connector</button>
     </div>
   </div>

--- a/app/templates/filters.html
+++ b/app/templates/filters.html
@@ -25,7 +25,7 @@
       <label for="filter-description" class="form-label">Description</label>
       <input type="text" id="filter-description" class="form-control" />
     </div>
-    <div class="col-auto">
+    <div class="col-12 col-sm-auto">
       <button type="submit" class="btn btn-primary">Add Filter</button>
     </div>
   </div>

--- a/app/templates/messages_log.html
+++ b/app/templates/messages_log.html
@@ -24,9 +24,9 @@
         <!-- Messages will be displayed here -->
       </div>
     </div>
-    <div class="input-group mt-2">
-      <input type="text" class="form-control" id="messageInput" placeholder="Type your message...">
-      <button class="btn btn-primary" id="sendButton" type="button">Send</button>
+    <div class="input-group mt-2 flex-column flex-sm-row">
+      <input type="text" class="form-control mb-2 mb-sm-0" id="messageInput" placeholder="Type your message...">
+      <button class="btn btn-primary w-100" id="sendButton" type="button">Send</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- collapse navigation earlier on small screens
- tweak forms and inputs for better mobile layout
- add CSS rules for responsive behavior across pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d825e74a08333aecc21716335f2a9