### PR TITLE
Add OpenAPI schema generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,15 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000 --compression gzip
 If `brotli_asgi` is installed and supported by your Uvicorn version,
 replace `gzip` with `brotli` for improved compression.
 
-7. Open the API documentation in your browser: [http://localhost:8000/docs](http://localhost:8000/docs)
+7. Generate the OpenAPI schema:
+```bash
+python generate_openapi.py
+```
+   The schema is saved to `docs/openapi.json`.
+
+8. Open the API documentation in your browser: [http://localhost:8000/docs](http://localhost:8000/docs)
    A basic health check endpoint is available at [http://localhost:8000/health](http://localhost:8000/health)
+9. View the hosted API documentation at [https://kristopherkubicki.github.io/norman](https://kristopherkubicki.github.io/norman)
 
 Norman emits structured JSON logs that include the timestamp, module and request ID. Sensitive data such as API keys are automatically redacted so these logs can be safely forwarded to monitoring systems.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Welcome to the Norman documentation! Here you'll find everything you need to kno
 - [Contributing](../contributing.md) - A guide on how to contribute to the Norman project.
 - [Community](community.md) - Information about the Norman community and how to get involved.
 - [Connectors](connectors.md) - An overview of the available connectors and how to use them.
+- [API Docs](https://kristopherkubicki.github.io/norman) - Hosted Swagger UI generated on each release.
 
 ## Getting Started
 

--- a/generate_openapi.py
+++ b/generate_openapi.py
@@ -1,0 +1,23 @@
+"""Utility to generate OpenAPI schema JSON."""
+
+from pathlib import Path
+import json
+
+from main import app
+
+
+def generate_schema(path: Path = Path("docs/openapi.json")) -> Path:
+    """Generate the OpenAPI schema and write it to ``path``."""
+    schema = app.openapi()
+    path.write_text(json.dumps(schema, indent=2))
+    return path
+
+
+def main() -> None:
+    """Entry point for the script."""
+    output = generate_schema()
+    print(f"OpenAPI schema written to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import json
+
+from generate_openapi import generate_schema
+
+
+def test_generate_schema(tmp_path: Path) -> None:
+    """Ensure the OpenAPI schema is generated."""
+    out = generate_schema(tmp_path / "schema.json")
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert "openapi" in data
+    assert data["openapi"].startswith("3")


### PR DESCRIPTION
## Summary
- generate a static OpenAPI JSON file
- document hosted API docs and how to generate the schema
- link to hosted docs from the docs index
- test schema generation

## Testing
- `make lint` *(fails: 171 files would be reformatted)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68502c0dfcc0833395911529a4860542