### PR TITLE
Expand AWS EventBridge tests

### DIFF
--- a/tests/connectors/test_aws_eventbridge.py
+++ b/tests/connectors/test_aws_eventbridge.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import types
 import pytest
 
@@ -18,11 +19,20 @@ class DummyClient:
 
 
 def test_send_message_success(monkeypatch):
-    stub = types.SimpleNamespace(client=lambda service, region_name=None: DummyClient())
+    dummy = DummyClient()
+    stub = types.SimpleNamespace(client=lambda service, region_name=None: dummy)
     monkeypatch.setattr(mod, "boto3", stub)
     connector = mod.AWSEventBridgeConnector(region="us", event_bus_name="bus")
     result = asyncio.get_event_loop().run_until_complete(connector.send_message({"a":1}))
     assert result == {"ok": True}
+    assert dummy.entries == [
+        {
+            "Source": "norman",
+            "DetailType": "message",
+            "Detail": json.dumps({"a": 1}),
+            "EventBusName": "bus",
+        }
+    ]
 
 
 def test_send_message_no_boto3(monkeypatch):
@@ -45,6 +55,12 @@ def test_is_connected_error(monkeypatch):
     client.ok = False
     stub = types.SimpleNamespace(client=lambda service, region_name=None: client)
     monkeypatch.setattr(mod, "boto3", stub)
+    connector = mod.AWSEventBridgeConnector(region="us", event_bus_name="bus")
+    assert not connector.is_connected()
+
+
+def test_is_connected_no_boto3(monkeypatch):
+    monkeypatch.setattr(mod, "boto3", None)
     connector = mod.AWSEventBridgeConnector(region="us", event_bus_name="bus")
     assert not connector.is_connected()
 


### PR DESCRIPTION
## Summary
- improve AWS EventBridge tests to verify emitted entries
- add coverage for `is_connected` when boto3 is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d9083b60833398d8787c99f71b71