### PR TITLE
Implement form input validation

### DIFF
--- a/app/schemas/bot.py
+++ b/app/schemas/bot.py
@@ -1,30 +1,32 @@
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, constr
+
 
 class BotBase(BaseModel):
-    name: str
+    name: constr(strip_whitespace=True, min_length=1)
+    gpt_model: constr(strip_whitespace=True, min_length=1)
     session_id: Optional[str] = None
-    gpt_model: str
 
-class BotCreate(BaseModel):
-    name: str
+
+class BotCreate(BotBase):
     description: Optional[str] = None
-    gpt_model: str
-    session_id: Optional[str] = None
+
 
 class BotOut(BaseModel):
     id: int
     name: str
     description: Optional[str]
+
     class Config:
         orm_mode = True
 
+
 class BotUpdate(BotBase):
     pass
+
 
 class Bot(BotBase):
     id: int
 
     class Config:
         orm_mode = True
-

--- a/app/schemas/channel.py
+++ b/app/schemas/channel.py
@@ -1,15 +1,19 @@
 from typing import List
-from pydantic import BaseModel
+from pydantic import BaseModel, constr, conint
+
 
 class ChannelBase(BaseModel):
-    name: str
-    connector_id: int
+    name: constr(strip_whitespace=True, min_length=1)
+    connector_id: conint(gt=0)
+
 
 class ChannelCreate(ChannelBase):
     pass
 
+
 class ChannelUpdate(ChannelBase):
     pass
+
 
 class Channel(ChannelBase):
     id: int

--- a/app/schemas/connector.py
+++ b/app/schemas/connector.py
@@ -1,20 +1,23 @@
 from typing import List, Dict, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, constr, Field
+
 
 class ConnectorBase(BaseModel):
-    name: str
-    config: Dict[str, Any]
-    connector_type: str
+    name: constr(strip_whitespace=True, min_length=1)
+    config: Dict[str, Any] = Field(default_factory=dict)
+    connector_type: constr(strip_whitespace=True, min_length=1)
+
 
 class ConnectorCreate(ConnectorBase):
     pass
 
+
 class ConnectorUpdate(ConnectorBase):
     pass
+
 
 class Connector(ConnectorBase):
     id: int
 
     class Config:
         orm_mode = True
-

--- a/app/schemas/filter.py
+++ b/app/schemas/filter.py
@@ -1,16 +1,29 @@
 from typing import List
-from pydantic import BaseModel
+from pydantic import BaseModel, constr, conint, validator
+import re
+
 
 class FilterBase(BaseModel):
-    channel_id: int
-    regex: str
+    channel_id: conint(gt=0)
+    regex: constr(strip_whitespace=True, min_length=1)
     description: str
+
+    @validator("regex")
+    def validate_regex(cls, v):
+        try:
+            re.compile(v)
+        except re.error as exc:
+            raise ValueError("Invalid regular expression") from exc
+        return v
+
 
 class FilterCreate(FilterBase):
     pass
 
+
 class FilterUpdate(FilterBase):
     pass
+
 
 class Filter(FilterBase):
     id: int

--- a/app/static/js/bots.js
+++ b/app/static/js/bots.js
@@ -2,6 +2,23 @@
 let selectedBotId = null;
 const sendButton = document.getElementById('send-message');
 
+function showError(input, message) {
+  input.classList.add('is-invalid');
+  let feedback = input.parentNode.querySelector('.invalid-feedback');
+  if (!feedback) {
+    feedback = document.createElement('div');
+    feedback.className = 'invalid-feedback';
+    input.parentNode.appendChild(feedback);
+  }
+  feedback.textContent = message;
+}
+
+function clearError(input) {
+  input.classList.remove('is-invalid');
+  const feedback = input.parentNode.querySelector('.invalid-feedback');
+  if (feedback) feedback.textContent = '';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const sendButton = document.getElementById('send-message');
   // Fetch bots and render them in the bots container
@@ -12,12 +29,18 @@ document.addEventListener('DOMContentLoaded', () => {
   if (saveBtn) {
     saveBtn.addEventListener('click', async () => {
       if (!selectedBotId) return;
+      const nameInput = document.getElementById('edit-bot-name');
+      clearError(nameInput);
       const data = {
-        name: document.getElementById('edit-bot-name').value.trim(),
+        name: nameInput.value.trim(),
         description: document.getElementById('edit-bot-description').value.trim(),
         gpt_model: document.getElementById('edit-bot-model').value.trim(),
         enabled: document.getElementById('edit-bot-enabled').checked
       };
+      if (!data.name) {
+        showError(nameInput, 'Name is required');
+        return;
+      }
       const updated = await updateBot(selectedBotId, data);
       if (updated) {
         fetchBotsAndRender();
@@ -36,11 +59,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const nameInput = document.getElementById("bot-name");
       const descriptionInput = document.getElementById("bot-description");
 
+      clearError(nameInput);
+
       const name = nameInput.value.trim();
       const description = descriptionInput.value.trim();
 
       if (!name) {
-        alert("Please enter a bot name.");
+        showError(nameInput, 'Name is required');
         return;
       }
 

--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -1,4 +1,21 @@
 // Add a listener for DOMContentLoaded to make sure the page is fully loaded before running the script
+function showError(input, message) {
+  input.classList.add('is-invalid');
+  let feedback = input.parentNode.querySelector('.invalid-feedback');
+  if (!feedback) {
+    feedback = document.createElement('div');
+    feedback.className = 'invalid-feedback';
+    input.parentNode.appendChild(feedback);
+  }
+  feedback.textContent = message;
+}
+
+function clearError(input) {
+  input.classList.remove('is-invalid');
+  const feedback = input.parentNode.querySelector('.invalid-feedback');
+  if (feedback) feedback.textContent = '';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   fetchChannelsAndRender();
 });
@@ -98,9 +115,25 @@ document.getElementById('add-channel-form').addEventListener('submit', async (ev
   const nameInput = document.getElementById('channel-name');
   const connectorInput = document.getElementById('channel-connector');
 
+  clearError(nameInput);
+  clearError(connectorInput);
+
+  const name = nameInput.value.trim();
+  const connector = connectorInput.value;
+
+  if (!name) {
+    showError(nameInput, 'Name is required');
+    return;
+  }
+
+  if (!connector) {
+    showError(connectorInput, 'Connector is required');
+    return;
+  }
+
   const channelData = {
-    name: nameInput.value,
-    connector_id: parseInt(connectorInput.value, 10),
+    name,
+    connector_id: connector,
   };
 
   const newChannel = await createChannel(channelData);

--- a/app/static/js/connectors.js
+++ b/app/static/js/connectors.js
@@ -1,5 +1,22 @@
 // connectors.js - dynamic connector management
 
+function showError(input, message) {
+  input.classList.add('is-invalid');
+  let feedback = input.parentNode.querySelector('.invalid-feedback');
+  if (!feedback) {
+    feedback = document.createElement('div');
+    feedback.className = 'invalid-feedback';
+    input.parentNode.appendChild(feedback);
+  }
+  feedback.textContent = message;
+}
+
+function clearError(input) {
+  input.classList.remove('is-invalid');
+  const feedback = input.parentNode.querySelector('.invalid-feedback');
+  if (feedback) feedback.textContent = '';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   fetchConnectorsAndRender();
 
@@ -10,18 +27,35 @@ document.addEventListener('DOMContentLoaded', () => {
       const nameInput = document.getElementById('connector-name');
       const typeInput = document.getElementById('connector-type');
       const configInput = document.getElementById('connector-config');
+      clearError(nameInput);
+      clearError(typeInput);
+      clearError(configInput);
+
+      const name = nameInput.value.trim();
+      const type = typeInput.value.trim();
       let config = {};
+
+      if (!name) {
+        showError(nameInput, 'Name is required');
+        return;
+      }
+
+      if (!type) {
+        showError(typeInput, 'Type is required');
+        return;
+      }
+
       if (configInput.value.trim()) {
         try {
           config = JSON.parse(configInput.value);
         } catch (e) {
-          alert('Config must be valid JSON');
+          showError(configInput, 'Config must be valid JSON');
           return;
         }
       }
       const connector = await createConnector({
-        name: nameInput.value.trim(),
-        connector_type: typeInput.value.trim(),
+        name,
+        connector_type: type,
         config: config
       });
       document.querySelector('.connectors-container')

--- a/app/static/js/filters.js
+++ b/app/static/js/filters.js
@@ -1,3 +1,20 @@
+function showError(input, message) {
+  input.classList.add('is-invalid');
+  let feedback = input.parentNode.querySelector('.invalid-feedback');
+  if (!feedback) {
+    feedback = document.createElement('div');
+    feedback.className = 'invalid-feedback';
+    input.parentNode.appendChild(feedback);
+  }
+  feedback.textContent = message;
+}
+
+function clearError(input) {
+  input.classList.remove('is-invalid');
+  const feedback = input.parentNode.querySelector('.invalid-feedback');
+  if (feedback) feedback.textContent = '';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   loadChannels();
   fetchFiltersAndRender();
@@ -111,9 +128,25 @@ document.getElementById('add-filter-form').addEventListener('submit', async (eve
   const regexInput = document.getElementById('filter-regex');
   const descriptionInput = document.getElementById('filter-description');
 
+  clearError(regexInput);
+
+  const regexValue = regexInput.value.trim();
+
+  if (!regexValue) {
+    showError(regexInput, 'Regex is required');
+    return;
+  }
+
+  try {
+    new RegExp(regexValue);
+  } catch (e) {
+    showError(regexInput, 'Invalid regular expression');
+    return;
+  }
+
   const filterData = {
     channel_id: parseInt(channelSelect.value, 10),
-    regex: regexInput.value,
+    regex: regexValue,
     description: descriptionInput.value,
   };
 


### PR DESCRIPTION
## Summary
- validate bot, channel, connector and filter models with Pydantic
- add client-side helpers to show inline form errors
- validate forms for bots, channels, connectors and filters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d826e3b588333bc835ec69e8c0e98