### PR TITLE
Add Pinterest connector implementation

### DIFF
--- a/app/connectors/pinterest_connector.py
+++ b/app/connectors/pinterest_connector.py
@@ -1,8 +1,15 @@
+"""Connector for interacting with the Pinterest API."""
+
+import importlib
+from typing import Any, Optional
+
 from .base_connector import BaseConnector
-from typing import Any
+from app.core.logging import setup_logger
+
+logger = setup_logger(__name__)
 
 class PinterestConnector(BaseConnector):
-    """Stub connector for the Pinterest API."""
+    """Connector for creating pins on a Pinterest board."""
 
     id = "pinterest"
     name = "Pinterest"
@@ -11,14 +18,38 @@ class PinterestConnector(BaseConnector):
         super().__init__(config)
         self.access_token = access_token
         self.board_id = board_id
+        self.api_url = "https://api.pinterest.com/v5/pins"
         self.sent_messages = []
 
-    async def send_message(self, message: Any) -> str:
-        self.sent_messages.append(message)
-        return "sent"
+    async def send_message(self, message: str) -> Optional[str]:
+        """Create a pin with ``message`` as the note on ``board_id``."""
+        httpx = importlib.import_module("httpx")
+        payload = {"board_id": self.board_id, "note": message}
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(self.api_url, json=payload, headers=headers)
+                resp.raise_for_status()
+                self.sent_messages.append(message)
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                logger.error("Error sending Pinterest message: %s", exc)
+                return None
 
     async def listen_and_process(self) -> None:
         return None
 
     async def process_incoming(self, message: Any) -> Any:
         return message
+
+    def is_connected(self) -> bool:
+        """Return ``True`` if the API token appears valid."""
+        httpx = importlib.import_module("httpx")
+        url = "https://api.pinterest.com/v5/user_account"
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        try:
+            resp = httpx.get(url, headers=headers)
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            return False

--- a/docs/connectors/pinterest.md
+++ b/docs/connectors/pinterest.md
@@ -10,4 +10,5 @@ pinterest_board_id: "your_pinterest_board_id"
 ```
 
 ## Usage
-The current code is a stub and can be expanded to integrate with the Pinterest API.
+The connector now creates pins on the specified board by calling the Pinterest API.
+Each message sent becomes the ``note`` field of the new pin.

--- a/tests/connectors/test_pinterest.py
+++ b/tests/connectors/test_pinterest.py
@@ -1,15 +1,81 @@
 import asyncio
+import httpx
+
 from app.connectors.pinterest_connector import PinterestConnector
 
 
-def test_send_message():
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, headers=None):
+        self.sent = (url, json, headers)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    client = DummyClient(resp)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
     connector = PinterestConnector("tok", "board")
     result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
     assert result == "sent"
-    assert connector.sent_messages == ["hi"]
+    assert client.sent[0].startswith("https://api.pinterest.com")
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None, headers=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = PinterestConnector("tok", "board")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result is None
 
 
 def test_process_incoming():
     connector = PinterestConnector("tok", "board")
     result = asyncio.get_event_loop().run_until_complete(connector.process_incoming({"m": 1}))
     assert result == {"m": 1}
+
+
+class DummyGetResponse:
+    def __init__(self, status=200):
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+def test_is_connected_success(monkeypatch):
+    monkeypatch.setattr(httpx, "get", lambda url, headers=None: DummyGetResponse())
+    connector = PinterestConnector("tok", "board")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    def raise_err(url, headers=None):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "get", raise_err)
+    connector = PinterestConnector("tok", "board")
+    assert not connector.is_connected()


### PR DESCRIPTION
## Summary
- implement Pinterest connector using HTTP API
- extend Pinterest connector tests
- document the updated Pinterest connector

## Testing
- `pytest -k pinterest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d97387a48333a374436f96761ec9