### PR TITLE
Implement Instagram DM connector

### DIFF
--- a/docs/connectors/instagram_dm.md
+++ b/docs/connectors/instagram_dm.md
@@ -13,4 +13,7 @@ instagram_user_id: "your_instagram_user_id"
 
 ## Usage
 
-Once configured, Norman can send and receive direct messages via Instagram. The current implementation is a stub meant to be extended for your preferred integration method.
+Once configured, Norman can send direct messages using the Instagram Graph API.
+The connector issues a ``POST`` request to the Graph API endpoint for your
+configured ``instagram_user_id``. Incoming messages are not yet supported, so
+``listen_and_process`` currently returns ``None``.

--- a/tests/connectors/test_instagram_dm.py
+++ b/tests/connectors/test_instagram_dm.py
@@ -1,12 +1,54 @@
 import asyncio
+import httpx
 from app.connectors.instagram_dm_connector import InstagramDMConnector
 
 
-def test_send_message():
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, params=None, json=None):
+        self.sent = (url, params, json)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    client = DummyClient(resp)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
     connector = InstagramDMConnector("tok", "uid")
     result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
     assert result == "sent"
     assert connector.sent_messages == ["hi"]
+    assert client.sent[0].startswith("https://graph.facebook.com")
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, params=None, json=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = InstagramDMConnector("tok", "uid")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result is None
 
 
 def test_process_incoming():
@@ -15,3 +57,18 @@ def test_process_incoming():
         connector.process_incoming({"d": 3})
     )
     assert result == {"d": 3}
+
+
+def test_is_connected_success(monkeypatch):
+    monkeypatch.setattr(httpx, "get", lambda url, params=None: DummyResponse())
+    connector = InstagramDMConnector("tok", "uid")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    def raise_err(url, params=None):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "get", raise_err)
+    connector = InstagramDMConnector("tok", "uid")
+    assert not connector.is_connected()


### PR DESCRIPTION
## Summary
- implement Instagram DM connector using Graph API
- expand Instagram DM tests with HTTP mocking
- document how to use the Instagram DM connector

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840d8d72ec483339c4878961e584e22