### PR TITLE
Secure admin UI with login enforcement

### DIFF
--- a/app/auth_middleware.py
+++ b/app/auth_middleware.py
@@ -9,8 +9,10 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/token")
 async def auth_middleware(request: Request, call_next):
     token = request.cookies.get("access_token", None)
 
+    path = request.url.path
+
     if token is None:
-        if request.url.path.endswith(".html") and request.url.path != "/login.html":
+        if (path.endswith(".html") or path in ("/", "/index.html")) and path != "/login.html":
             return RedirectResponse(url="/login.html", status_code=303)
     elif request.url.path == "/login.html":
         # If the user already has a valid token, redirect them away from the

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,8 @@
 from fastapi.testclient import TestClient
 
 
-def test_home_page(test_app: TestClient) -> None:
-    """The root endpoint should return a HTML page."""
-    response = test_app.get("/")
-    assert response.status_code == 200
-    assert "text/html" in response.headers["content-type"]
+def test_home_page_requires_login(test_app: TestClient) -> None:
+    """The root endpoint should redirect unauthenticated users to login."""
+    response = test_app.get("/", allow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login.html"


### PR DESCRIPTION
## Summary
- restrict access to admin pages in the auth middleware
- verify redirect to login page in root endpoint test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d82649e508333b5c6ab8bc31a0ad5