### PR TITLE
Implement configuration dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Norman is an open-source chatbot that leverages OpenAI's GPT models to assist an
 - Supports multiple chat platforms (e.g., Slack, IRC) through connectors
 - Allows multiple chatbots with different GPT models (e.g., gpt-4.1-mini, o3)
 - Configurable channel filters and actions for automation
-- Minimal Web UI for configuration and management
+- Configuration dashboard accessible from the Web UI
 - SQLite database for lightweight deployment
 - Authentication and authorization support
 - Extendable with custom connectors

--- a/alembic/versions/add_enabled_fields.py
+++ b/alembic/versions/add_enabled_fields.py
@@ -1,0 +1,22 @@
+"""add enabled fields to bot and connector
+
+Revision ID: add_enabled_fields
+Revises: fdfa37da0489
+Create Date: 2024-05-19
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'add_enabled_fields'
+down_revision = 'fdfa37da0489'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('bots', sa.Column('enabled', sa.Boolean(), nullable=False, server_default=sa.true()))
+    op.add_column('connectors', sa.Column('enabled', sa.Boolean(), nullable=False, server_default=sa.true()))
+
+
+def downgrade():
+    op.drop_column('bots', 'enabled')
+    op.drop_column('connectors', 'enabled')

--- a/app/crud/bot.py
+++ b/app/crud/bot.py
@@ -10,6 +10,7 @@ def create_bot(db: Session, bot_create: schemas.BotCreate):
         description=bot_create.description,
         gpt_model=bot_create.gpt_model,
         session_id=bot_create.session_id,
+        enabled=bot_create.enabled,
     )
     db.add(bot)
     db.commit()
@@ -28,7 +29,7 @@ def update_bot(db: Session, bot_id: int, bot_data: schemas.BotUpdate):
     bot = db.query(models.Bot).filter(models.Bot.id == bot_id).first()
     if bot is None:
         return None
-    for key, value in bot_data.dict().items():
+    for key, value in bot_data.dict(exclude_unset=True).items():
         if value is not None:
             setattr(bot, key, value)
     db.commit()

--- a/app/models/bot.py
+++ b/app/models/bot.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Boolean
 from sqlalchemy.sql import func
 from app.db.base import Base
 
@@ -9,6 +9,7 @@ class Bot(Base):
     description = Column(String, nullable=False)
     user_id = Column(Integer, ForeignKey("users.id"))
     session_id = Column(String, nullable=True)
+    enabled = Column(Boolean, nullable=False, default=True)
     gpt_model = Column(String, nullable=False, default="gpt-4.1-mini")
     system_prompt = Column(String, nullable=False, default="You are a helpful assistant.")
     default_response_tokens = Column(Integer, nullable=False, default=150) # how much to generate

--- a/app/models/connectors.py
+++ b/app/models/connectors.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, JSON
+from sqlalchemy import Column, Integer, String, DateTime, JSON, Boolean
 from sqlalchemy.sql import func
 from app.db.base import Base
 
@@ -14,5 +14,6 @@ class Connector(Base):
     last_message_sent = Column(DateTime(timezone=True))
     last_message_received = Column(DateTime(timezone=True))
     last_successful_message = Column(DateTime(timezone=True))
+    enabled = Column(Boolean, nullable=False, default=True)
     config = Column(JSON)
 

--- a/app/schemas/bot.py
+++ b/app/schemas/bot.py
@@ -5,17 +5,20 @@ class BotBase(BaseModel):
     name: str
     session_id: Optional[str] = None
     gpt_model: str
+    enabled: bool = True
 
 class BotCreate(BaseModel):
     name: str
     description: Optional[str] = None
     gpt_model: str
     session_id: Optional[str] = None
+    enabled: bool = True
 
 class BotOut(BaseModel):
     id: int
     name: str
     description: Optional[str]
+    enabled: bool
     class Config:
         orm_mode = True
 

--- a/app/schemas/connector.py
+++ b/app/schemas/connector.py
@@ -5,6 +5,7 @@ class ConnectorBase(BaseModel):
     name: str
     config: Dict[str, Any]
     connector_type: str
+    enabled: bool = True
 
 class ConnectorCreate(ConnectorBase):
     pass

--- a/app/static/js/bots.js
+++ b/app/static/js/bots.js
@@ -44,13 +44,19 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
-      const bot = await addBot(name, description, "gpt4");
+      const modelInput = document.getElementById("bot-model");
+      const enabledInput = document.getElementById("bot-enabled");
+      const model = modelInput.value.trim() || "gpt-4.1-mini";
+      const enabled = enabledInput.checked;
+      const bot = await addBot(name, description, model, enabled);
       const botElement = createBotElement(bot);
       const botsContainer = document.querySelector('.bots-container');
       botsContainer.appendChild(botElement);
 
       nameInput.value = "";
       descriptionInput.value = "";
+      modelInput.value = "gpt-4.1-mini";
+      enabledInput.checked = true;
     });
   }
   sendButton.addEventListener("click", async (event) => {
@@ -110,6 +116,10 @@ function createBotElement(bot) {
   botElement.classList.add('list-group-item', 'list-group-item-action', 'bot-item');
   botElement.dataset.botId = bot.id;
   botElement.textContent = bot.name;
+  const enabledSpan = document.createElement('span');
+  enabledSpan.className = 'badge ms-2 ' + (bot.enabled ? 'bg-success' : 'bg-warning');
+  enabledSpan.textContent = bot.enabled ? 'enabled' : 'disabled';
+  botElement.appendChild(enabledSpan);
 
   const editButton = document.createElement('button');
   editButton.className = 'btn btn-sm btn-secondary float-end ms-2';
@@ -148,13 +158,13 @@ function createBotElement(bot) {
 }
 
 
-async function addBot(name, description, model) {
+async function addBot(name, description, model, enabled) {
   const response = await fetch("/api/bots/create", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ name, description, model }),
+    body: JSON.stringify({ name, description, gpt_model: model, enabled }),
   });
   const bot = await response.json();
   return bot;

--- a/app/static/js/connectors.js
+++ b/app/static/js/connectors.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const nameInput = document.getElementById('connector-name');
       const typeInput = document.getElementById('connector-type');
       const configInput = document.getElementById('connector-config');
+      const enabledInput = document.getElementById('connector-enabled');
       let config = {};
       if (configInput.value.trim()) {
         try {
@@ -22,13 +23,15 @@ document.addEventListener('DOMContentLoaded', () => {
       const connector = await createConnector({
         name: nameInput.value.trim(),
         connector_type: typeInput.value.trim(),
-        config: config
+        config: config,
+        enabled: enabledInput.checked
       });
       document.querySelector('.connectors-container')
         .appendChild(createConnectorElement(connector));
       nameInput.value = '';
       typeInput.value = '';
       configInput.value = '';
+      enabledInput.checked = true;
     });
   }
 });
@@ -97,7 +100,11 @@ function createConnectorElement(connector) {
   const statusSpan = document.createElement('span');
   statusSpan.className = 'badge bg-secondary ms-2 connector-status';
   statusSpan.textContent = '...';
+  const enabledSpan = document.createElement('span');
+  enabledSpan.className = 'badge ms-2 ' + (connector.enabled ? 'bg-success' : 'bg-warning');
+  enabledSpan.textContent = connector.enabled ? 'enabled' : 'disabled';
   header.appendChild(statusSpan);
+  header.appendChild(enabledSpan);
   body.appendChild(header);
 
   const editBtn = document.createElement('button');
@@ -126,6 +133,17 @@ function createConnectorElement(connector) {
     }
   });
 
+  const toggleBtn = document.createElement('button');
+  toggleBtn.className = 'btn btn-sm btn-outline-secondary me-2';
+  toggleBtn.textContent = connector.enabled ? 'Disable' : 'Enable';
+  toggleBtn.addEventListener('click', async () => {
+    connector.enabled = !connector.enabled;
+    const updated = await updateConnector(connector.id, { enabled: connector.enabled });
+    toggleBtn.textContent = updated.enabled ? 'Disable' : 'Enable';
+    enabledSpan.className = 'badge ms-2 ' + (updated.enabled ? 'bg-success' : 'bg-warning');
+    enabledSpan.textContent = updated.enabled ? 'enabled' : 'disabled';
+  });
+
   const deleteBtn = document.createElement('button');
   deleteBtn.className = 'btn btn-sm btn-danger me-2';
   deleteBtn.textContent = 'Delete';
@@ -143,6 +161,7 @@ function createConnectorElement(connector) {
   });
 
   body.appendChild(editBtn);
+  body.appendChild(toggleBtn);
   body.appendChild(deleteBtn);
   body.appendChild(testBtn);
   card.appendChild(body);

--- a/app/templates/bots.html
+++ b/app/templates/bots.html
@@ -22,6 +22,14 @@
         <label for="bot-description" class="form-label">Description</label>
         <input type="text" id="bot-description" class="form-control" />
       </div>
+      <div class="mb-3">
+        <label for="bot-model" class="form-label">GPT Model</label>
+        <input type="text" id="bot-model" class="form-control" value="gpt-4.1-mini" />
+      </div>
+      <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" id="bot-enabled" checked>
+        <label class="form-check-label" for="bot-enabled">Enabled</label>
+      </div>
       <button type="submit" class="btn btn-primary">Add Bot</button>
     </form>
 

--- a/app/templates/connectors.html
+++ b/app/templates/connectors.html
@@ -17,6 +17,10 @@
       <label for="connector-config" class="form-label">Config (JSON)</label>
       <input type="text" id="connector-config" class="form-control" />
     </div>
+    <div class="col-auto form-check mt-4">
+      <input class="form-check-input" type="checkbox" id="connector-enabled" checked>
+      <label class="form-check-label" for="connector-enabled">Enabled</label>
+    </div>
     <div class="col-auto">
       <button type="submit" class="btn btn-primary">Add Connector</button>
     </div>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,6 +2,8 @@
 
 This document provides an overview of how to interact with Norman, including creating and configuring chatbots, setting up channel filters and actions, and examples of common use-cases and automations.
 
+Norman now includes a configuration dashboard accessible from the Web UI. Most settings that previously required editing `config.yaml` can be managed directly in the browser. Use the dashboard to create or edit chatbots, enable or disable connectors, and review the status of each integration.
+
 ## Table of Contents
 
 - [Creating a Chatbot](#creating-a-chatbot)
@@ -60,7 +62,7 @@ Remember to expand on these sections and provide more detailed information based
 
 This example demonstrates how to connect Norman to Slack and create a simple bot.
 
-1. Run Norman once to generate `config.yaml` and edit the Slack section:
+1. Run Norman once to generate `config.yaml`. You can edit the Slack section in the file or provide the details later via the dashboard:
 
 ```yaml
 slack_token: "xoxb-your-slack-token"

--- a/tests/routers/test_connectors.py
+++ b/tests/routers/test_connectors.py
@@ -3,22 +3,24 @@ from sqlalchemy.orm import Session
 
 
 def test_connectors_router_crud(test_app: TestClient, db: Session) -> None:
-    payload = {"connector_type": "irc", "name": "c1", "config": {}}
+    payload = {"connector_type": "irc", "name": "c1", "config": {}, "enabled": True}
     resp = test_app.post("/api/v1/connectors/", json=payload)
     assert resp.status_code == 201
     data = resp.json()
+    assert data["enabled"] is True
     connector_id = data["id"]
 
     resp = test_app.get("/api/v1/connectors/")
     assert resp.status_code == 200
     assert any(c["id"] == connector_id for c in resp.json())
 
-    update = {"connector_type": "irc", "name": "c2", "config": {}}
+    update = {"connector_type": "irc", "name": "c2", "config": {}, "enabled": False}
     resp = test_app.put(
         f"/api/v1/connectors/{connector_id}", json=update
     )
     assert resp.status_code == 200
     assert resp.json()["name"] == update["name"]
+    assert resp.json()["enabled"] == update["enabled"]
 
     resp = test_app.delete(f"/api/v1/connectors/{connector_id}")
     assert resp.status_code == 200

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -12,6 +12,7 @@ def test_create_bot_api(test_app: TestClient, db: Session) -> None:
     data = response.json()
     assert data["name"] == payload["name"]
     assert data["description"] == payload["description"]
+    assert data["enabled"] is True
     assert "id" in data
 
 

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -17,6 +17,7 @@ def test_create_bot(test_app: TestClient, db: Session) -> None:
     assert bot.gpt_model == gpt_model
     assert bot.name == name
     assert bot.session_id == session_id
+    assert bot.enabled is True
 
 def test_get_bot(test_app: TestClient, db: Session) -> None:
     gpt_model = "test-model"
@@ -32,4 +33,5 @@ def test_get_bot(test_app: TestClient, db: Session) -> None:
     assert bot.name == bot_2.name
     assert bot.id == bot_2.id
     assert bot.session_id == bot_2.session_id
+    assert bot_2.enabled is True
 


### PR DESCRIPTION
## Summary
- add `enabled` field to bots and connectors
- expose bot and connector enable settings through new API fields
- extend dashboard UI for creating and editing bots and connectors
- document configuration dashboard usage
- create Alembic migration
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d824ef9b08333ad010b13d5c40158