### PR TITLE
Improve router and OpenAI tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,3 +6,9 @@ def test_home_page_requires_login(test_app: TestClient) -> None:
     response = test_app.get("/", allow_redirects=False)
     assert response.status_code == 303
     assert response.headers["location"] == "/login.html"
+
+
+def test_bots_page_requires_login(test_app: TestClient) -> None:
+    response = test_app.get("/bots.html", allow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login.html"

--- a/tests/test_openai_handler.py
+++ b/tests/test_openai_handler.py
@@ -1,0 +1,36 @@
+import asyncio
+import pytest
+
+from app.handlers import openai_handler
+from app.core.exceptions import APIError
+
+
+def test_openai_handler_returns_fallback(monkeypatch):
+    monkeypatch.setattr(openai_handler.openai, "api_key", None)
+
+    async def _fail(*args, **kwargs):
+        raise Exception("boom")
+
+    monkeypatch.setattr(openai_handler.openai.ChatCompletion, "acreate", _fail)
+
+    messages = [{"role": "user", "content": "hi"}]
+    resp = asyncio.get_event_loop().run_until_complete(
+        openai_handler.create_chat_interaction(messages)
+    )
+    assert resp.get("error") is True
+    assert "Please add your OpenAI API key" in resp["choices"][0]["message"]["content"]
+
+
+def test_openai_handler_raises_apierror(monkeypatch):
+    monkeypatch.setattr(openai_handler.openai, "api_key", "x")
+
+    async def _fail(*args, **kwargs):
+        raise Exception("boom")
+
+    monkeypatch.setattr(openai_handler.openai.ChatCompletion, "acreate", _fail)
+
+    messages = [{"role": "user", "content": "hi"}]
+    with pytest.raises(APIError):
+        asyncio.get_event_loop().run_until_complete(
+            openai_handler.create_chat_interaction(messages)
+        )

--- a/tests/test_slack_router.py
+++ b/tests/test_slack_router.py
@@ -1,5 +1,6 @@
 import sys
 import types
+from fastapi.testclient import TestClient
 
 # Provide a minimal slack_sdk stub if the real package isn't installed
 if 'slack_sdk' not in sys.modules:
@@ -29,3 +30,20 @@ def test_get_slack_connector_uses_settings():
     connector = get_slack_connector(test_settings)
     assert connector.token == test_settings.slack_token
     assert connector.channel_id == test_settings.slack_channel_id
+
+
+def test_process_slack_update_endpoint(monkeypatch, test_app: TestClient):
+    received = {}
+
+    class DummyConnector:
+        def process_incoming(self, payload):
+            received["payload"] = payload
+
+    test_app.app.dependency_overrides[get_slack_connector] = lambda: DummyConnector()
+    payload = {"text": "hello"}
+    resp = test_app.post("/api/v1/connectors/slack/webhooks/slack", json=payload)
+
+    assert resp.status_code == 200
+    assert received["payload"] == payload
+
+    test_app.app.dependency_overrides = {}


### PR DESCRIPTION
## Summary
- add missing security regression test for protected pages
- exercise Slack router endpoint via TestClient
- test OpenAI error handling paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e204d7a888333b2a294fac5e46bbd