### PR TITLE
Remove app.main

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can also edit `config.yaml` manually to provide your own values. Be sure to 
 
 6. Run the application with Uvicorn:
 ```bash
-uvicorn app.main:app --host 0.0.0.0 --port 8000 --compression gzip
+uvicorn main:app --host 0.0.0.0 --port 8000 --compression gzip
 ```
 If `brotli_asgi` is installed and supported by your Uvicorn version,
 replace `gzip` with `brotli` for improved compression.

--- a/app/main.py
+++ b/app/main.py
@@ -1,1 +1,0 @@
-from main import app

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ Here is a text-based representation of Norman's high-level architecture:
 ```
 +---------------------+     +--------------------+     +-------------------+
 | Chat Platform       | <-> | Connector          | <-> | FastAPI App       |
-| (Slack, IRC, etc.)  |     | (Slack, IRC, etc.) |     | (app/main.py)     |
+| (Slack, IRC, etc.)  |     | (Slack, IRC, etc.) |     | (main.py)        |
 +---------------------+     +--------------------+     +-------------------+
                                           |                  |
                                           v                  v

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,7 +61,7 @@ Before deploying Norman, ensure that your server meets the following requirement
 1. Start the Norman application:
 
    ```
-   uvicorn app.main:app --host 0.0.0.0 --port 8000 --compression gzip
+   uvicorn main:app --host 0.0.0.0 --port 8000 --compression gzip
 
    If the `brotli_asgi` package is installed and your Uvicorn version supports
    it, you can use `--compression brotli` instead for better compression.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -49,7 +49,7 @@ Norman performs various actions based on the filters and rules defined by the us
 
 Norman's core functionality can be modified and extended to suit your specific needs. Before making changes, familiarize yourself with the codebase and understand the key components, such as:
 
-- The FastAPI application (`app/main.py`)
+- The FastAPI application (`main.py`)
 - The database models (`app/models`)
 - The API routes (`app/api`)
 - The connectors (`app/connectors`)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import sys
 from pydantic import typing as _pydantic_typing
 
 if sys.version_info >= (3, 12):
+
     def _evaluate_forwardref(type_, globalns, localns):
         return type_._evaluate(globalns, localns, None, recursive_guard=set())
 
@@ -17,7 +18,7 @@ from sqlalchemy.pool import QueuePool
 from pathlib import Path
 
 os.environ["SKIP_MIGRATIONS"] = "1"
-from app.main import app
+from main import app
 from app.connectors import init_connectors
 from app.core.test_settings import test_settings
 from app.core.config import settings
@@ -35,18 +36,22 @@ engine = create_engine(
     poolclass=QueuePool,
     pool_size=settings.database_pool_size,
     max_overflow=settings.database_max_overflow,
-    connect_args={"check_same_thread": False}
-    if settings.database_url.startswith("sqlite")
-    else {},
+    connect_args=(
+        {"check_same_thread": False}
+        if settings.database_url.startswith("sqlite")
+        else {}
+    ),
 )
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base.metadata.create_all(bind=engine)
 
 # Override the application's SessionLocal to ensure the API uses the test database
 from app.db import session as db_session
+
 db_session.SessionLocal = TestingSessionLocal
 db_session.engine = engine
 import app.api.deps as api_deps
+
 api_deps.SessionLocal = TestingSessionLocal
 
 
@@ -64,4 +69,3 @@ def db():
         yield session
     finally:
         session.close()
-


### PR DESCRIPTION
## Summary
- drop `app/main.py`
- document running `uvicorn main:app`
- clean up docs referencing `app/main.py`
- adjust tests to import `app` from `main`

## Testing
- `make lint` *(fails: 170 files would be reformatted, pylint not found)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68502bfae8ec8333abe9f8fb65466e97