### PR TITLE
Release native Bedrock capacity routing

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,6 +85,11 @@ The repository includes `scripts/systemd/norman-release@.service` for a
 loopback-only canary. It is intentionally separate from `norman.service`, so a
 candidate can be validated without replacing the active service:
 
+The canary reads its resolver settings only from `/etc/norman/release.env`;
+do not reuse the live service's `/etc/norman/runtime.env`. Keep
+`release.env` root-owned and mode `0600`, and limit it to
+`NORMAN_CONFIG_SECRET` plus the selected broker resolver and token settings.
+
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl start norman-release@<release-sha>

--- a/scripts/systemd/norman-release@.service
+++ b/scripts/systemd/norman-release@.service
@@ -8,7 +8,7 @@ Type=simple
 User=kristopher
 Group=kristopher
 WorkingDirectory=/home/kristopher/releases/norman-%i
-EnvironmentFile=-/etc/norman/runtime.env
+EnvironmentFile=-/etc/norman/release.env
 Environment=PYTHONUNBUFFERED=1
 Environment=PYTHONDONTWRITEBYTECODE=1
 Environment=NORMAN_CONFIG_REQUESTER_ID=norman-release

--- a/tests/test_auth_cache.py
+++ b/tests/test_auth_cache.py
@@ -1,6 +1,8 @@
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+
 from app.api import deps
 from app.core.auth_cache import (
     cache_admin_exists,
@@ -13,8 +15,14 @@ from app.core.auth_cache import (
 from app.models.user import User
 
 
-def test_user_cache_round_trips_detached_snapshot():
+@pytest.fixture(autouse=True)
+def _clear_auth_cache_between_tests():
     clear_auth_caches()
+    yield
+    clear_auth_caches()
+
+
+def test_user_cache_round_trips_detached_snapshot():
     user = User(
         id=7,
         username="normal",
@@ -34,7 +42,6 @@ def test_user_cache_round_trips_detached_snapshot():
 
 
 def test_auth_cache_invalidation_and_admin_cache():
-    clear_auth_caches()
     user = User(
         id=9,
         username="operator",
@@ -53,7 +60,6 @@ def test_auth_cache_invalidation_and_admin_cache():
 
 
 def test_console_runtime_service_token_auth_uses_cached_user(monkeypatch):
-    clear_auth_caches()
     user = User(
         id=11,
         username="runtime",

--- a/tests/test_console_runtime_api.py
+++ b/tests/test_console_runtime_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from app.api.deps import get_console_runtime_user, get_current_user
+from app.core.auth_cache import clear_auth_caches
 from app.core.config import settings
 from app.crud.user import create_user, get_user_by_email
 from app.main import app
@@ -891,6 +892,7 @@ def test_console_runtime_api_approval_resumes_waiting_job(test_app):
 
 
 def test_console_runtime_api_accepts_configured_service_token(test_app, db):
+    clear_auth_caches()
     previous_token = settings.console_runtime_service_token
     previous_email = settings.console_runtime_service_user_email
     saved_current_override = app.dependency_overrides.pop(get_current_user, None)
@@ -933,6 +935,7 @@ def test_console_runtime_api_accepts_configured_service_token(test_app, db):
             item["job_id"] == "job-service-token" for item in listed.json()["items"]
         )
     finally:
+        clear_auth_caches()
         settings.console_runtime_service_token = previous_token
         settings.console_runtime_service_user_email = previous_email
         if saved_current_override is not None:

--- a/tests/test_norman_service_guardrails.py
+++ b/tests/test_norman_service_guardrails.py
@@ -25,7 +25,7 @@ def test_isolated_release_unit_requires_managed_configuration() -> None:
     ).read_text(encoding="utf-8")
 
     assert "WorkingDirectory=/home/kristopher/releases/norman-%i" in source
-    assert "EnvironmentFile=-/etc/norman/runtime.env" in source
+    assert "EnvironmentFile=-/etc/norman/release.env" in source
     assert "NORMAN_CONFIG_REQUESTER_ID=norman-release" in source
     assert 'test -n "$NORMAN_CONFIG_SECRET"' in source
     assert "NORMAN_CONFIG_SECRET_CMD" in source


### PR DESCRIPTION
## Summary
- add native, policy-gated Bedrock execution while preserving Norllama local-first routing
- add Codex capacity monitoring and separate plan, API, and Bedrock accounting
- harden managed release configuration and skip unsolicited private-host fleet scans
- isolate the canary from the live service environment with `/etc/norman/release.env`

## Why
The release canary must validate a clean, brokered configuration path without inheriting unrelated live-service environment or silently falling back between providers.

## Validation
- `make format`
- `make lint`
- `make test` (`1906 passed, 6 warnings`)
- `./.venv/bin/pytest -q tests/test_norman_service_guardrails.py` (`2 passed`)

## Release Gate
The canary unit is installed on `norman.home.arpa`, but promotion remains blocked until a Norman Keys-backed `norman/runtime-config` alias, resolver, and policy for requester `norman-release` are provisioned. No live configuration was copied or read, and production has not been restarted.