### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 ENV PYTHONUNBUFFERED=1
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/)
 [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/)
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/)
+[![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/)
 [![GitHub release](https://img.shields.io/github/v/release/KristopherKubicki/norman.svg)](https://github.com/KristopherKubicki/norman/releases)
 
 Norman is an open-source chatbot that leverages OpenAI's GPT models to assist and automate communication on various chat platforms like Slack and IRC. The project is built with FastAPI, SQLite, and SQLAlchemy, and is designed to be easily extensible with additional connectors.
@@ -52,7 +53,7 @@ Norman is an open-source chatbot that leverages OpenAI's GPT models to assist an
 
 ### Prerequisites
 
-- Python 3.8, 3.9, or 3.10
+ - Python 3.8, 3.9, 3.10, or 3.11
 - pip
 - SQLite
 - virtualenv (optional)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,7 @@ This document outlines the steps to deploy Norman on a server or cloud provider.
 
 Before deploying Norman, ensure that your server meets the following requirements:
 
-- Python 3.8, 3.9, or 3.10
+- Python 3.8, 3.9, 3.10, or 3.11
 - SQLite (or another supported database system)
 - A compatible operating system, such as Ubuntu, Debian, or CentOS
 


### PR DESCRIPTION
## Summary
- support Python 3.11 in CI and documentation
- switch Dockerfile base image to Python 3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e23f9aa84833389c6c754fd2590fc