### PR TITLE
Fix Python 3.8 typing compatibility

### DIFF
--- a/app/app_routes.py
+++ b/app/app_routes.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict, Optional
 from fastapi import APIRouter, Depends, Request, HTTPException
 from fastapi import status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -42,7 +42,7 @@ app_routes = APIRouter()
 
 
 @app_routes.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> Dict[str, str]:
     """Simple health check endpoint."""
     return {"status": "ok"}
 
@@ -119,7 +119,7 @@ async def get_messages_endpoint(
     bot_id: int,
     limit: int = 100,
     offset: int = 0,
-    cursor: int | None = None,
+    cursor: Optional[int] = None,
     db: Session = Depends(get_async_db),
 ):
     """Return messages for a bot with optional pagination."""

--- a/app/core/hooks.py
+++ b/app/core/hooks.py
@@ -1,9 +1,9 @@
 import asyncio
-from typing import Awaitable, Callable, List, Tuple
+from typing import Awaitable, Callable, List, Tuple, Union
 
 # Type alias for hook callables
-PreHook = Callable[[str, dict], Awaitable[Tuple[str, dict]] | Tuple[str, dict]]
-PostHook = Callable[[str, dict], Awaitable[Tuple[str, dict]] | Tuple[str, dict]]
+PreHook = Callable[[str, dict], Union[Awaitable[Tuple[str, dict]], Tuple[str, dict]]]
+PostHook = Callable[[str, dict], Union[Awaitable[Tuple[str, dict]], Tuple[str, dict]]]
 
 _pre_hooks: List[PreHook] = []
 _post_hooks: List[PostHook] = []


### PR DESCRIPTION
## Summary
- update types in app routes and hooks to work on Python 3.8
- replace union syntax and builtin generics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d93c7a2f88333969edc30820a47ef