### PR TITLE
Add fuzz tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ coverage==7.4.4
 black==24.3.0
 pylint==3.1.0
 pre-commit==3.5.0
+hypothesis==6.99.0

--- a/tests/test_encryption_fuzz.py
+++ b/tests/test_encryption_fuzz.py
@@ -1,0 +1,16 @@
+import pytest
+
+pytest.importorskip("hypothesis")
+from hypothesis import given, strategies as st
+
+from app.core.test_settings import test_settings
+from tests.test_encryption import load_encryption_module
+
+
+@given(st.text())
+def test_encrypt_decrypt_round_trip_fuzz(monkeypatch, text: str) -> None:
+    enc = load_encryption_module(monkeypatch)
+    monkeypatch.setattr(enc, "get_settings", lambda: test_settings)
+    manager = enc.EncryptionManager()
+    encrypted = manager.encrypt(text)
+    assert manager.decrypt(encrypted) == text

--- a/tests/test_encryption_fuzz.py
+++ b/tests/test_encryption_fuzz.py
@@ -1,12 +1,13 @@
 import pytest
 
 pytest.importorskip("hypothesis")
-from hypothesis import given, strategies as st
+from hypothesis import given, strategies as st, settings, HealthCheck
 
 from app.core.test_settings import test_settings
 from tests.test_encryption import load_encryption_module
 
 
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(st.text())
 def test_encrypt_decrypt_round_trip_fuzz(monkeypatch, text: str) -> None:
     enc = load_encryption_module(monkeypatch)

--- a/tests/test_utils_hypothesis.py
+++ b/tests/test_utils_hypothesis.py
@@ -1,0 +1,25 @@
+import uuid
+import pytest
+
+pytest.importorskip("hypothesis")
+from hypothesis import given, strategies as st
+
+from app.core import utils
+
+
+@given(st.integers(min_value=1, max_value=20))
+def test_generate_unique_id_unique(n: int) -> None:
+    ids = {utils.generate_unique_id() for _ in range(n)}
+    assert len(ids) == n
+    for uid in ids:
+        uuid.UUID(uid)
+
+
+@given(
+    st.dictionaries(st.text(min_size=1, max_size=5), st.integers(), max_size=10),
+    st.sets(st.text(min_size=1, max_size=5), max_size=10),
+)
+def test_get_subdict_matches_comprehension(data, keys) -> None:
+    result = utils.get_subdict(data, keys)
+    expected = {k: v for k, v in data.items() if k in keys}
+    assert result == expected


### PR DESCRIPTION
## Summary
- add Hypothesis to dev requirements
- test utils and encryption with fuzzing strategies

## Testing
- `pytest -k 'fuzz or hypothesis' -vv`

------
https://chatgpt.com/codex/tasks/task_e_683f0a47c7588333a2c200ac1c93ed4d