### PR TITLE
Add Jest test setup for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ pip install -r requirements-dev.txt
 pytest -vv
 ```
 
+For front-end components located in the `frontend` directory, Jest is used
+alongside React Testing Library. To run these tests you will need Node.js and
+install the dev dependencies defined in `package.json`:
+
+```bash
+npm install
+npm test
+```
+
 For a test coverage report you can additionally run:
 
 ```bash

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react']
+};

--- a/frontend/InfiniteMessages.jsx
+++ b/frontend/InfiniteMessages.jsx
@@ -43,7 +43,7 @@ export default function InfiniteMessages({ botId }) {
   if (status === 'error') return <p>Error loading messages</p>;
 
   return (
-    <div>
+    <div role="region">
       {data.pages.map((page, pageIndex) => (
         <React.Fragment key={pageIndex}>
           {page.map((msg, i) => {

--- a/frontend/__tests__/InfiniteMessages.test.jsx
+++ b/frontend/__tests__/InfiniteMessages.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import InfiniteMessages from '../InfiniteMessages.jsx';
+
+// Mock react-query's useInfiniteQuery to control component state
+jest.mock('react-query', () => ({
+  useInfiniteQuery: jest.fn(() => ({
+    data: { pages: [[]] },
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    status: 'success'
+  }))
+}));
+
+describe('InfiniteMessages', () => {
+  it('renders messages container', () => {
+    render(<InfiniteMessages botId="1" />);
+    const container = screen.getByRole('region');
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "norman-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.24.0",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/react": "^14.2.1",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "transform": {
+      "^.+\\.(js|jsx)$": "babel-jest"
+    },
+    "moduleFileExtensions": ["js", "jsx"],
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"]
+  }
+}


### PR DESCRIPTION
## Summary
- configure Jest and Babel for React component tests
- add an initial test for `InfiniteMessages`
- document running frontend tests in the README
- mark messages container with an accessible role attribute

## Testing
- `pytest -q`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409e0673fc8333b2c593ee2d13dabb