### PR TITLE
Add Docker deployment option

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+venv/
+.env/
+*.db
+tests/
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.9-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Norman is an open-source chatbot that leverages OpenAI's GPT models to assist an
 - [Testing](#testing)
 - [Contributing](#contributing)
 - [License](#license)
+- [Docker Deployment](docs/docker.md)
 
 ### Features
 
@@ -119,7 +120,7 @@ pytest --cov=./ -vv
 
 ## Deployment
 
-Norman can be deployed on various platforms, such as on a local server or a cloud provider. For detailed deployment instructions, please refer to our [Deployment](docs/deployment.md) guide.
+Norman can be deployed on various platforms, such as on a local server or a cloud provider. For detailed deployment instructions, please refer to our [Deployment](docs/deployment.md) guide. A separate [Docker Deployment](docs/docker.md) guide is available if you prefer running Norman in containers.
 
 ## Architecture
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: norman
+      POSTGRES_PASSWORD: norman
+      POSTGRES_DB: norman
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+  app:
+    build: .
+    environment:
+      DATABASE_URL: postgresql+psycopg2://norman:norman@db:5432/norman
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./config.yaml:/app/config.yaml
+volumes:
+  postgres-data:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,36 @@
+# Docker Deployment
+
+This guide explains how to run Norman inside Docker for a reproducible environment.
+
+## Building the Image
+
+1. Copy `config.yaml.dist` to `config.yaml` and adjust the settings for your installation.
+2. Build the Docker image from the repository root:
+
+   ```bash
+   docker build -t norman .
+   ```
+
+## Running the Container
+
+Run Norman with the generated image and mount your configuration and database directory:
+
+```bash
+docker run -v $(pwd)/config.yaml:/app/config.yaml \
+           -v $(pwd)/db:/app/db \
+           -p 8000:8000 norman
+```
+
+Visit `http://localhost:8000` to access the API.
+
+## docker-compose Example
+
+A sample `docker-compose.yml` is included for running Norman together with a PostgreSQL database.
+Start both services with:
+
+```bash
+docker-compose up
+```
+
+The compose file sets the `DATABASE_URL` environment variable so Norman uses the
+`db` service. Database data is stored in the `postgres-data` volume.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Welcome to the Norman documentation! Here you'll find everything you need to kno
 - [Usage](usage.md) - Learn how to set up and use Norman.
 - [Examples](examples.md) - Step-by-step usage examples and API calls.
 - [Deployment](deployment.md) - Instructions on how to deploy Norman on various platforms.
+- [Docker Deployment](docker.md) - Containerized setup using Docker and docker-compose.
 - [Extending Norman](extending.md) - A guide on how to extend Norman with new connectors, actions, and filters.
 - [Architecture](architecture.md) - An explanation of Norman's architecture and design principles.
 - [Philosophy](philosophy.md) - Learn about the philosophy behind Norman and our project goals.


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose example
- document running Norman in Docker
- link to Docker docs from README and docs index
- add .dockerignore

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d82da19688333b9af7a572d9b845c