### PR TITLE
Implement Kik connector

### DIFF
--- a/app/connectors/kik_connector.py
+++ b/app/connectors/kik_connector.py
@@ -1,24 +1,81 @@
+"""Connector for the Kik messaging platform using the HTTP API."""
+
+from typing import Any, Dict, Optional
+
+import asyncio
+import httpx
+
 from .base_connector import BaseConnector
-from typing import Any
+from app.core.logging import setup_logger
+
+logger = setup_logger(__name__)
+
 
 class KikConnector(BaseConnector):
-    """Stub connector for the Kik messaging platform."""
+    """Connector for interacting with Kik's bot API."""
 
     id = "kik"
     name = "Kik"
 
-    def __init__(self, username: str, api_key: str, config=None) -> None:
+    def __init__(
+        self, username: str, api_key: str, config: Optional[dict] = None
+    ) -> None:
         super().__init__(config)
         self.username = username
         self.api_key = api_key
-        self.sent_messages = []
+        self.api_url = "https://api.kik.com/v1"
 
-    async def send_message(self, message: Any) -> str:
-        self.sent_messages.append(message)
-        return "sent"
+    async def send_message(
+        self, message: str, to: Optional[str] = None
+    ) -> Optional[str]:
+        """Send ``message`` to ``to`` using Kik's HTTP API."""
+
+        payload = {
+            "messages": [
+                {
+                    "type": "text",
+                    "to": to or self.username,
+                    "body": message,
+                }
+            ]
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.post(
+                    f"{self.api_url}/message",
+                    json=payload,
+                    auth=(self.username, self.api_key),
+                )
+                resp.raise_for_status()
+                return resp.text
+            except httpx.HTTPError as exc:  # pragma: no cover - network
+                logger.error("Error sending Kik message: %s", exc)
+                return None
 
     async def listen_and_process(self) -> None:
-        return None
+        """Kik bots primarily use webhooks; no polling implementation."""
 
-    async def process_incoming(self, message: Any) -> Any:
-        return message
+        self.logger.info("Kik connector does not support polling for messages")
+        await asyncio.sleep(0)
+
+    async def process_incoming(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize an incoming Kik message payload."""
+
+        return {
+            "text": message.get("body", ""),
+            "from": message.get("from"),
+            "id": message.get("id"),
+        }
+
+    def is_connected(self) -> bool:
+        """Return ``True`` if the API credentials appear valid."""
+
+        try:
+            resp = httpx.get(
+                f"{self.api_url}/config", auth=(self.username, self.api_key)
+            )
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            return False

--- a/docs/connectors/kik.md
+++ b/docs/connectors/kik.md
@@ -1,6 +1,6 @@
 # Kik Connector
 
-This connector enables Norman to interact with the Kik messaging platform.
+This connector enables Norman to interact with the Kik messaging platform via the official HTTP API.
 
 ## Configuration
 
@@ -12,4 +12,4 @@ kik_api_key: "your_kik_api_key"
 
 ## Usage
 
-With these values provided, Norman can send and receive messages through Kik. The current implementation is a stub for future integration with the Kik API.
+With these values provided, Norman can send messages through Kik using the built-in API integration. Incoming messages should be delivered to Norman via a webhook endpoint.

--- a/tests/connectors/test_kik.py
+++ b/tests/connectors/test_kik.py
@@ -1,15 +1,84 @@
 import asyncio
+import httpx
+
 from app.connectors.kik_connector import KikConnector
 
 
-def test_send_message():
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, auth=None):
+        self.sent = (url, json, auth)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    client = DummyClient(resp)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
     connector = KikConnector("user", "key")
     result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
     assert result == "sent"
-    assert connector.sent_messages == ["hi"]
+    assert client.sent[0].endswith("/message")
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None, auth=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = KikConnector("user", "key")
+    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    assert result is None
 
 
 def test_process_incoming():
     connector = KikConnector("user", "key")
-    result = asyncio.get_event_loop().run_until_complete(connector.process_incoming({"m": 1}))
-    assert result == {"m": 1}
+    payload = {"body": "hello", "from": "alice", "id": "1"}
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming(payload)
+    )
+    assert result == {"text": "hello", "from": "alice", "id": "1"}
+
+
+class DummyGetResponse:
+    def __init__(self, status=200):
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+def test_is_connected_success(monkeypatch):
+    monkeypatch.setattr(httpx, "get", lambda url, auth=None: DummyGetResponse())
+    connector = KikConnector("user", "key")
+    assert connector.is_connected()
+
+
+def test_is_connected_error(monkeypatch):
+    def raise_err(url, auth=None):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "get", raise_err)
+    connector = KikConnector("user", "key")
+    assert not connector.is_connected()


### PR DESCRIPTION
## Summary
- implement Kik connector using HTTP API
- improve documentation for Kik connector
- add comprehensive unit tests for the new connector

## Testing
- `make lint` *(fails: would reformat many files)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840e4f6202083338cb6562eb4de2a71