### PR TITLE
Add stub connectors for Flowdock and HipChat

### DIFF
--- a/app/connectors/flowdock_connector.py
+++ b/app/connectors/flowdock_connector.py
@@ -1,0 +1,30 @@
+"""Stub connector for sending messages to Flowdock."""
+
+from typing import Any, Optional, List
+
+from .base_connector import BaseConnector
+
+
+class FlowdockConnector(BaseConnector):
+    """Minimal implementation for Flowdock."""
+
+    id = "flowdock"
+    name = "Flowdock"
+
+    def __init__(self, api_token: str, flow: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.api_token = api_token
+        self.flow = flow
+        self.sent_messages: List[Any] = []
+
+    async def send_message(self, message: Any) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
+
+    async def listen_and_process(self) -> None:
+        """Listening for Flowdock messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message: Any) -> Any:
+        return message

--- a/app/connectors/hipchat_connector.py
+++ b/app/connectors/hipchat_connector.py
@@ -1,0 +1,30 @@
+"""Stub connector for Atlassian HipChat rooms."""
+
+from typing import Any, Optional, List
+
+from .base_connector import BaseConnector
+
+
+class HipChatConnector(BaseConnector):
+    """Minimal implementation for HipChat."""
+
+    id = "hipchat"
+    name = "HipChat"
+
+    def __init__(self, token: str, room_id: str, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.token = token
+        self.room_id = room_id
+        self.sent_messages: List[Any] = []
+
+    async def send_message(self, message: Any) -> str:
+        """Record ``message`` locally and return a confirmation string."""
+        self.sent_messages.append(message)
+        return "sent"
+
+    async def listen_and_process(self) -> None:
+        """Listening for HipChat messages is not implemented."""
+        return None
+
+    async def process_incoming(self, message: Any) -> Any:
+        return message

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -73,6 +73,8 @@ The following connectors are currently supported:
 64. [X.com](./connectors/xcom.md)
 65. [Zoom](./connectors/zoom.md)
 66. [DingTalk](./connectors/dingtalk.md)
+67. [Flowdock](./connectors/flowdock.md)
+68. [HipChat](./connectors/hipchat.md)
 
 
 ## Usage
@@ -142,5 +144,7 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Broadcast Connector](./connectors/broadcast.md)
 - [Zoom Connector](./connectors/zoom.md)
 - [DingTalk Connector](./connectors/dingtalk.md)
+- [Flowdock Connector](./connectors/flowdock.md)
+- [HipChat Connector](./connectors/hipchat.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/flowdock.md
+++ b/docs/connectors/flowdock.md
@@ -1,0 +1,16 @@
+# Flowdock Connector
+
+The Flowdock connector allows Norman to interact with Flowdock flows.
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+flowdock_api_token: "your_flowdock_api_token"
+flowdock_flow: "your_flowdock_flow"
+```
+
+## Usage
+
+This connector currently records sent messages locally. Extend it to integrate with the Flowdock API.

--- a/docs/connectors/hipchat.md
+++ b/docs/connectors/hipchat.md
@@ -1,0 +1,16 @@
+# HipChat Connector
+
+The HipChat connector enables Norman to post messages to HipChat rooms.
+
+## Configuration
+
+Add the following keys to your `config.yaml` file:
+
+```yaml
+hipchat_token: "your_hipchat_token"
+hipchat_room_id: "your_hipchat_room_id"
+```
+
+## Usage
+
+With these values provided, Norman can send and receive messages through HipChat. The connector is currently a stub intended for future integration with the HipChat API.

--- a/tests/connectors/test_flowdock.py
+++ b/tests/connectors/test_flowdock.py
@@ -1,0 +1,19 @@
+import asyncio
+from app.connectors.flowdock_connector import FlowdockConnector
+
+
+def test_send_message():
+    connector = FlowdockConnector("token", "flow")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = FlowdockConnector("token", "flow")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"msg": 1})
+    )
+    assert result == {"msg": 1}

--- a/tests/connectors/test_hipchat.py
+++ b/tests/connectors/test_hipchat.py
@@ -1,0 +1,19 @@
+import asyncio
+from app.connectors.hipchat_connector import HipChatConnector
+
+
+def test_send_message():
+    connector = HipChatConnector("token", "room")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message("hi")
+    )
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = HipChatConnector("token", "room")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"msg": 1})
+    )
+    assert result == {"msg": 1}


### PR DESCRIPTION
## Summary
- add `FlowdockConnector` and matching docs/tests
- add `HipChatConnector` and matching docs/tests
- document new connectors in docs/connectors.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f02dee7108333b7c86dd0571e7cf2