### PR TITLE
Implement redis rate limiting backend

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -209,6 +209,8 @@ class Settings(BaseSettings):
     port: int
     rate_limit_requests: int = 60
     rate_limit_window_seconds: int = 60
+    rate_limit_backend: str = "memory"
+    rate_limit_redis_url: str = "redis://localhost:6379/0"
 
     @validator("secret_key", pre=True)
     def validate_secret_key(cls, v):

--- a/app/core/rate_limit.py
+++ b/app/core/rate_limit.py
@@ -1,29 +1,73 @@
-from typing import Dict, List
-import time
+from __future__ import annotations
+
 import asyncio
 import sys
+import time
+from typing import Dict, List, Protocol
+
 from fastapi import Request, Response
+
 from app.core.config import get_settings
 
-class RateLimiter:
-    """Simple in-memory IP based rate limiter middleware."""
+
+class RateLimitStore(Protocol):
+    """Abstract storage for rate limiting."""
+
+    async def increment(self, identifier: str, timestamp: float, window: int) -> int:
+        """Prune old entries, record the timestamp and return current count."""
+
+
+class MemoryRateLimitStore:
+    """In-memory rate limit storage suitable for testing."""
 
     def __init__(self) -> None:
+        self.requests: Dict[str, List[float]] = {}
+        self.lock = asyncio.Lock()
+
+    async def increment(self, identifier: str, timestamp: float, window: int) -> int:
+        async with self.lock:
+            timestamps = [
+                t for t in self.requests.get(identifier, []) if timestamp - t < window
+            ]
+            timestamps.append(timestamp)
+            self.requests[identifier] = timestamps
+            return len(timestamps)
+
+
+class RedisRateLimitStore:
+    """Redis-backed rate limit storage."""
+
+    def __init__(self, url: str) -> None:
+        import redis.asyncio as redis  # optional dependency
+
+        self.client = redis.from_url(url, decode_responses=True)
+
+    async def increment(self, identifier: str, timestamp: float, window: int) -> int:
+        key = f"rate:{identifier}"
+        pipe = self.client.pipeline()
+        pipe.zremrangebyscore(key, 0, timestamp - window)
+        pipe.zadd(key, {str(timestamp): timestamp})
+        pipe.expire(key, window)
+        await pipe.execute()
+        return await self.client.zcount(key, timestamp - window, timestamp)
+
+
+class RateLimiter:
+    """IP based rate limiting middleware."""
+
+    def __init__(self, store: RateLimitStore | None = None) -> None:
         settings = get_settings()
         self.max_requests = settings.rate_limit_requests
         self.window = settings.rate_limit_window_seconds
         if "pytest" in sys.modules:
             self.max_requests = 10000
-        self.requests: Dict[str, List[float]] = {}
-        self.lock = asyncio.Lock()
+        self.store = store or MemoryRateLimitStore()
 
     async def __call__(self, request: Request, call_next):
         identifier = request.client.host if request.client else "unknown"
         now = time.time()
-        async with self.lock:
-            timestamps = [t for t in self.requests.get(identifier, []) if now - t < self.window]
-            if len(timestamps) >= self.max_requests:
-                return Response(status_code=429, content="Too Many Requests")
-            timestamps.append(now)
-            self.requests[identifier] = timestamps
+        count = await self.store.increment(identifier, now, self.window)
+        if count > self.max_requests:
+            return Response(status_code=429, content="Too Many Requests")
         return await call_next(request)
+

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -198,6 +198,8 @@ host: "0.0.0.0"
 port: 8000
 rate_limit_requests: 60
 rate_limit_window_seconds: 60
+rate_limit_backend: "memory"
+rate_limit_redis_url: "redis://localhost:6379/0"
 
 
 # how long before a session should close from the web ui
@@ -205,3 +207,4 @@ access_token_expire_minutes: 1440
 algorithm: HS256
 encryption_key: "your_encryption_key"
 encryption_salt: "your_encryption_salt"
+

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from fastapi.middleware.gzip import GZipMiddleware
 
 try:
     from brotli_asgi import BrotliMiddleware  # type: ignore
+
     _brotli = True
 except Exception:  # pragma: no cover - optional dep may not be installed
     BrotliMiddleware = None  # type: ignore
@@ -21,8 +22,13 @@ from app.app_routes import app_routes
 from app.core.config import settings
 from app.auth_middleware import auth_middleware
 from app.core.logging import request_context_middleware
-from app.core.rate_limit import RateLimiter
+from app.core.rate_limit import (
+    RateLimiter,
+    MemoryRateLimitStore,
+    RedisRateLimitStore,
+)
 from app.core.exception_handlers import add_exception_handlers
+
 
 def run_alembic_migrations():
     if not os.path.exists("alembic/versions"):
@@ -31,9 +37,15 @@ def run_alembic_migrations():
     alembic_cfg.set_main_option("sqlalchemy.url", settings.database_url)
     command.upgrade(alembic_cfg, "head")
 
+
 app = FastAPI()
 
-rate_limiter = RateLimiter()
+if settings.rate_limit_backend == "redis":
+    store = RedisRateLimitStore(settings.rate_limit_redis_url)
+else:
+    store = MemoryRateLimitStore()
+
+rate_limiter = RateLimiter(store=store)
 
 if _brotli and BrotliMiddleware:
     app.add_middleware(BrotliMiddleware)
@@ -43,15 +55,16 @@ else:
 app.middleware("http")(request_context_middleware)
 app.middleware("http")(rate_limiter)
 
+
 @app.middleware("http")
 async def cache_control_middleware(request: Request, call_next):
     response = await call_next(request)
-    if (
-        request.method == "GET"
-        and response.headers.get("content-type", "").startswith("application/json")
+    if request.method == "GET" and response.headers.get("content-type", "").startswith(
+        "application/json"
     ):
         response.headers.setdefault("Cache-Control", "max-age=60")
     return response
+
 
 # Create the initial user
 @app.on_event("startup")
@@ -61,6 +74,7 @@ async def startup_event():
             os.makedirs("db", exist_ok=True)
         run_alembic_migrations()
         create_initial_admin_user()
+
 
 # add authentication
 app.middleware("http")(auth_middleware)
@@ -73,11 +87,16 @@ init_routers(app)
 add_exception_handlers(app)
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
-app.mount("/static", StaticFiles(directory=os.path.join(current_dir, "app/static")), name="static")
+app.mount(
+    "/static",
+    StaticFiles(directory=os.path.join(current_dir, "app/static")),
+    name="static",
+)
 
 
 # Include app_routes
 app.include_router(app_routes)
+
 
 def main() -> None:
     """Run the FastAPI application using Uvicorn."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ tiktoken
 paho-mqtt
 pika
 tweepy
+redis>=4.6.0

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,9 +1,11 @@
 from fastapi.testclient import TestClient
 from main import rate_limiter
+from app.core.rate_limit import MemoryRateLimitStore
 
 
 def test_rate_limiting(test_app: TestClient) -> None:
-    rate_limiter.requests.clear()
+    assert isinstance(rate_limiter.store, MemoryRateLimitStore)
+    rate_limiter.store.requests.clear()
     rate_limiter.max_requests = 2
     for _ in range(2):
         resp = test_app.get("/api/v1/filters/")
@@ -11,4 +13,4 @@ def test_rate_limiting(test_app: TestClient) -> None:
     resp = test_app.get("/api/v1/filters/")
     assert resp.status_code == 429
     rate_limiter.max_requests = 10000
-    rate_limiter.requests.clear()
+    rate_limiter.store.requests.clear()


### PR DESCRIPTION
## Summary
- abstract rate limit storage with a protocol
- create redis-backed store and keep memory store for tests
- allow configuration of the backend
- wire main.py to choose the store
- update tests and dependencies

## Testing
- `make lint` *(fails: would reformat many files)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68502c126d908333a9f5df80bac79471