### PR TITLE
Add webhooks for event services

### DIFF
--- a/app/api/api_v1/routers/connectors/__init__.py
+++ b/app/api/api_v1/routers/connectors/__init__.py
@@ -6,6 +6,8 @@ from .google_chat import router as google_chat_router
 from .discord import router as discord_router
 from .webhook import router as webhook_router
 from .mcp import router as mcp_router
+from .aws_eventbridge import router as aws_eventbridge_router
+from .azure_eventgrid import router as azure_eventgrid_router
 
 router = APIRouter()
 
@@ -16,4 +18,14 @@ router.include_router(google_chat_router, prefix="/google_chat", tags=["Google C
 router.include_router(discord_router, prefix="/discord", tags=["Discord"])
 router.include_router(webhook_router, prefix="/webhook", tags=["Webhook"])
 router.include_router(mcp_router, prefix="/mcp", tags=["MCP"])
+router.include_router(
+    aws_eventbridge_router,
+    prefix="/aws_eventbridge",
+    tags=["AWS EventBridge"],
+)
+router.include_router(
+    azure_eventgrid_router,
+    prefix="/azure_eventgrid",
+    tags=["Azure Event Grid"],
+)
 

--- a/app/api/api_v1/routers/connectors/aws_eventbridge.py
+++ b/app/api/api_v1/routers/connectors/aws_eventbridge.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, Request
+from app.connectors.aws_eventbridge_connector import AWSEventBridgeConnector
+from app.core.config import get_settings, Settings
+
+router = APIRouter()
+
+
+def get_eventbridge_connector(settings: Settings = Depends(get_settings)) -> AWSEventBridgeConnector:
+    return AWSEventBridgeConnector(
+        region=settings.aws_eventbridge_region,
+        event_bus_name=settings.aws_eventbridge_event_bus_name,
+    )
+
+
+@router.post("/webhooks/eventbridge")
+async def process_eventbridge_update(
+    request: Request,
+    eventbridge_connector: AWSEventBridgeConnector = Depends(get_eventbridge_connector),
+):
+    payload = await request.json()
+    eventbridge_connector.process_incoming(payload)
+    return {"detail": "Update processed"}

--- a/app/api/api_v1/routers/connectors/azure_eventgrid.py
+++ b/app/api/api_v1/routers/connectors/azure_eventgrid.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, Request
+from app.connectors.azure_eventgrid_connector import AzureEventGridConnector
+from app.core.config import get_settings, Settings
+
+router = APIRouter()
+
+
+def get_eventgrid_connector(settings: Settings = Depends(get_settings)) -> AzureEventGridConnector:
+    return AzureEventGridConnector(
+        endpoint=settings.azure_eventgrid_endpoint,
+        key=settings.azure_eventgrid_key,
+    )
+
+
+@router.post("/webhooks/eventgrid")
+async def process_eventgrid_update(
+    request: Request,
+    eventgrid_connector: AzureEventGridConnector = Depends(get_eventgrid_connector),
+):
+    payload = await request.json()
+    eventgrid_connector.process_incoming(payload)
+    return {"detail": "Update processed"}

--- a/docs/connectors/aws_eventbridge.md
+++ b/docs/connectors/aws_eventbridge.md
@@ -18,8 +18,10 @@ aws_eventbridge_event_bus_name: "default"
 
 ## Usage
 
-Incoming messages are not supported. The connector only publishes events.
+Events can be delivered to Norman via a webhook. Configure EventBridge to send
+notifications to `/api/v1/connectors/aws_eventbridge/webhooks/eventbridge`.
 
-The connector checks connectivity by calling `DescribeEventBus` on startup when
-`is_connected()` is invoked. If the credentials or event bus are incorrect, this
-method returns `False`.
+The connector still publishes events to EventBridge using `put_events`.  It
+verifies connectivity by calling `DescribeEventBus` when `is_connected()` is
+invoked. If the credentials or event bus are incorrect, this method returns
+`False`.

--- a/docs/connectors/azure_eventgrid.md
+++ b/docs/connectors/azure_eventgrid.md
@@ -18,8 +18,11 @@ azure_eventgrid_key: "your-access-key"
 
 ## Usage
 
-This connector only sends events and does not listen for incoming messages.
+Configure Azure Event Grid to post events to
+`/api/v1/connectors/azure_eventgrid/webhooks/eventgrid`. The connector will
+process these incoming events in addition to publishing events to the configured
+topic.
 
-The connector verifies connectivity by making a simple HTTP request to the
-configured endpoint when :code:`is_connected()` is called. If the request fails
-or returns an error status code, the method returns ``False``.
+Connectivity is verified by making a simple HTTP request to the configured
+endpoint when :code:`is_connected()` is called. If the request fails or returns
+an error status code, the method returns ``False``.

--- a/tests/test_aws_eventbridge_router.py
+++ b/tests/test_aws_eventbridge_router.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+from app.api.api_v1.routers.connectors import aws_eventbridge as eventbridge_router
+from app.core.test_settings import test_settings
+
+
+def test_get_eventbridge_connector_uses_settings():
+    connector = eventbridge_router.get_eventbridge_connector(test_settings)
+    assert connector.region == test_settings.aws_eventbridge_region
+    assert connector.event_bus_name == test_settings.aws_eventbridge_event_bus_name
+
+
+def test_process_eventbridge_update(monkeypatch, test_app: TestClient):
+    received = {}
+
+    class DummyConnector:
+        def __init__(self, region: str, event_bus_name: str, config=None):
+            self.region = region
+            self.event_bus_name = event_bus_name
+
+        def process_incoming(self, payload):
+            received["payload"] = payload
+
+    monkeypatch.setattr(eventbridge_router, "AWSEventBridgeConnector", DummyConnector)
+    resp = test_app.post(
+        "/api/v1/connectors/aws_eventbridge/webhooks/eventbridge",
+        json={"msg": "hi"},
+    )
+    assert resp.status_code == 200
+    assert received["payload"] == {"msg": "hi"}

--- a/tests/test_azure_eventgrid_router.py
+++ b/tests/test_azure_eventgrid_router.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+from app.api.api_v1.routers.connectors import azure_eventgrid as eventgrid_router
+from app.core.test_settings import test_settings
+
+
+def test_get_eventgrid_connector_uses_settings():
+    connector = eventgrid_router.get_eventgrid_connector(test_settings)
+    assert connector.endpoint == test_settings.azure_eventgrid_endpoint
+    assert connector.key == test_settings.azure_eventgrid_key
+
+
+def test_process_eventgrid_update(monkeypatch, test_app: TestClient):
+    received = {}
+
+    class DummyConnector:
+        def __init__(self, endpoint: str, key: str, config=None):
+            self.endpoint = endpoint
+            self.key = key
+
+        def process_incoming(self, payload):
+            received["payload"] = payload
+
+    monkeypatch.setattr(eventgrid_router, "AzureEventGridConnector", DummyConnector)
+    resp = test_app.post(
+        "/api/v1/connectors/azure_eventgrid/webhooks/eventgrid",
+        json={"msg": "hi"},
+    )
+    assert resp.status_code == 200
+    assert received["payload"] == {"msg": "hi"}


### PR DESCRIPTION
## Summary
- route EventBridge events to Norman via `/api/v1/connectors/aws_eventbridge/webhooks/eventbridge`
- route Azure Event Grid events via `/api/v1/connectors/azure_eventgrid/webhooks/eventgrid`
- document new endpoints and add integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684174566c4c833393e64f8d5868f7f8