### PR TITLE
Fix Python 3.8 type hints

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -9,10 +9,10 @@ from fastapi import Request
 
 from .config import settings
 
-request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+request_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "request_id", default=None
 )
-conversation_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+conversation_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "conversation_id", default=None
 )
 


### PR DESCRIPTION
## Summary
- fix union type hints in logging util

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_683d878254d48333bc4b56814b86b6e4