### PR TITLE
Fix fresh database migrations

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -13,7 +13,7 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/alembic/versions/6b0f56df66f1_add_tailnet_urls_to_estate_services.py
+++ b/alembic/versions/6b0f56df66f1_add_tailnet_urls_to_estate_services.py
@@ -19,6 +19,8 @@ depends_on = None
 def upgrade() -> None:
     bind = op.get_bind()
     inspector = inspect(bind)
+    if not inspector.has_table("estate_services"):
+        return
     columns = {column["name"] for column in inspector.get_columns("estate_services")}
     if "web_url_tailnet" not in columns:
         op.add_column(
@@ -34,6 +36,8 @@ def upgrade() -> None:
 def downgrade() -> None:
     bind = op.get_bind()
     inspector = inspect(bind)
+    if not inspector.has_table("estate_services"):
+        return
     columns = {column["name"] for column in inspector.get_columns("estate_services")}
     if "console_url_tailnet" in columns:
         op.drop_column("estate_services", "console_url_tailnet")

--- a/alembic/versions/e18f4b7c0d21_add_console_url_to_estate_services.py
+++ b/alembic/versions/e18f4b7c0d21_add_console_url_to_estate_services.py
@@ -19,6 +19,8 @@ depends_on = None
 def upgrade() -> None:
     bind = op.get_bind()
     inspector = inspect(bind)
+    if not inspector.has_table("estate_services"):
+        return
     columns = {column["name"] for column in inspector.get_columns("estate_services")}
     if "console_url" not in columns:
         op.add_column("estate_services", sa.Column("console_url", sa.String(), nullable=True))
@@ -27,6 +29,8 @@ def upgrade() -> None:
 def downgrade() -> None:
     bind = op.get_bind()
     inspector = inspect(bind)
+    if not inspector.has_table("estate_services"):
+        return
     columns = {column["name"] for column in inspector.get_columns("estate_services")}
     if "console_url" in columns:
         op.drop_column("estate_services", "console_url")

--- a/tests/test_alembic_fresh_database.py
+++ b/tests/test_alembic_fresh_database.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+from app.db.base import Base
+
+
+def test_upgrade_heads_and_create_metadata_on_fresh_sqlite_database(tmp_path):
+    database_path = tmp_path / "norman.db"
+    repository_root = Path(__file__).resolve().parents[1]
+    config = Config(str(repository_root / "alembic.ini"))
+    config.set_main_option("script_location", str(repository_root / "alembic"))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{database_path}")
+
+    command.upgrade(config, "heads")
+
+    engine = create_engine(f"sqlite:///{database_path}")
+    try:
+        Base.metadata.create_all(bind=engine)
+        inspector = inspect(engine)
+        assert "estate_services" in inspector.get_table_names()
+        columns = {
+            column["name"] for column in inspector.get_columns("estate_services")
+        }
+        assert {
+            "console_url",
+            "web_url_tailnet",
+            "console_url_tailnet",
+        } <= columns
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Summary
- make estate-services column migrations no-op when the table is not present
- preserve existing loggers when Alembic runs in-process
- add a fresh SQLite migration and metadata-startup regression test

## Root cause
A new release database has no `estate_services` table before application metadata creation, but historical Alembic revisions unconditionally inspected that table and aborted startup.

## Validation
- `make format`
- `make lint`
- `make test` (`1911 passed, 7 warnings`)