### PR TITLE
Add message processing hooks

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -134,7 +134,11 @@ async def create_message_endpoint(
 ):
     try:
         ljson = await request.json()
-        message = create_message(db=db, bot_id=bot_id, text=ljson.get('content'), source='user')
+        user_text = ljson.get('content')
+        from app.core.hooks import run_pre_hooks, run_post_hooks
+
+        user_text, hook_ctx = await run_pre_hooks(user_text, {"bot_id": bot_id})
+        message = create_message(db=db, bot_id=bot_id, text=user_text, source='user')
 
 
         # get the last messages for this bot, so it can generate a response based on history
@@ -164,13 +168,16 @@ async def create_message_endpoint(
             max_tokens=bot.default_response_tokens
         )
 
+        assistant_text = interaction_response['choices'][0]['message']['content']
+        assistant_text, hook_ctx = await run_post_hooks(assistant_text, hook_ctx)
+
         # Create an interaction schema
         interaction_in = InteractionCreate(
             bot_id=bot_id,
             message_id=message.id,
             input_data=message.text,
             gpt_model=interaction_response['model'],
-            output_data=interaction_response['choices'][0]['message']['content'],
+            output_data=assistant_text,
             tokens_in=interaction_response['usage']['prompt_tokens'],
             tokens_out=interaction_response.get("usage", {}).get("completion_tokens", 0),
             status_code=200,
@@ -179,7 +186,7 @@ async def create_message_endpoint(
 
         # Create a new interaction in the database
         interaction = create_interaction(db=db, interaction=interaction_in)
-        message = create_message(db=db, bot_id=bot_id, text=interaction_response['choices'][0]['message']['content'], source='assistant')
+        message = create_message(db=db, bot_id=bot_id, text=assistant_text, source='assistant')
         return {"status": "success", "message": "Message and interaction created successfully", "data": {"message": message, "interaction": interaction}}
     except Exception as e:
         print("Error:", e)

--- a/app/core/hooks.py
+++ b/app/core/hooks.py
@@ -1,0 +1,41 @@
+import asyncio
+from typing import Awaitable, Callable, List, Tuple
+
+# Type alias for hook callables
+PreHook = Callable[[str, dict], Awaitable[Tuple[str, dict]] | Tuple[str, dict]]
+PostHook = Callable[[str, dict], Awaitable[Tuple[str, dict]] | Tuple[str, dict]]
+
+_pre_hooks: List[PreHook] = []
+_post_hooks: List[PostHook] = []
+
+
+def register_pre_hook(hook: PreHook) -> None:
+    """Register a function to run before sending a message to the AI."""
+    _pre_hooks.append(hook)
+
+
+def register_post_hook(hook: PostHook) -> None:
+    """Register a function to run after receiving a reply from the AI."""
+    _post_hooks.append(hook)
+
+
+async def run_pre_hooks(message: str, context: dict) -> Tuple[str, dict]:
+    """Execute all registered pre-processing hooks."""
+    for hook in _pre_hooks:
+        result = hook(message, context)
+        if asyncio.iscoroutine(result):
+            message, context = await result
+        else:
+            message, context = result
+    return message, context
+
+
+async def run_post_hooks(reply: str, context: dict) -> Tuple[str, dict]:
+    """Execute all registered post-processing hooks."""
+    for hook in _post_hooks:
+        result = hook(reply, context)
+        if asyncio.iscoroutine(result):
+            reply, context = await result
+        else:
+            reply, context = result
+    return reply, context

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -57,6 +57,33 @@ Norman's core functionality can be modified and extended to suit your specific n
 
 When making changes to the core functionality, ensure that your modifications are compatible with the existing features and that they do not introduce new issues or vulnerabilities.
 
+## Registering Pre/Post Hooks
+
+Norman exposes simple hook points that allow you to run code before a message is
+sent to the LLM and after a reply is generated. This lets you implement custom
+checks, logging, or response rewriting without touching the core code.
+
+Hooks are defined in `app.core.hooks`:
+
+```python
+from app.core import hooks
+
+def my_pre_hook(message: str, context: dict) -> tuple[str, dict]:
+    # Modify or reject the message here
+    return message, context
+
+def my_post_hook(reply: str, context: dict) -> tuple[str, dict]:
+    # Inspect or alter the assistant reply
+    return reply, context
+
+hooks.register_pre_hook(my_pre_hook)
+hooks.register_post_hook(my_post_hook)
+```
+
+The hooks receive the message text (or reply) and a context dictionary. Each
+hook should return the possibly modified text and context. All registered hooks
+are executed in the order they were added.
+
 ## Contributing to Norman
 
 Contributions to the Norman project are welcome. Before submitting a pull request, please read and follow the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+from app.handlers import openai_handler
+import app.app_routes as app_routes
+from app.core import hooks
+
+async def _dummy_chat_interaction(messages, max_tokens=openai_handler.DEFAULT_MAX_TOKENS, model=openai_handler.DEFAULT_MODEL):
+    return {
+        "model": model,
+        "choices": [{"message": {"content": "assistant reply"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+    }
+
+
+def _pre_hook(message, context):
+    return message + " pre", context
+
+
+def _post_hook(reply, context):
+    return reply + " post", context
+
+
+def test_message_hooks(monkeypatch, test_app: TestClient):
+    monkeypatch.setattr(openai_handler, "create_chat_interaction", _dummy_chat_interaction)
+    monkeypatch.setattr(app_routes, "create_chat_interaction", _dummy_chat_interaction)
+
+    hooks._pre_hooks.clear()
+    hooks._post_hooks.clear()
+    hooks.register_pre_hook(_pre_hook)
+    hooks.register_post_hook(_post_hook)
+
+    payload = {"name": "hookbot", "description": "desc", "gpt_model": "gpt-4.1-mini"}
+    resp = test_app.post("/api/bots/create", json=payload)
+    assert resp.status_code == 200
+    bot_id = resp.json()["id"]
+
+    resp = test_app.post(f"/api/bots/{bot_id}/messages", json={"content": "hello"})
+    assert resp.status_code == 200
+
+    resp = test_app.get(f"/api/bots/{bot_id}/messages")
+    assert resp.status_code == 200
+    messages = resp.json()
+    assert messages[0]["text"] == "hello pre"
+    assert messages[1]["text"] == "assistant reply post"


### PR DESCRIPTION
## Summary
- introduce simple pre- and post-processing hooks
- call hooks from message endpoint
- document hook registration
- test hook behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d82b726348333bb0c5e5017cddfd7