### PR TITLE
Target startup migrations at configured database

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,4 +1,5 @@
 from logging.config import fileConfig
+import os
 
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
@@ -10,6 +11,9 @@ from app.db.base import Base
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
+configured_database_url = os.environ.get("NORMAN_ALEMBIC_DATABASE_URL", "").strip()
+if configured_database_url:
+    config.set_main_option("sqlalchemy.url", configured_database_url)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/main.py
+++ b/main.py
@@ -49,12 +49,15 @@ def run_alembic_migrations():
         os.makedirs("alembic/versions", exist_ok=True)
     logger.info("Alembic: upgrade heads start")
     try:
+        migration_env = dict(os.environ)
+        migration_env["NORMAN_ALEMBIC_DATABASE_URL"] = settings.database_url
         # Run alembic in a subprocess to avoid abrupt exits in the main process.
         result = subprocess.run(
             [sys.executable, "-m", "alembic", "upgrade", "heads"],
             check=True,
             capture_output=True,
             text=True,
+            env=migration_env,
         )
         if result.stdout:
             logger.info("Alembic stdout: %s", result.stdout.strip())

--- a/tests/test_alembic_fresh_database.py
+++ b/tests/test_alembic_fresh_database.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import subprocess
 
 from alembic import command
 from alembic.config import Config
@@ -7,12 +8,14 @@ from sqlalchemy import create_engine, inspect
 from app.db.base import Base
 
 
-def test_upgrade_heads_and_create_metadata_on_fresh_sqlite_database(tmp_path):
+def test_upgrade_heads_and_create_metadata_on_fresh_sqlite_database(
+    tmp_path, monkeypatch
+):
     database_path = tmp_path / "norman.db"
     repository_root = Path(__file__).resolve().parents[1]
     config = Config(str(repository_root / "alembic.ini"))
     config.set_main_option("script_location", str(repository_root / "alembic"))
-    config.set_main_option("sqlalchemy.url", f"sqlite:///{database_path}")
+    monkeypatch.setenv("NORMAN_ALEMBIC_DATABASE_URL", f"sqlite:///{database_path}")
 
     command.upgrade(config, "heads")
 
@@ -31,3 +34,29 @@ def test_upgrade_heads_and_create_metadata_on_fresh_sqlite_database(tmp_path):
         } <= columns
     finally:
         engine.dispose()
+
+
+def test_startup_migrations_pass_configured_database_to_alembic(monkeypatch, tmp_path):
+    import main
+
+    database_url = f"sqlite:///{tmp_path / 'configured.db'}"
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args[0], 0, "", "")
+
+    monkeypatch.setattr(main.settings, "database_url", database_url)
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+
+    main.run_alembic_migrations()
+
+    assert captured["args"][0] == [
+        main.sys.executable,
+        "-m",
+        "alembic",
+        "upgrade",
+        "heads",
+    ]
+    assert captured["kwargs"]["env"]["NORMAN_ALEMBIC_DATABASE_URL"] == database_url


### PR DESCRIPTION
## What changed
- Pass the active Norman `settings.database_url` to the startup Alembic subprocess.
- Make `alembic/env.py` prefer that internal startup target over the checkout-local `alembic.ini` default.
- Cover the environment override and startup launcher wiring with fresh-SQLite regression tests.

## Why
The isolated release canary configured its application database outside the checkout, but startup migrations still used `alembic.ini`'s `./db/norman.db`. `Base.metadata.create_all()` could mask that mismatch. Migrations now run against the same database used by the service.

## Validation
- `make format`
- `make lint`
- `make test` (`1912 passed, 65 warnings`)

No frontend files changed; `npm test` was not applicable.