### PR TITLE
Optimize SQLite settings

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -33,5 +33,6 @@ if settings.database_url.startswith("sqlite"):
         os.makedirs(os.path.dirname(db_path), exist_ok=True)
     with engine.connect() as conn:
         conn.execute(text("PRAGMA journal_mode=WAL"))
+        conn.execute(text("PRAGMA synchronous=NORMAL"))
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/tests/test_db_session.py
+++ b/tests/test_db_session.py
@@ -45,6 +45,18 @@ def test_sqlite_wal_enabled():
         assert mode == "wal"
 
 
+def test_sqlite_synchronous_normal():
+    spec = importlib.util.spec_from_file_location(
+        "temp_db_session", os.path.join("app", "db", "session.py")
+    )
+    db_session = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(db_session)
+    if settings.database_url.startswith("sqlite"):
+        with db_session.engine.connect() as conn:
+            synchronous = conn.execute(db_session.text("PRAGMA synchronous")).scalar()
+        assert synchronous == 1
+
+
 def test_session_connection_cleanup():
     spec = importlib.util.spec_from_file_location(
         "temp_db_session", os.path.join("app", "db", "session.py")


### PR DESCRIPTION
## Summary
- configure SQLite synchronous=normal in db session
- test that SQLite synchronous pragma is set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d9e082a948333b22fe34e4617199a