### PR TITLE
Add Bandit security scan

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,29 @@
+name: Bandit Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Bandit
+        run: pip install bandit
+      - name: Run Bandit
+        run: bandit -r app -f sarif -o bandit.sarif
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: bandit.sarif


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for Bandit security scan

## Testing
- `make lint` *(fails: black would reformat files)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68502c0f975c8333b724fc3aea44acaa