### PR TITLE
Add Azure Event Grid connectivity check

### DIFF
--- a/app/connectors/azure_eventgrid_connector.py
+++ b/app/connectors/azure_eventgrid_connector.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict, Optional
 
+import importlib
+
 try:
     from azure.eventgrid import EventGridPublisherClient, EventGridEvent
     from azure.core.credentials import AzureKeyCredential
@@ -35,6 +37,18 @@ class AzureEventGridConnector(BaseConnector):
         event = EventGridEvent(subject="norman", event_type="Message", data=message, data_version="1.0")
         self.client.send([event])
         return "ok"
+
+    def is_connected(self) -> bool:
+        """Return ``True`` if the Event Grid endpoint is reachable."""
+        if not EventGridPublisherClient:
+            return False
+        httpx = importlib.import_module("httpx")
+        try:
+            resp = httpx.get(self.endpoint, timeout=5)
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            return False
 
     async def listen_and_process(self) -> None:
         """Listening is not implemented for Event Grid."""

--- a/docs/connectors/azure_eventgrid.md
+++ b/docs/connectors/azure_eventgrid.md
@@ -19,3 +19,7 @@ azure_eventgrid_key: "your-access-key"
 ## Usage
 
 This connector only sends events and does not listen for incoming messages.
+
+The connector verifies connectivity by making a simple HTTP request to the
+configured endpoint when :code:`is_connected()` is called. If the request fails
+or returns an error status code, the method returns ``False``.

--- a/tests/connectors/test_azure_eventgrid.py
+++ b/tests/connectors/test_azure_eventgrid.py
@@ -3,6 +3,15 @@ import types
 import pytest
 import app.connectors.azure_eventgrid_connector as mod
 
+
+class DummyResponse:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("bad")
+
 class DummyClient:
     def __init__(self, endpoint, credential):
         self.sent = []
@@ -36,3 +45,41 @@ def test_send_message_no_library(monkeypatch):
     connector = mod.AzureEventGridConnector("https://e", "KEY")
     with pytest.raises(RuntimeError):
         asyncio.get_event_loop().run_until_complete(connector.send_message({}))
+
+
+def test_is_connected(monkeypatch):
+    stub = types.SimpleNamespace(
+        EventGridPublisherClient=DummyClient,
+        EventGridEvent=DummyEvent,
+        AzureKeyCredential=lambda key: object(),
+    )
+    monkeypatch.setattr(mod, "EventGridPublisherClient", stub.EventGridPublisherClient)
+    monkeypatch.setattr(mod, "EventGridEvent", stub.EventGridEvent)
+    monkeypatch.setattr(mod, "AzureKeyCredential", stub.AzureKeyCredential)
+    monkeypatch.setattr(mod.importlib, "import_module", lambda n: types.SimpleNamespace(get=lambda *a, **kw: DummyResponse()))
+    connector = mod.AzureEventGridConnector("https://e", "KEY")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    stub = types.SimpleNamespace(
+        EventGridPublisherClient=DummyClient,
+        EventGridEvent=DummyEvent,
+        AzureKeyCredential=lambda key: object(),
+    )
+    monkeypatch.setattr(mod, "EventGridPublisherClient", stub.EventGridPublisherClient)
+    monkeypatch.setattr(mod, "EventGridEvent", stub.EventGridEvent)
+    monkeypatch.setattr(mod, "AzureKeyCredential", stub.AzureKeyCredential)
+    def bad_import(name):
+        def raise_err(*args, **kwargs):
+            raise Exception("boom")
+        return types.SimpleNamespace(get=raise_err, HTTPError=Exception)
+    monkeypatch.setattr(mod.importlib, "import_module", bad_import)
+    connector = mod.AzureEventGridConnector("https://e", "KEY")
+    assert not connector.is_connected()
+
+
+def test_is_connected_no_library(monkeypatch):
+    monkeypatch.setattr(mod, "EventGridPublisherClient", None)
+    connector = mod.AzureEventGridConnector("https://e", "KEY")
+    assert not connector.is_connected()


### PR DESCRIPTION
## Summary
- add `is_connected` method to AzureEventGridConnector
- explain connectivity check in Azure Event Grid docs
- expand tests for Azure Event Grid connector

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840d9129ce08333a8231140b3d787a9