### PR TITLE
Improve error handling

### DIFF
--- a/app/core/exception_handlers.py
+++ b/app/core/exception_handlers.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from .exceptions import (
+    APIError,
+    AuthenticationError,
+    AuthorizationError,
+    DatabaseError,
+    NormanError,
+)
+from .logging import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def add_exception_handlers(app: FastAPI) -> None:
+    """Register standard exception handlers on the given ``app``."""
+
+    async def _handle(request: Request, exc: Exception, status: int, detail: str):
+        logger.error("%s on %s: %s", exc.__class__.__name__, request.url.path, exc)
+        return JSONResponse(status_code=status, content={"detail": detail})
+
+    @app.exception_handler(AuthenticationError)
+    async def _auth_exc_handler(request: Request, exc: AuthenticationError):
+        return await _handle(request, exc, 401, str(exc))
+
+    @app.exception_handler(AuthorizationError)
+    async def _authz_exc_handler(request: Request, exc: AuthorizationError):
+        return await _handle(request, exc, 403, str(exc))
+
+    @app.exception_handler(DatabaseError)
+    async def _db_exc_handler(request: Request, exc: DatabaseError):
+        return await _handle(request, exc, 500, "Database error")
+
+    @app.exception_handler(APIError)
+    async def _api_exc_handler(request: Request, exc: APIError):
+        return await _handle(request, exc, 502, str(exc))
+
+    @app.exception_handler(NormanError)
+    async def _norman_exc_handler(request: Request, exc: NormanError):
+        return await _handle(request, exc, 500, str(exc))

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from app.app_routes import app_routes
 from app.core.config import settings
 from app.auth_middleware import auth_middleware
 from app.core.logging import request_context_middleware
+from app.core.exception_handlers import add_exception_handlers
 
 def run_alembic_migrations():
     if not os.path.exists("alembic/versions"):
@@ -65,6 +66,7 @@ init_connectors(app, settings)
 
 # Initialize the routers
 init_routers(app)
+add_exception_handlers(app)
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
 app.mount("/static", StaticFiles(directory=os.path.join(current_dir, "app/static")), name="static")

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import add_exception_handlers
+from app.core.exceptions import APIError, DatabaseError, AuthenticationError
+
+
+def _create_app():
+    app = FastAPI()
+    add_exception_handlers(app)
+
+    @app.get("/api")
+    async def _api():
+        raise APIError("boom")
+
+    @app.get("/db")
+    async def _db():
+        raise DatabaseError("broken")
+
+    @app.get("/auth")
+    async def _auth():
+        raise AuthenticationError("bad token")
+
+    return app
+
+
+def test_api_error_handler():
+    client = TestClient(_create_app())
+    resp = client.get("/api")
+    assert resp.status_code == 502
+    assert resp.json() == {"detail": "boom"}
+
+
+def test_database_error_handler():
+    client = TestClient(_create_app())
+    resp = client.get("/db")
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "Database error"}
+
+
+def test_authentication_error_handler():
+    client = TestClient(_create_app())
+    resp = client.get("/auth")
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "bad token"}


### PR DESCRIPTION
## Summary
- add exception handlers for common Norman errors
- use `add_exception_handlers` during app startup
- test API, DB and auth error handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e205e4ea883339107e93097a204f5