### PR TITLE
Finish Mastodon connector

### DIFF
--- a/docs/connectors/mastodon.md
+++ b/docs/connectors/mastodon.md
@@ -17,4 +17,6 @@ mastodon_access_token: "your_mastodon_token"
 
 ## Usage
 
-After configuration, Norman can send status updates to Mastodon. Incoming message processing is not yet implemented.
+After configuration, Norman can send status updates to Mastodon. The connector
+also listens to the public streaming API and parses incoming events for use by
+other parts of the system.

--- a/tests/connectors/test_mastodon.py
+++ b/tests/connectors/test_mastodon.py
@@ -70,3 +70,62 @@ def test_is_connected_error(monkeypatch):
     monkeypatch.setattr(httpx, "get", raise_err)
     connector = MastodonConnector("http://host", "TOKEN")
     assert not connector.is_connected()
+
+
+class DummyStreamResponse:
+    def __init__(self, lines):
+        self.lines = lines
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_lines(self):
+        for line in self.lines:
+            yield line
+
+
+class StreamClient(DummyClient):
+    def __init__(self, response):
+        super().__init__(response)
+
+    def stream(self, method, url, headers=None, params=None):
+        self.sent_stream = (method, url, headers, params)
+        return self.response
+
+
+def test_listen_and_process(monkeypatch):
+    lines = [
+        "event: update",
+        'data: {"content": "hi"}',
+        "",
+    ]
+    resp = DummyStreamResponse(lines)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: StreamClient(resp))
+
+    processed = []
+
+    class TestConnector(MastodonConnector):
+        async def process_incoming(self, message):
+            processed.append(await super().process_incoming(message))
+
+    connector = TestConnector("http://host", "TOKEN")
+    asyncio.get_event_loop().run_until_complete(connector.listen_and_process())
+    assert processed == [{"event": "update", "data": {"content": "hi"}}]
+
+
+def test_listen_and_process_error(monkeypatch):
+    class BadClient(StreamClient):
+        def stream(self, method, url, headers=None, params=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: BadClient(DummyStreamResponse([])))
+
+    connector = MastodonConnector("http://host", "TOKEN")
+    result = asyncio.get_event_loop().run_until_complete(connector.listen_and_process())
+    assert result is None


### PR DESCRIPTION
## Summary
- support SSE event parsing in `MastodonConnector`
- decode JSON data in incoming Mastodon events
- add tests for Mastodon streaming functionality
- document streaming support for Mastodon connector

## Testing
- `pytest tests/connectors/test_mastodon.py -q`
- `pytest tests/connectors/test_connector_utils.py::test_get_connector_returns_mastodon -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d923d0f48333acced50f89b6b5dd