### PR TITLE
Implement Flowdock integration

### DIFF
--- a/app/connectors/flowdock_connector.py
+++ b/app/connectors/flowdock_connector.py
@@ -1,26 +1,41 @@
-"""Stub connector for sending messages to Flowdock."""
+"""Connector for sending messages to Flowdock flows."""
 
-from typing import Any, Optional, List
+from typing import Any, Optional
+
+import httpx
 
 from .base_connector import BaseConnector
+from app.core.logging import setup_logger
+
+logger = setup_logger(__name__)
 
 
 class FlowdockConnector(BaseConnector):
-    """Minimal implementation for Flowdock."""
+    """Interact with Flowdock using the push API."""
 
     id = "flowdock"
     name = "Flowdock"
 
-    def __init__(self, api_token: str, flow: str, config: Optional[dict] = None) -> None:
+    def __init__(
+        self, api_token: str, flow: str, config: Optional[dict] = None
+    ) -> None:
         super().__init__(config)
         self.api_token = api_token
         self.flow = flow
-        self.sent_messages: List[Any] = []
+        self.api_url = f"https://api.flowdock.com/v1/messages/chat/{flow}"
 
-    async def send_message(self, message: Any) -> str:
-        """Record ``message`` locally and return a confirmation string."""
-        self.sent_messages.append(message)
-        return "sent"
+    async def send_message(self, message: Any) -> Optional[str]:
+        """POST ``message`` to the Flowdock push API."""
+        data = {"event": "message", "content": str(message)}
+        params = {"flow_token": self.api_token}
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(self.api_url, params=params, json=data)
+                resp.raise_for_status()
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                logger.error("Error sending Flowdock message: %s", exc)
+                return None
 
     async def listen_and_process(self) -> None:
         """Listening for Flowdock messages is not implemented."""
@@ -28,3 +43,14 @@ class FlowdockConnector(BaseConnector):
 
     async def process_incoming(self, message: Any) -> Any:
         return message
+
+    def is_connected(self) -> bool:
+        """Check if the Flowdock flow is reachable."""
+        url = f"https://api.flowdock.com/v1/flows/{self.flow}"
+        params = {"flow_token": self.api_token}
+        try:
+            resp = httpx.get(url, params=params, timeout=5)
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            return False

--- a/docs/connectors/flowdock.md
+++ b/docs/connectors/flowdock.md
@@ -13,4 +13,5 @@ flowdock_flow: "your_flowdock_flow"
 
 ## Usage
 
-This connector currently records sent messages locally. Extend it to integrate with the Flowdock API.
+Once configured, Norman can send chat messages using Flowdock's push API.
+Incoming message polling is not implemented.

--- a/tests/connectors/test_flowdock.py
+++ b/tests/connectors/test_flowdock.py
@@ -1,14 +1,70 @@
 import asyncio
+import httpx
 from app.connectors.flowdock_connector import FlowdockConnector
 
 
-def test_send_message():
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, params=None, json=None):
+        self.sent = (url, params, json)
+        return self.response
+
+    async def get(self, url, params=None, timeout=None):
+        self.sent = (url, params)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(resp))
     connector = FlowdockConnector("token", "flow")
-    result = asyncio.get_event_loop().run_until_complete(
-        connector.send_message("hi")
-    )
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
     assert result == "sent"
-    assert connector.sent_messages == ["hi"]
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, params=None, json=None):
+            raise httpx.HTTPError("fail")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = FlowdockConnector("token", "flow")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result is None
+
+
+def test_is_connected(monkeypatch):
+    monkeypatch.setattr(httpx, "get", lambda *a, **kw: DummyResponse())
+    connector = FlowdockConnector("token", "flow")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    def bad_get(*a, **kw):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "get", bad_get)
+    connector = FlowdockConnector("token", "flow")
+    assert not connector.is_connected()
 
 
 def test_process_incoming():


### PR DESCRIPTION
## Summary
- implement Flowdock connector using push API
- update Flowdock docs to describe the real integration
- revise Flowdock connector tests

## Testing
- `black app/connectors/flowdock_connector.py tests/connectors/test_flowdock.py`
- `black --check app/connectors/flowdock_connector.py tests/connectors/test_flowdock.py`
- `pylint app/connectors/flowdock_connector.py tests/connectors/test_flowdock.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409ba576dc83338d537a7a394043c8