### PR TITLE
Implement Matrix connector listener

### DIFF
--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -29,6 +29,8 @@ The fields are:
 ## Usage
 
 Once configured, Norman will join the specified room and can send and receive messages via Matrix.
+The connector polls the Matrix sync API for new events and dispatches any
+`m.room.message` content to Norman.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- extend `MatrixConnector` with a `_next_batch` field
- implement `listen_and_process` to poll the Matrix sync API
- document Matrix event polling behaviour
- add tests for the new listener

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683da93332c4833391f150c38758ca39