### PR TITLE
Add BaseAction class for plugin extensibility

### DIFF
--- a/app/actions/__init__.py
+++ b/app/actions/__init__.py
@@ -1,0 +1,5 @@
+"""Action plugin package."""
+
+from .base_action import BaseAction
+
+__all__ = ["BaseAction"]

--- a/app/actions/base_action.py
+++ b/app/actions/base_action.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+
+class BaseAction(ABC):
+    """Base class for all action plugins."""
+
+    def __init__(self, config: Optional[dict] = None) -> None:
+        self.config = config or {}
+
+    @abstractmethod
+    async def execute(self, message: Any, context: dict) -> Any:
+        """Perform the action for ``message`` and return a result."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- introduce an `app/actions` package
- add `BaseAction` abstract class to define action plugin interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e2063e2ec8333a805e5528cba8aba