### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9']
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -18,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/kristopherkubicki/norman/badge)](https://securityscorecards.dev/viewer/?uri=github.com/kristopherkubicki/norman)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 [![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/)
+[![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/)
 [![GitHub release](https://img.shields.io/github/v/release/KristopherKubicki/norman.svg)](https://github.com/KristopherKubicki/norman/releases)
 
 Norman is an open-source chatbot that leverages OpenAI's GPT models to assist and automate communication on various chat platforms like Slack and IRC. The project is built with FastAPI, SQLite, and SQLAlchemy, and is designed to be easily extensible with additional connectors.
@@ -50,7 +51,7 @@ Norman is an open-source chatbot that leverages OpenAI's GPT models to assist an
 
 ### Prerequisites
 
-- Python 3.8 or higher
+- Python 3.8 or 3.9
 - pip
 - SQLite
 - virtualenv (optional)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,7 @@ This document outlines the steps to deploy Norman on a server or cloud provider.
 
 Before deploying Norman, ensure that your server meets the following requirements:
 
-- Python 3.8 or higher
+- Python 3.8 or 3.9
 - SQLite (or another supported database system)
 - A compatible operating system, such as Ubuntu, Debian, or CentOS
 


### PR DESCRIPTION
## Summary
- update CI pipeline to test on Python 3.8 and 3.9
- document Python 3.9 support in README and deployment guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dd0bac2e08333afa52e39cc027f96