### PR TITLE
Implement basic Tox connector

### DIFF
--- a/app/connectors/tox_connector.py
+++ b/app/connectors/tox_connector.py
@@ -1,12 +1,22 @@
-"""Placeholder connector for the Tox peer-to-peer network."""
+"""Minimal connector for the decentralized Tox messenger network."""
 
+import asyncio
+import importlib
 from typing import Any, Optional, List
 
 from .base_connector import BaseConnector
+from app.core.logging import setup_logger
+
+logger = setup_logger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    toxcore = importlib.import_module("toxcore")
+except ImportError:  # pragma: no cover - tox library may be absent
+    toxcore = None  # type: ignore
 
 
 class ToxConnector(BaseConnector):
-    """Stub implementation for the Tox protocol."""
+    """Connector using the ``toxcore`` Python bindings if available."""
 
     id = "tox"
     name = "Tox"
@@ -23,16 +33,54 @@ class ToxConnector(BaseConnector):
         self.bootstrap_port = bootstrap_port
         self.friend_id = friend_id
         self.sent_messages: List[Any] = []
+        self._tox = None
+        self._friend_number: Optional[int] = None
+
+    def connect(self) -> None:
+        if toxcore is None:
+            raise RuntimeError("toxcore not installed")
+        tox_cls = getattr(toxcore, "Tox", None) or getattr(toxcore, "ToxCore", None)
+        if tox_cls is None:
+            raise RuntimeError("toxcore library missing Tox class")
+        self._tox = tox_cls()
+        self._tox.bootstrap(self.bootstrap_host, self.bootstrap_port, self.friend_id)
+        if self.friend_id:
+            self._friend_number = self._tox.add_friend(self.friend_id)
+        self._tox.callback_friend_message(self._on_message)
+
+    def disconnect(self) -> None:
+        self._tox = None
+        self._friend_number = None
 
     async def send_message(self, message: Any) -> str:
-        """Record ``message`` locally and return a confirmation string."""
+        if toxcore is None:
+            raise RuntimeError("toxcore not installed")
+        if not self._tox:
+            self.connect()
+        assert self._tox is not None
+        if self._friend_number is None and self.friend_id:
+            self._friend_number = self._tox.add_friend(self.friend_id)
+        self._tox.friend_send_message(self._friend_number, message)
         self.sent_messages.append(message)
         return "sent"
 
     async def listen_and_process(self) -> None:
-        """Listening for Tox messages is not implemented."""
-        return None
+        if toxcore is None:
+            raise RuntimeError("toxcore not installed")
+        if not self._tox:
+            self.connect()
+        assert self._tox is not None
+        while True:  # pragma: no cover - loop runs until cancelled
+            self._tox.iterate()
+            await asyncio.sleep(0.1)
 
     async def process_incoming(self, message: Any) -> Any:
-        # Placeholder for processing inbound messages
         return message
+
+    def _on_message(self, _tox, friend_number, message) -> None:
+        try:
+            result = self.process_incoming(message)
+            if asyncio.iscoroutine(result):
+                asyncio.create_task(result)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Error processing Tox message from %s", friend_number)

--- a/tests/connectors/test_tox.py
+++ b/tests/connectors/test_tox.py
@@ -1,21 +1,75 @@
 import asyncio
+import types
+import pytest
 
-from app.connectors.tox_connector import ToxConnector
+import app.connectors.tox_connector as mod
 
 
-def test_send_message():
-    connector = ToxConnector("host")
+class DummyTox:
+    def __init__(self):
+        self.bootstrap_args = None
+        self.friend_id = None
+        self.sent = []
+        self.callbacks = {}
+        self.iterated = 0
+
+    def bootstrap(self, host, port, key):
+        self.bootstrap_args = (host, port, key)
+
+    def add_friend(self, friend_id):
+        self.friend_id = friend_id
+        return 0
+
+    def friend_send_message(self, friend_number, message):
+        self.sent.append((friend_number, message))
+
+    def callback_friend_message(self, cb):
+        self.callbacks['friend_message'] = cb
+
+    def iterate(self):
+        self.iterated += 1
+        if 'friend_message' in self.callbacks:
+            self.callbacks['friend_message'](self, 0, 'hello')
+
+
+def test_send_message(monkeypatch):
+    dummy = DummyTox()
+    monkeypatch.setattr(mod, 'toxcore', types.SimpleNamespace(Tox=lambda: dummy))
+    connector = mod.ToxConnector('host', friend_id='id')
     result = asyncio.get_event_loop().run_until_complete(
-        connector.send_message("hi")
+        connector.send_message('hi')
     )
-    assert result == "sent"
-    assert connector.sent_messages == ["hi"]
+    assert result == 'sent'
+    assert dummy.sent == [(0, 'hi')]
+    assert connector.sent_messages == ['hi']
+    assert dummy.bootstrap_args == ('host', 33445, 'id')
 
 
-def test_process_incoming():
-    connector = ToxConnector("host")
-    payload = {"foo": 1}
-    result = asyncio.get_event_loop().run_until_complete(
-        connector.process_incoming(payload)
-    )
-    assert result == payload
+def test_no_library(monkeypatch):
+    monkeypatch.setattr(mod, 'toxcore', None)
+    connector = mod.ToxConnector('host')
+    with pytest.raises(RuntimeError):
+        asyncio.get_event_loop().run_until_complete(connector.send_message('hi'))
+
+
+def test_listen_and_process(monkeypatch):
+    dummy = DummyTox()
+    monkeypatch.setattr(mod, 'toxcore', types.SimpleNamespace(Tox=lambda: dummy))
+
+    processed = []
+
+    class TestConnector(mod.ToxConnector):
+        async def process_incoming(self, message):
+            processed.append(message)
+
+    connector = TestConnector('host', friend_id='id')
+
+    async def fake_sleep(t):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, 'sleep', fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.get_event_loop().run_until_complete(connector.listen_and_process())
+
+    assert processed == ['hello']


### PR DESCRIPTION
## Summary
- complete the Tox connector implementation
- extend tests for the Tox connector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d9625f748333b24c095ad6bfa26f