### PR TITLE
Improve bot selection styling

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -81,6 +81,11 @@ main {
     cursor: pointer;
   }
 
+  .bot-item.active {
+    background-color: #0d6efd;
+    color: #fff;
+  }
+
 
 textarea {
   width: 60vw; /* or any other width you want */

--- a/app/static/js/bots.js
+++ b/app/static/js/bots.js
@@ -167,6 +167,9 @@ function createBotElement(bot) {
     document.getElementById('send-message').removeAttribute('disabled');
     document.getElementById('input-message').removeAttribute('disabled');
     document.getElementById('input-message').placeholder = 'Enter your message...';
+
+    document.querySelectorAll('.bot-item').forEach(item => item.classList.remove('active'));
+    botElement.classList.add('active');
   });
 
 


### PR DESCRIPTION
## Summary
- highlight the selected bot in the bots page

## Testing
- `make lint` *(fails: 162 files would be reformatted)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_683e35f154708333af9f2d6ff8f36fd4