### PR TITLE
Add stub connectors

### DIFF
--- a/app/connectors/groupme_connector.py
+++ b/app/connectors/groupme_connector.py
@@ -1,0 +1,23 @@
+from .base_connector import BaseConnector
+from typing import Any
+
+class GroupMeConnector(BaseConnector):
+    """Stub connector for the GroupMe messaging service."""
+
+    id = "groupme"
+    name = "GroupMe"
+
+    def __init__(self, bot_id: str, config=None) -> None:
+        super().__init__(config)
+        self.bot_id = bot_id
+        self.sent_messages = []
+
+    async def send_message(self, message: Any) -> str:
+        self.sent_messages.append(message)
+        return "sent"
+
+    async def listen_and_process(self) -> None:
+        return None
+
+    async def process_incoming(self, message: Any) -> Any:
+        return message

--- a/app/connectors/kik_connector.py
+++ b/app/connectors/kik_connector.py
@@ -1,0 +1,24 @@
+from .base_connector import BaseConnector
+from typing import Any
+
+class KikConnector(BaseConnector):
+    """Stub connector for the Kik messaging platform."""
+
+    id = "kik"
+    name = "Kik"
+
+    def __init__(self, username: str, api_key: str, config=None) -> None:
+        super().__init__(config)
+        self.username = username
+        self.api_key = api_key
+        self.sent_messages = []
+
+    async def send_message(self, message: Any) -> str:
+        self.sent_messages.append(message)
+        return "sent"
+
+    async def listen_and_process(self) -> None:
+        return None
+
+    async def process_incoming(self, message: Any) -> Any:
+        return message

--- a/app/connectors/pinterest_connector.py
+++ b/app/connectors/pinterest_connector.py
@@ -1,0 +1,24 @@
+from .base_connector import BaseConnector
+from typing import Any
+
+class PinterestConnector(BaseConnector):
+    """Stub connector for the Pinterest API."""
+
+    id = "pinterest"
+    name = "Pinterest"
+
+    def __init__(self, access_token: str, board_id: str, config=None) -> None:
+        super().__init__(config)
+        self.access_token = access_token
+        self.board_id = board_id
+        self.sent_messages = []
+
+    async def send_message(self, message: Any) -> str:
+        self.sent_messages.append(message)
+        return "sent"
+
+    async def listen_and_process(self) -> None:
+        return None
+
+    async def process_incoming(self, message: Any) -> Any:
+        return message

--- a/app/connectors/snapchat_connector.py
+++ b/app/connectors/snapchat_connector.py
@@ -1,0 +1,24 @@
+from .base_connector import BaseConnector
+from typing import Any
+
+class SnapchatConnector(BaseConnector):
+    """Stub connector for the Snapchat messaging service."""
+
+    id = "snapchat"
+    name = "Snapchat"
+
+    def __init__(self, username: str, password: str, config=None) -> None:
+        super().__init__(config)
+        self.username = username
+        self.password = password
+        self.sent_messages = []
+
+    async def send_message(self, message: Any) -> str:
+        self.sent_messages.append(message)
+        return "sent"
+
+    async def listen_and_process(self) -> None:
+        return None
+
+    async def process_incoming(self, message: Any) -> Any:
+        return message

--- a/docs/connectors/groupme.md
+++ b/docs/connectors/groupme.md
@@ -1,0 +1,12 @@
+# GroupMe Connector
+
+The GroupMe connector sends messages via the GroupMe bot API.
+
+## Configuration
+Add the following key to your `config.yaml` file:
+```yaml
+groupme_bot_id: "your_groupme_bot_id"
+```
+
+## Usage
+This connector is a stub and can be expanded to integrate with GroupMe's API.

--- a/docs/connectors/kik.md
+++ b/docs/connectors/kik.md
@@ -1,0 +1,15 @@
+# Kik Connector
+
+This connector enables Norman to interact with the Kik messaging platform.
+
+## Configuration
+
+Add the following settings to your `config.yaml` file:
+```yaml
+kik_username: "your_kik_username"
+kik_api_key: "your_kik_api_key"
+```
+
+## Usage
+
+With these values provided, Norman can send and receive messages through Kik. The current implementation is a stub for future integration with the Kik API.

--- a/docs/connectors/pinterest.md
+++ b/docs/connectors/pinterest.md
@@ -1,0 +1,13 @@
+# Pinterest Connector
+
+This connector posts pins or reads updates from Pinterest boards.
+
+## Configuration
+Add the following settings to your `config.yaml` file:
+```yaml
+pinterest_access_token: "your_pinterest_access_token"
+pinterest_board_id: "your_pinterest_board_id"
+```
+
+## Usage
+The current code is a stub and can be expanded to integrate with the Pinterest API.

--- a/docs/connectors/snapchat.md
+++ b/docs/connectors/snapchat.md
@@ -1,0 +1,13 @@
+# Snapchat Connector
+
+The Snapchat connector allows Norman to post updates or send messages via Snapchat.
+
+## Configuration
+Add the following keys to your `config.yaml` file:
+```yaml
+snapchat_username: "your_snapchat_username"
+snapchat_password: "your_snapchat_password"
+```
+
+## Usage
+This connector is currently a stub that can be expanded to integrate with the Snapchat API.

--- a/tests/connectors/test_groupme.py
+++ b/tests/connectors/test_groupme.py
@@ -1,0 +1,15 @@
+import asyncio
+from app.connectors.groupme_connector import GroupMeConnector
+
+
+def test_send_message():
+    connector = GroupMeConnector("botid")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = GroupMeConnector("botid")
+    result = asyncio.get_event_loop().run_until_complete(connector.process_incoming({"m": 1}))
+    assert result == {"m": 1}

--- a/tests/connectors/test_kik.py
+++ b/tests/connectors/test_kik.py
@@ -1,0 +1,15 @@
+import asyncio
+from app.connectors.kik_connector import KikConnector
+
+
+def test_send_message():
+    connector = KikConnector("user", "key")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = KikConnector("user", "key")
+    result = asyncio.get_event_loop().run_until_complete(connector.process_incoming({"m": 1}))
+    assert result == {"m": 1}

--- a/tests/connectors/test_pinterest.py
+++ b/tests/connectors/test_pinterest.py
@@ -1,0 +1,15 @@
+import asyncio
+from app.connectors.pinterest_connector import PinterestConnector
+
+
+def test_send_message():
+    connector = PinterestConnector("tok", "board")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = PinterestConnector("tok", "board")
+    result = asyncio.get_event_loop().run_until_complete(connector.process_incoming({"m": 1}))
+    assert result == {"m": 1}

--- a/tests/connectors/test_snapchat.py
+++ b/tests/connectors/test_snapchat.py
@@ -1,0 +1,15 @@
+import asyncio
+from app.connectors.snapchat_connector import SnapchatConnector
+
+
+def test_send_message():
+    connector = SnapchatConnector("user", "pw")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result == "sent"
+    assert connector.sent_messages == ["hi"]
+
+
+def test_process_incoming():
+    connector = SnapchatConnector("user", "pw")
+    result = asyncio.get_event_loop().run_until_complete(connector.process_incoming({"m": 1}))
+    assert result == {"m": 1}


### PR DESCRIPTION
## Summary
- add stub connectors for Kik, Snapchat, Pinterest and GroupMe
- document basic config for new connectors
- test minimal functionality for each stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409b9dafa883339e28bb308cde0a69