### PR TITLE
Finish Snapchat connector

### DIFF
--- a/app/connectors/snapchat_connector.py
+++ b/app/connectors/snapchat_connector.py
@@ -1,24 +1,87 @@
+"""Snapchat connector implemented using a hypothetical client library."""
+
+import asyncio
+import importlib
+from typing import Any, List, Optional
+
 from .base_connector import BaseConnector
-from typing import Any
+from app.core.logging import setup_logger
+
+logger = setup_logger(__name__)
 
 class SnapchatConnector(BaseConnector):
-    """Stub connector for the Snapchat messaging service."""
+    """Connector for the Snapchat messaging service."""
 
     id = "snapchat"
     name = "Snapchat"
 
-    def __init__(self, username: str, password: str, config=None) -> None:
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        recipient: str,
+        config: Optional[dict] = None,
+    ) -> None:
         super().__init__(config)
         self.username = username
         self.password = password
-        self.sent_messages = []
+        self.recipient = recipient
+        self.sent_messages: List[Any] = []
+        self._client = None
 
-    async def send_message(self, message: Any) -> str:
-        self.sent_messages.append(message)
-        return "sent"
+    def _get_client(self):
+        """Lazily import and return the Snapchat client."""
+        if self._client is None:
+            snap_mod = importlib.import_module("snapchat")
+            self._client = snap_mod.Client(self.username, self.password)
+        return self._client
 
-    async def listen_and_process(self) -> None:
-        return None
+    async def send_message(self, message: Any) -> Optional[str]:
+        """Send ``message`` to the configured ``recipient``."""
+
+        client = self._get_client()
+        snap_mod = importlib.import_module("snapchat")
+        try:
+            result = client.send(self.recipient, message)
+            if asyncio.iscoroutine(result):
+                await result
+            self.sent_messages.append(message)
+            return "sent"
+        except snap_mod.SnapchatError as exc:  # pragma: no cover - network
+            logger.error("Error sending Snapchat message: %s", exc)
+            return None
+
+    async def listen_and_process(self) -> List[Any]:
+        """Fetch new messages and process them."""
+
+        client = self._get_client()
+        snap_mod = importlib.import_module("snapchat")
+        try:
+            messages = client.get_messages()
+            if asyncio.iscoroutine(messages):
+                messages = await messages
+        except snap_mod.SnapchatError as exc:  # pragma: no cover - network
+            logger.error("Error fetching Snapchat messages: %s", exc)
+            return []
+
+        results = []
+        for msg in messages:
+            processed = self.process_incoming(msg)
+            if asyncio.iscoroutine(processed):
+                processed = await processed
+            if processed:
+                results.append(processed)
+        return results
 
     async def process_incoming(self, message: Any) -> Any:
+        """Return the incoming ``message`` payload."""
         return message
+
+    def is_connected(self) -> bool:
+        """Return ``True`` if authentication appears valid."""
+
+        client = self._get_client()
+        try:
+            return bool(client.logged_in())
+        except Exception:  # pragma: no cover - client may raise various errors
+            return False

--- a/docs/connectors/snapchat.md
+++ b/docs/connectors/snapchat.md
@@ -1,13 +1,19 @@
 # Snapchat Connector
 
 The Snapchat connector allows Norman to post updates or send messages via Snapchat.
+It relies on a lightweight client library that authenticates with your Snapchat credentials.
 
 ## Configuration
 Add the following keys to your `config.yaml` file:
 ```yaml
 snapchat_username: "your_snapchat_username"
 snapchat_password: "your_snapchat_password"
+snapchat_recipient: "friend_to_message"
 ```
 
 ## Usage
-This connector is currently a stub that can be expanded to integrate with the Snapchat API.
+
+With these settings, Norman can send basic text messages to the configured
+`snapchat_recipient` and poll for new incoming snaps.  The implementation uses a
+hypothetical Python package named `snapchat`.  In the unit tests a dummy version
+of this package is injected so no real network access is required.

--- a/tests/connectors/test_snapchat.py
+++ b/tests/connectors/test_snapchat.py
@@ -1,15 +1,91 @@
+import sys
+import types
 import asyncio
+
+# Provide a minimal snapchat stub if the real package isn't installed
+if "snapchat" not in sys.modules:
+    snapchat = types.ModuleType("snapchat")
+
+    class SnapchatError(Exception):
+        pass
+
+    class DummyClient:
+        def __init__(self, username, password):
+            self.username = username
+            self.password = password
+            self.sent = []
+            self.messages = []
+            self.raise_on_send = False
+            self.raise_on_messages = False
+            self.logged_in_state = True
+
+        def send(self, to, text):
+            if self.raise_on_send:
+                raise SnapchatError("boom")
+            self.sent.append((to, text))
+            return "ok"
+
+        def get_messages(self):
+            if self.raise_on_messages:
+                raise SnapchatError("boom")
+            return self.messages
+
+        def logged_in(self):
+            return self.logged_in_state
+
+    snapchat.Client = DummyClient
+    snapchat.SnapchatError = SnapchatError
+    sys.modules["snapchat"] = snapchat
+else:
+    import snapchat
+
 from app.connectors.snapchat_connector import SnapchatConnector
 
 
-def test_send_message():
-    connector = SnapchatConnector("user", "pw")
+def test_send_message_success():
+    connector = SnapchatConnector("user", "pw", "friend")
     result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
     assert result == "sent"
-    assert connector.sent_messages == ["hi"]
+    assert connector._get_client().sent == [("friend", "hi")]
+
+
+def test_send_message_error():
+    connector = SnapchatConnector("user", "pw", "friend")
+    client = connector._get_client()
+    client.raise_on_send = True
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result is None
 
 
 def test_process_incoming():
-    connector = SnapchatConnector("user", "pw")
+    connector = SnapchatConnector("user", "pw", "friend")
     result = asyncio.get_event_loop().run_until_complete(connector.process_incoming({"m": 1}))
     assert result == {"m": 1}
+
+
+def test_is_connected_success():
+    connector = SnapchatConnector("user", "pw", "friend")
+    assert connector.is_connected()
+
+
+def test_is_connected_error():
+    connector = SnapchatConnector("user", "pw", "friend")
+    client = connector._get_client()
+    client.logged_in_state = False
+    assert not connector.is_connected()
+
+
+def test_listen_and_process():
+    connector = SnapchatConnector("user", "pw", "friend")
+    client = connector._get_client()
+    client.messages = [{"text": "hello"}]
+    results = asyncio.get_event_loop().run_until_complete(connector.listen_and_process())
+    assert results == [{"text": "hello"}]
+
+
+def test_listen_and_process_error():
+    connector = SnapchatConnector("user", "pw", "friend")
+    client = connector._get_client()
+    client.raise_on_messages = True
+    results = asyncio.get_event_loop().run_until_complete(connector.listen_and_process())
+    assert results == []


### PR DESCRIPTION
## Summary
- implement functional Snapchat connector using a hypothetical client
- document Snapchat configuration and usage
- expand unit tests for the connector

## Testing
- `pre-commit run --files app/connectors/snapchat_connector.py tests/connectors/test_snapchat.py docs/connectors/snapchat.md` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d8f9b94083339373e28f5d5e5a7f