### PR TITLE
Add connector entry point discovery

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -29,6 +29,16 @@ Norman supports various chat platforms through connectors. To create a new conne
 
 6. Test your new connector and ensure it works correctly with Norman's core functionality.
 
+7. If you package the connector separately, expose it via the
+   `norman.connectors` entry point group in your `pyproject.toml`:
+
+   ```toml
+   [project.entry-points."norman.connectors"]
+   my_connector = "your_package.module:ConnectorClass"
+   ```
+
+   Norman will automatically load connectors advertised through this group.
+
 ## Adding Custom Actions
 
 Norman performs various actions based on the filters and rules defined by the user. To add a custom action, follow these steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "norman"
+version = "0.2.0"
+
+[project.entry-points."norman.connectors"]
+# Third-party packages can add connectors here.

--- a/tests/connectors/test_entrypoint_discovery.py
+++ b/tests/connectors/test_entrypoint_discovery.py
@@ -1,0 +1,43 @@
+import sys
+import types
+from importlib.metadata import EntryPoint
+
+from app.connectors import connector_utils
+from app.connectors.base_connector import BaseConnector
+
+
+class DummyConnector(BaseConnector):
+    id = "dummy"
+    name = "Dummy"
+
+    def send_message(self, message):
+        pass
+
+    async def listen_and_process(self):  # pragma: no cover - dummy implementation
+        pass
+
+    async def process_incoming(
+        self, message
+    ):  # pragma: no cover - dummy implementation
+        pass
+
+
+# Create a module path for the entry point
+module = types.ModuleType("tests.dummy_entry")
+module.DummyConnector = DummyConnector
+sys.modules["tests.dummy_entry"] = module
+
+
+def test_discover_connectors_from_entry_points(monkeypatch):
+    ep = EntryPoint(
+        name="dummy",
+        value="tests.dummy_entry:DummyConnector",
+        group="norman.connectors",
+    )
+    monkeypatch.setattr(connector_utils, "connector_classes", {})
+    monkeypatch.setattr(connector_utils.pkgutil, "iter_modules", lambda paths: [])
+    monkeypatch.setattr(connector_utils.metadata, "entry_points", lambda **kw: [ep])
+
+    connector_utils._discover_connectors()
+    assert "dummy" in connector_utils.connector_classes
+    assert connector_utils.connector_classes["dummy"] is DummyConnector


### PR DESCRIPTION
## Summary
- load connector classes from the `norman.connectors` entry point group
- document how to register connectors via entry points
- add dummy package test for entry point discovery
- include empty `pyproject.toml` defining the new group

## Testing
- `make lint` *(fails: would reformat many files)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68502bf9765c8333b888f6d5dc388f53