### PR TITLE
Add connector info endpoint

### DIFF
--- a/app/api/api_v1/routers/connectors_crud.py
+++ b/app/api/api_v1/routers/connectors_crud.py
@@ -3,11 +3,22 @@ from sqlalchemy.orm import Session
 from typing import List
 
 from app import crud
-from app.connectors.connector_utils import connector_classes
-from app.schemas import ConnectorCreate, ConnectorUpdate, Connector
+from app.connectors.connector_utils import connector_classes, get_connectors_data
+from app.schemas import (
+    ConnectorCreate,
+    ConnectorUpdate,
+    Connector,
+    ConnectorInfo,
+)
 from app.api.deps import get_db
 
 router = APIRouter(prefix="/connectors", tags=["connectors"])
+
+
+@router.get("/available", response_model=List[ConnectorInfo])
+async def list_available_connectors() -> List[ConnectorInfo]:
+    """Return metadata about all available connector implementations."""
+    return get_connectors_data()
 
 @router.post("/", response_model=Connector, status_code=201)
 async def create_connector(

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,4 +4,5 @@ from .channel import ChannelCreate, ChannelUpdate, Channel
 from .filter import FilterCreate, FilterUpdate, Filter
 from .token import Token
 from .connector import ConnectorCreate, ConnectorUpdate, Connector
+from .connector_info import ConnectorInfo
 

--- a/app/schemas/connector_info.py
+++ b/app/schemas/connector_info.py
@@ -1,0 +1,16 @@
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class ConnectorInfo(BaseModel):
+    """Metadata about an available connector."""
+
+    id: str
+    name: str
+    status: str
+    fields: List[str]
+    last_message_sent: Optional[str] = None
+    enabled: bool
+
+    class Config:
+        orm_mode = True

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,6 +114,12 @@ Delete a bot:
 curl -X DELETE http://localhost:8000/api/v1/bots/1
 ```
 
+List available connectors and their status:
+
+```bash
+curl http://localhost:8000/api/v1/connectors/available
+```
+
 Authentication headers may be required depending on your configuration.
 
 ### Rate limiting

--- a/tests/routers/test_connectors_available.py
+++ b/tests/routers/test_connectors_available.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+from app.core.test_settings import test_settings
+
+
+def test_available_connectors_endpoint(monkeypatch, test_app: TestClient):
+    sample = [
+        {
+            "id": "slack",
+            "name": "Slack",
+            "status": "missing_config",
+            "fields": ["token", "channel_id"],
+            "last_message_sent": None,
+            "enabled": False,
+        }
+    ]
+
+    monkeypatch.setattr(
+        "app.api.api_v1.routers.connectors_crud.get_connectors_data",
+        lambda: sample,
+    )
+
+    resp = test_app.get("/api/v1/connectors/available")
+    assert resp.status_code == 200
+    assert resp.json() == sample


### PR DESCRIPTION
## Summary
- expose `/api/v1/connectors/available` endpoint for metadata
- add `ConnectorInfo` schema
- document the new endpoint
- test the available connectors route

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683f09e8b5d0833388b69e30a2cc228a