### PR TITLE
Add lint tooling and style guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/pylint
+    rev: v3.1.0
+    hooks:
+      - id: pylint
+        args: ["--rcfile=.pylintrc"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,12 @@ Please adhere to the following coding standards when contributing to the project
 - Include comments to explain complex or non-obvious code.
 - Keep functions and methods small and focused on a single task.
 - Follow the established code structure and organization.
+### Style Guide
+- Run `make lint` or use `pre-commit` to format with Black and check with pylint.
+- Use `snake_case` for functions and variables and `CamelCase` for classes.
+- Name database session objects `db` when passed as a dependency.
+- Keep error handling consistent across connectors.
+
 
 ## Testing
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: lint format test
+
+lint:
+	black --check .
+	pylint --rcfile=.pylintrc $(shell git ls-files '*.py')
+
+format:
+	black .
+
+test:
+	pytest -vv

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 ## Checklist:
 
-- [ ] My code follows the style guidelines of this project
+- [ ] My code follows the style guidelines (`make lint`) of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Norman is built to be extensible, allowing you to add new connectors, actions, a
 ## Philosophy
 
 We created Norman to provide an open, self-hosted, and open-source solution for accessing large language models like GPT-4. We hope others can build upon and extend Norman to incorporate additional chat technologies and channels. Our philosophy centers on continuous improvement, utilizing automation, and striving for excellence in our project. Learn more about our philosophy in our [Philosophy](docs/philosophy.md) document.
+## Coding Style
+
+We use [pylint](https://pylint.pycqa.org/) with the configuration in `.pylintrc` and format code using [Black](https://github.com/psf/black). Run `make lint` before submitting a PR or install pre-commit hooks with `pre-commit install` to automatically check formatting and linting.
+
 
 ## Contributing
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,6 @@
 pytest==6.2.5
 pytest-asyncio==0.16.0
 coverage==7.4.4
+black==24.3.0
+pylint==3.1.0
+pre-commit==3.5.0


### PR DESCRIPTION
## Summary
- add `Makefile` with lint/format/test targets
- add `.pre-commit-config.yaml`
- update developer docs with a brief style guide referencing `make lint`
- mention lint command in PR template
- add dev dependencies for black, pylint and pre-commit

## Testing
- `pytest -q`
- `make lint` *(fails: pylint missing, black found formatting issues)*

------
https://chatgpt.com/codex/tasks/task_e_683e2058c7608333ae0412281c51a9d3