### PR TITLE
Set up Vite build and integrate frontend assets

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -18,6 +18,16 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Detect frontend changes
+        id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+              - 'package.json'
+              - 'vite.config.js'
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -31,6 +41,25 @@ jobs:
 
       - name: Run pylint
         run: pylint --rcfile=.pylintrc $(git ls-files '*.py') || true
+
+      - name: Set up Node
+        if: steps.changes.outputs.frontend == 'true'
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install frontend dependencies
+        if: steps.changes.outputs.frontend == 'true'
+        run: npm ci
+
+      - name: Run frontend tests
+        if: steps.changes.outputs.frontend == 'true'
+        run: npm test
+
+      - name: Build frontend
+        if: steps.changes.outputs.frontend == 'true'
+        run: npm run build
 
       - name: Run tests with coverage
         run: |

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -69,5 +69,6 @@
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoKMJQ0Z6D9F6EU2ygSABR03SuhDL7z8Zef3CJXTgq1Q0Q" crossorigin="anonymous"></script>
     <script src="/static/js/theme.js"></script>
+    <script type="module" src="{{ url_for('static', path='frontend/main.js') }}"></script>
 </body>
 </html>

--- a/frontend/main.jsx
+++ b/frontend/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import InfiniteMessages from './InfiniteMessages.jsx';
+
+const mount = document.getElementById('messages-log');
+if (mount) {
+  const botId = mount.dataset.botId || '1';
+  ReactDOM.createRoot(mount).render(<InfiniteMessages botId={botId} />);
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "dev": "vite",
+    "build": "vite build"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.0",
@@ -13,7 +15,9 @@
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "vite": "^5.0.11",
+    "@vitejs/plugin-react": "^4.2.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/tests/test_frontend_assets.py
+++ b/tests/test_frontend_assets.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.schemas.user import UserCreate
+from app.tests.utils.utils import random_email, random_lower_string
+
+
+def _create_user(db: Session):
+    email = random_email()
+    password = "pass123"
+    user_in = UserCreate(email=email, username=random_lower_string(), password=password)
+    user = crud.user.create_user(db, user=user_in)
+    return user, password
+
+
+def test_frontend_script_included(test_app: TestClient, db: Session) -> None:
+    user, password = _create_user(db)
+    resp = test_app.post(
+        "/login",
+        data={"username": user.email, "password": password},
+        allow_redirects=False,
+    )
+    token = resp.cookies.get("access_token").strip('"')
+    resp2 = test_app.get("/index.html", headers={"Authorization": f"Bearer {token}"})
+    assert resp2.status_code == 200
+    assert "frontend/main.js" in resp2.text

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: resolve(__dirname, 'app/static/frontend'),
+    emptyOutDir: true,
+    rollupOptions: {
+      input: resolve(__dirname, 'frontend/main.jsx'),
+      output: {
+        entryFileNames: 'main.js',
+        format: 'es'
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vite for React bundle output
- add build & dev scripts to `package.json`
- include compiled frontend bundle in templates
- execute frontend steps in CI when relevant files change
- add test checking compiled asset is served

## Testing
- `make lint` *(fails: 171 files would be reformatted; pylint not found)*
- `make test`
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502c14d854833391d59b848ef3b512