### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ENV PYTHONUNBUFFERED=1
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 [![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/)
 [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/)
+[![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/)
 [![GitHub release](https://img.shields.io/github/v/release/KristopherKubicki/norman.svg)](https://github.com/KristopherKubicki/norman/releases)
 
 Norman is an open-source chatbot that leverages OpenAI's GPT models to assist and automate communication on various chat platforms like Slack and IRC. The project is built with FastAPI, SQLite, and SQLAlchemy, and is designed to be easily extensible with additional connectors.
@@ -51,7 +52,7 @@ Norman is an open-source chatbot that leverages OpenAI's GPT models to assist an
 
 ### Prerequisites
 
-- Python 3.8 or 3.9
+- Python 3.8, 3.9, or 3.10
 - pip
 - SQLite
 - virtualenv (optional)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,7 @@ This document outlines the steps to deploy Norman on a server or cloud provider.
 
 Before deploying Norman, ensure that your server meets the following requirements:
 
-- Python 3.8 or 3.9
+- Python 3.8, 3.9, or 3.10
 - SQLite (or another supported database system)
 - A compatible operating system, such as Ubuntu, Debian, or CentOS
 


### PR DESCRIPTION
## Summary
- update Dockerfile to use python 3.10
- run CI on Python 3.8, 3.9 and 3.10
- document support for Python 3.10

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dd5ae6ed48333a9e3f73fc2cb6e88