### PR TITLE
Implement Pinterest connector

### DIFF
--- a/app/connectors/pinterest_connector.py
+++ b/app/connectors/pinterest_connector.py
@@ -1,24 +1,58 @@
+import asyncio
+from typing import Any, Dict, Optional
+
+import httpx
+
 from .base_connector import BaseConnector
-from typing import Any
+from app.core.logging import setup_logger
+
+logger = setup_logger(__name__)
+
 
 class PinterestConnector(BaseConnector):
-    """Stub connector for the Pinterest API."""
+    """Connector for posting pins via the Pinterest REST API."""
 
     id = "pinterest"
     name = "Pinterest"
 
-    def __init__(self, access_token: str, board_id: str, config=None) -> None:
+    def __init__(
+        self, access_token: str, board_id: str, config: Optional[dict] = None
+    ) -> None:
         super().__init__(config)
         self.access_token = access_token
         self.board_id = board_id
-        self.sent_messages = []
+        self.api_url = "https://api.pinterest.com/v5"
 
-    async def send_message(self, message: Any) -> str:
-        self.sent_messages.append(message)
-        return "sent"
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.access_token}"}
+
+    async def send_message(self, message: Dict[str, Any]) -> Optional[str]:
+        """Create a new pin on ``board_id`` using the provided ``message``."""
+        payload = {
+            "board_id": self.board_id,
+            "title": message.get("title", ""),
+            "description": message.get("description", ""),
+        }
+        if "image_url" in message:
+            payload["media_source"] = {
+                "source_type": "image_url",
+                "url": message["image_url"],
+            }
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"{self.api_url}/pins", json=payload, headers=self._headers()
+                )
+            resp.raise_for_status()
+            return resp.text
+        except httpx.HTTPError as exc:  # pragma: no cover - network
+            logger.error("Error creating Pinterest pin: %s", exc)
+            return None
 
     async def listen_and_process(self) -> None:
-        return None
+        """Pinterest does not offer polling for incoming messages."""
+        logger.info("Pinterest connector does not support incoming messages")
+        await asyncio.sleep(0)
 
     async def process_incoming(self, message: Any) -> Any:
         return message

--- a/docs/connectors/pinterest.md
+++ b/docs/connectors/pinterest.md
@@ -1,13 +1,28 @@
 # Pinterest Connector
 
-This connector posts pins or reads updates from Pinterest boards.
+The Pinterest connector allows Norman to create pins on a specific board using the Pinterest REST API.
+
+## Requirements
+
+- A Pinterest API access token
+- The ID of the board you want to post to
 
 ## Configuration
-Add the following settings to your `config.yaml` file:
+
+Add the access token and board ID to your `config.yaml` file:
+
 ```yaml
 pinterest_access_token: "your_pinterest_access_token"
 pinterest_board_id: "your_pinterest_board_id"
 ```
 
 ## Usage
-The current code is a stub and can be expanded to integrate with the Pinterest API.
+
+When invoked, Norman will create a new pin on the configured board. The message
+payload should include an `image_url`, and optionally a `title` and
+`description`.
+
+## Troubleshooting
+
+1. Ensure your access token has permission to create pins.
+2. Verify the board ID is correct and that the token has access to it.

--- a/tests/connectors/test_pinterest.py
+++ b/tests/connectors/test_pinterest.py
@@ -1,15 +1,64 @@
 import asyncio
+import httpx
 from app.connectors.pinterest_connector import PinterestConnector
 
 
-def test_send_message():
+class DummyResponse:
+    def __init__(self, text="ok", status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+        self.sent = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, headers=None):
+        self.sent = (url, json, headers)
+        return self.response
+
+
+def test_send_message_success(monkeypatch):
+    resp = DummyResponse("sent")
+    client = DummyClient(resp)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
     connector = PinterestConnector("tok", "board")
-    result = asyncio.get_event_loop().run_until_complete(connector.send_message("hi"))
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message({"image_url": "http://img"})
+    )
     assert result == "sent"
-    assert connector.sent_messages == ["hi"]
+    assert client.sent[0].endswith("/pins")
+    assert client.sent[1]["board_id"] == "board"
+    assert "Authorization" in client.sent[2]
+
+
+def test_send_message_error(monkeypatch):
+    class BadClient(DummyClient):
+        async def post(self, url, json=None, headers=None):
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: BadClient(DummyResponse()))
+    connector = PinterestConnector("tok", "board")
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.send_message({"image_url": "http://img"})
+    )
+    assert result is None
 
 
 def test_process_incoming():
     connector = PinterestConnector("tok", "board")
-    result = asyncio.get_event_loop().run_until_complete(connector.process_incoming({"m": 1}))
+    result = asyncio.get_event_loop().run_until_complete(
+        connector.process_incoming({"m": 1})
+    )
     assert result == {"m": 1}


### PR DESCRIPTION
## Summary
- implement functional Pinterest connector using httpx
- document configuration and usage in Pinterest docs
- expand unit tests for Pinterest connector

## Testing
- `make lint` *(fails: 171 files would be reformatted)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840e4ff431483338861d7cd29c92cc5