### PR TITLE
Add DingTalk connector stub

### DIFF
--- a/app/connectors/dingtalk_connector.py
+++ b/app/connectors/dingtalk_connector.py
@@ -1,0 +1,26 @@
+from .base_connector import BaseConnector
+
+
+class DingTalkConnector(BaseConnector):
+    """Connector for Alibaba DingTalk chat messages."""
+
+    id = "dingtalk"
+    name = "DingTalk"
+
+    def __init__(self, access_token: str, config=None):
+        super().__init__(config)
+        self.access_token = access_token
+        self.sent_messages = []
+
+    async def send_message(self, message) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
+
+    async def listen_and_process(self):
+        """Listening for DingTalk messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message):
+        """Return the incoming ``message`` payload."""
+        return message

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -72,6 +72,7 @@ The following connectors are currently supported:
 63. [Broadcast](./connectors/broadcast.md)
 64. [X.com](./connectors/xcom.md)
 65. [Zoom](./connectors/zoom.md)
+66. [DingTalk](./connectors/dingtalk.md)
 
 
 ## Usage
@@ -140,5 +141,6 @@ For more detailed information on each connector, please refer to the platform-sp
 - [SMS Connector](./connectors/sms.md)
 - [Broadcast Connector](./connectors/broadcast.md)
 - [Zoom Connector](./connectors/zoom.md)
+- [DingTalk Connector](./connectors/dingtalk.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/dingtalk.md
+++ b/docs/connectors/dingtalk.md
@@ -1,0 +1,16 @@
+# DingTalk Connector
+
+The DingTalk connector allows Norman to interact with Alibaba DingTalk chats.
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+dingtalk_access_token: "your_dingtalk_access_token"
+```
+
+## Usage
+
+The connector currently records messages locally and can be extended to
+integrate with the DingTalk API.

--- a/tests/connectors/test_dingtalk.py
+++ b/tests/connectors/test_dingtalk.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from app.connectors.dingtalk_connector import DingTalkConnector
+
+
+def test_send_message():
+    connector = DingTalkConnector("token")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = DingTalkConnector("token")
+    payload = {"foo": "bar"}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == payload


### PR DESCRIPTION
## Summary
- add `DingTalkConnector` stub
- document DingTalk connector
- include DingTalk in connector list
- add unit tests for the new stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e18d623548333ad43ac548dd04d0a