### PR TITLE
Add GitLab connector

### DIFF
--- a/app/connectors/gitlab_connector.py
+++ b/app/connectors/gitlab_connector.py
@@ -1,0 +1,61 @@
+"""Connector for interacting with GitLab projects."""
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .base_connector import BaseConnector
+from app.core.logging import setup_logger
+
+logger = setup_logger(__name__)
+
+
+class GitLabConnector(BaseConnector):
+    """Connector for creating issues or comments in GitLab."""
+
+    id = "gitlab"
+    name = "GitLab"
+
+    def __init__(
+        self,
+        token: str,
+        project_id: str,
+        api_url: str = "https://gitlab.com/api/v4",
+        config: Optional[dict] = None,
+    ) -> None:
+        super().__init__(config)
+        self.token = token
+        self.project_id = project_id
+        self.api_url = api_url.rstrip("/")
+
+    def _headers(self) -> Dict[str, str]:
+        return {"PRIVATE-TOKEN": self.token}
+
+    async def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        """Create an issue or comment on GitLab."""
+        issue_iid = message.get("issue_iid")
+        if issue_iid:
+            url = f"{self.api_url}/projects/{self.project_id}/issues/{issue_iid}/notes"
+            payload = {"body": message.get("body", "")}
+        else:
+            url = f"{self.api_url}/projects/{self.project_id}/issues"
+            payload = {
+                "title": message.get("title", "Norman Issue"),
+                "description": message.get("body", ""),
+            }
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(url, json=payload, headers=self._headers())
+            response.raise_for_status()
+            return response.text
+        except httpx.HTTPError as exc:  # pragma: no cover - network
+            logger.error("Error communicating with GitLab: %s", exc)
+            return None
+
+    async def listen_and_process(self) -> None:
+        """Listening is not implemented for GitLab."""
+        return None
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        await self.send_message(message)
+        return message

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -75,6 +75,7 @@ The following connectors are currently supported:
 66. [DingTalk](./connectors/dingtalk.md)
 67. [Flowdock](./connectors/flowdock.md)
 68. [HipChat](./connectors/hipchat.md)
+69. [GitLab](./connectors/gitlab.md)
 
 
 ## Usage
@@ -145,6 +146,7 @@ For more detailed information on each connector, please refer to the platform-sp
 - [Zoom Connector](./connectors/zoom.md)
 - [DingTalk Connector](./connectors/dingtalk.md)
 - [Flowdock Connector](./connectors/flowdock.md)
+- [GitLab Connector](./connectors/gitlab.md)
 - [HipChat Connector](./connectors/hipchat.md)
 
 Remember to follow the platform-specific guidelines and best practices when creating bots or apps for each service.

--- a/docs/connectors/gitlab.md
+++ b/docs/connectors/gitlab.md
@@ -1,0 +1,27 @@
+# GitLab Connector
+
+The GitLab connector allows Norman to create issues or comments in a GitLab project.
+
+## Requirements
+
+- A GitLab personal access token
+- The project ID for your GitLab project
+
+## Configuration
+
+Add these settings to your `config.yaml` file:
+
+```yaml
+gitlab_token: "your_gitlab_token"
+gitlab_project_id: "123456"
+```
+
+## Usage
+
+When invoked, Norman will create a new issue or comment on an existing issue.
+Include `issue_iid` in the message payload to comment, otherwise a new issue is opened.
+
+## Troubleshooting
+
+1. Ensure the token has the `api` scope.
+2. Verify the project ID is correct and accessible.

--- a/tests/connectors/test_gitlab.py
+++ b/tests/connectors/test_gitlab.py
@@ -1,0 +1,53 @@
+import asyncio
+import httpx
+
+from app.connectors.gitlab_connector import GitLabConnector
+
+
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, headers=None):
+        self.sent = (url, json, headers)
+        return self.response
+
+
+def test_send_message_issue(monkeypatch):
+    resp = DummyResponse("sent")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(resp))
+    connector = GitLabConnector("TOKEN", "123")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message({"title": "hi"})
+    )
+    assert result == "sent"
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None, headers=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = GitLabConnector("TOKEN", "123")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message({"title": "hi"})
+    )
+    assert result is None


### PR DESCRIPTION
## Summary
- add a new GitLab connector for creating issues or comments
- document the GitLab connector
- include unit tests for the connector
- list the connector in the connectors overview

## Testing
- `pytest -q`
- `pylint --rcfile=.pylintrc app/connectors/gitlab_connector.py tests/connectors/test_gitlab.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840afb8edb48333a53f34d74679ceaf