### PR TITLE
Improve first run docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ pip install -r requirements.txt
 Norman automatically enables [WAL](https://www.sqlite.org/wal.html) mode when using SQLite for improved concurrency.
 
 4. Run Norman once to automatically generate `config.yaml` with secure defaults.
-   Afterwards edit this file to configure connectors and add your OpenAI API key.
+   The admin username, email and password will be printed to the console.
+   Take note of these values, edit `config.yaml` to configure connectors and
+   add your OpenAI API key, then start Norman again.
 
 5. (Optional) Regenerate the secrets in `config.yaml` using the provided script:
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -287,6 +287,7 @@ def ensure_user_config():
         print(f"  email: {cfg['initial_admin_email']}")
         print(f"  password: {cfg['initial_admin_password']}")
         print("Edit config.yaml to customize settings, including your OpenAI API key.")
+        print("Restart Norman and visit http://localhost:8000 to sign in with these credentials.")
 
 def load_config():
     ensure_user_config()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,6 +8,7 @@ This document provides an overview of how to interact with Norman, including cre
 - [Configuring a Chatbot](#configuring-a-chatbot)
 - [Channel Filters and Actions](#channel-filters-and-actions)
 - [Examples](#examples)
+- [First Run](#first-run)
 - [Slack Quick Start](#slack-bot-quick-start)
 - [API Examples](#api-examples)
 
@@ -55,6 +56,15 @@ Here are some example use-cases for Norman:
 3. **Automated Code Review:** Create a channel filter that detects when users submit pull requests. Norman can then analyze the code, provide suggestions or corrections, and post a review comment on the pull request.
 
 Remember to expand on these sections and provide more detailed information based on your project's specific features and requirements.
+
+## First Run
+
+When starting Norman for the first time, the application creates a
+`config.yaml` file with random credentials. The admin username, email
+and password are printed to the console. Record these values, edit
+`config.yaml` to supply your `openai_api_key` and any connector
+settings, then restart Norman. Visit `http://localhost:8000` and sign
+in with the credentials shown.
 
 ## Slack Bot Quick Start
 


### PR DESCRIPTION
## Summary
- clarify that initial admin credentials are printed when running Norman for the first time
- show how to restart Norman after editing `config.yaml`
- add a dedicated *First Run* section in the usage guide
- mention web UI login instructions when generating config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683df1a02bd883339f9bcb7e5cf5da5b