### PR TITLE
Enforce Norman Keys host policy

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -597,7 +597,8 @@ def _brokered_config_secret(secret_name: str) -> str:
         "requester_id": _clean_env("NORMAN_CONFIG_REQUESTER_ID") or "norman-service",
         "session_id": "startup",
         "lane": "backend",
-        "target_host": _clean_env("HOSTNAME"),
+        "target_host": _clean_env("NORMAN_CONFIG_TARGET_HOST")
+        or _clean_env("HOSTNAME"),
     }
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
     token = _clean_env("NORMAN_KEYS_TOKEN") or _clean_env("NORMAN_KEYS_API_TOKEN")

--- a/app/services/secret_keys.py
+++ b/app/services/secret_keys.py
@@ -192,6 +192,21 @@ def _policy_score(
     return score
 
 
+def _normalized_host(value: object) -> str:
+    return str(value or "").strip().lower().rstrip(".")
+
+
+def _host_allowed(policy: SecretPolicy, target_host: str) -> bool:
+    allowed_hosts = {
+        _normalized_host(host)
+        for host in (policy.allowed_hosts or [])
+        if _normalized_host(host)
+    }
+    if not allowed_hosts:
+        return True
+    return _normalized_host(target_host) in allowed_hosts
+
+
 def _match_policy(
     db: Session, *, alias: SecretAlias, body: SecretRequestCreate
 ) -> Optional[SecretPolicy]:
@@ -205,7 +220,10 @@ def _match_policy(
     if not matches:
         return None
     matches.sort(key=lambda item: (item[0], item[1].id), reverse=True)
-    return matches[0][1]
+    selected = matches[0][1]
+    if not _host_allowed(selected, body.target_host):
+        return None
+    return selected
 
 
 def _issue_lease(

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,6 +67,7 @@ one approved resolver:
 NORMAN_CONFIG_SECRET=norman/runtime-config
 NORMAN_CONFIG_SECRET_CMD=<approved broker command using {name}>
 NORMAN_CONFIG_REQUESTER_ID=norman-release
+NORMAN_CONFIG_TARGET_HOST=norman.lollie.org
 ```
 
 `NORMAN_CONFIG_SECRET_CMD` is preferred for the temporary machine-local `cred`
@@ -80,6 +81,10 @@ YAML. It does not log the returned contents, generate a replacement
 `config.yaml`, or silently fall back to a repo-local config file. The optional
 `NORMAN_CONFIG_PATH` migration setting must be an absolute path outside the
 application working tree; do not use it to point back at a release checkout.
+When the secret policy has `allowed_hosts`, set
+`NORMAN_CONFIG_TARGET_HOST` to the exact approved hostname. Hostname matching
+is case-insensitive and ignores a trailing dot; an unset or unapproved host is
+denied.
 
 The repository includes `scripts/systemd/norman-release@.service` for a
 loopback-only canary. It is intentionally separate from `norman.service`, so a

--- a/tests/test_initial_setup.py
+++ b/tests/test_initial_setup.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from pathlib import Path
 
@@ -150,6 +151,43 @@ def test_load_config_uses_brokered_secret_without_creating_local_config(
     ]
     assert not (tmp_path / "config.yaml").exists()
     assert config.active_config_file_path() is None
+
+
+def test_brokered_config_secret_uses_explicit_target_host(monkeypatch):
+    monkeypatch.delenv("NORMAN_CONFIG_SECRET_CMD", raising=False)
+    monkeypatch.delenv("NORMAN_SECRET_CMD", raising=False)
+    monkeypatch.setenv("NORMAN_KEYS_URL", "http://keys.norman.test")
+    monkeypatch.setenv("NORMAN_CONFIG_REQUESTER_ID", "norman-release")
+    monkeypatch.setenv("NORMAN_CONFIG_TARGET_HOST", "norman.lollie.org")
+    monkeypatch.setenv("HOSTNAME", "untrusted-host")
+    requests = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"value":"admin_setup_key: brokered-key"}'
+
+    def fake_urlopen(request, timeout):
+        requests.append((request, timeout))
+        return Response()
+
+    monkeypatch.setattr(config.urllib_request, "urlopen", fake_urlopen)
+
+    assert config._brokered_config_secret("norman/runtime-config") == (
+        "admin_setup_key: brokered-key"
+    )
+    assert len(requests) == 1
+    request, timeout = requests[0]
+    assert request.full_url == "http://keys.norman.test/v1/secrets/get"
+    assert timeout == 5.0
+    assert json.loads(request.data.decode("utf-8"))["target_host"] == (
+        "norman.lollie.org"
+    )
 
 
 def test_load_config_uses_external_path_without_creating_local_config(

--- a/tests/test_keys_api.py
+++ b/tests/test_keys_api.py
@@ -45,6 +45,7 @@ def _seed_policy(
     allowed_modes: list[str],
     secret_prefix: str = "networking/",
     requester_id: str = "norman-prime",
+    allowed_hosts: list[str] | None = None,
 ):
     policy = SecretPolicy(
         name=name,
@@ -56,12 +57,102 @@ def _seed_policy(
         max_ttl_seconds=900,
         approval_required=approval_required,
         raw_reveal_allowed=raw_reveal_allowed,
+        allowed_hosts=allowed_hosts or [],
         enabled=True,
     )
     db.add(policy)
     db.commit()
     db.refresh(policy)
     return policy
+
+
+def test_keys_request_denies_host_outside_policy(test_app, db, tmp_path):
+    _, alias = _seed_file_alias(db, tmp_path, suffix="-host-denied")
+    _seed_policy(
+        db,
+        name="networking-host-denied",
+        approval_required=False,
+        raw_reveal_allowed=True,
+        allowed_modes=["read"],
+        allowed_hosts=["norman.lollie.org"],
+    )
+
+    response = test_app.post(
+        "/api/v1/keys/requests",
+        json={
+            "name": alias.name,
+            "requested_mode": "read",
+            "requester_type": "agent",
+            "requester_id": "norman-prime",
+            "lane": "shared_infra",
+            "target_host": "other.home.arpa",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "No secret policy matched request"
+
+
+def test_keys_request_accepts_normalized_allowed_host(test_app, db, tmp_path):
+    _, alias = _seed_file_alias(db, tmp_path, suffix="-host-allowed")
+    _seed_policy(
+        db,
+        name="networking-host-allowed",
+        approval_required=False,
+        raw_reveal_allowed=True,
+        allowed_modes=["read"],
+        allowed_hosts=["norman.lollie.org"],
+    )
+
+    response = test_app.post(
+        "/api/v1/keys/requests",
+        json={
+            "name": alias.name,
+            "requested_mode": "read",
+            "requester_type": "agent",
+            "requester_id": "norman-prime",
+            "lane": "shared_infra",
+            "target_host": "NORMAN.LOLLIE.ORG.",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["request"]["status"] == "issued"
+
+
+def test_keys_request_does_not_fall_back_from_host_bound_policy(test_app, db, tmp_path):
+    _, alias = _seed_file_alias(db, tmp_path, suffix="-host-precedence")
+    _seed_policy(
+        db,
+        name="networking-host-broad",
+        approval_required=False,
+        raw_reveal_allowed=True,
+        allowed_modes=["read"],
+    )
+    _seed_policy(
+        db,
+        name="networking-host-specific",
+        approval_required=False,
+        raw_reveal_allowed=True,
+        allowed_modes=["read"],
+        secret_prefix=alias.name,
+        allowed_hosts=["norman.lollie.org"],
+    )
+
+    response = test_app.post(
+        "/api/v1/keys/requests",
+        json={
+            "name": alias.name,
+            "requested_mode": "read",
+            "requester_type": "agent",
+            "requester_id": "norman-prime",
+            "lane": "shared_infra",
+            "target_host": "other.home.arpa",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "No secret policy matched request"
 
 
 def _seed_env_file_alias(db, tmp_path: Path, *, name: str = "norman/runtime-token"):


### PR DESCRIPTION
## Summary
- enforce `allowed_hosts` on the selected Norman Keys policy, with no fallback to a broader policy
- let managed configuration declare its approved host through `NORMAN_CONFIG_TARGET_HOST`
- document the host-bound broker configuration required by the isolated release canary

## Root Cause
`allowed_hosts` was stored on secret policies but was not evaluated when resolving broker requests. A host-bound runtime configuration policy could therefore not restrict retrieval to the intended host.

## Validation
- `make format`
- `make lint`
- `make test` (`1910 passed, 6 warnings`)
- focused Keys/configuration tests (`18 passed, 4 warnings`)