### PR TITLE
Trust local model CA for ping

### DIFF
--- a/app/services/model_ping.py
+++ b/app/services/model_ping.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import os
 import re
+import ssl
 import time
 from dataclasses import asdict, dataclass
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 import anyio
+import httpx
 import requests
 from openai import OpenAI
 
@@ -226,7 +228,22 @@ def _all_targets() -> list[ModelPingTarget]:
     return targets
 
 
-def _openai_client(target: ModelPingTarget) -> OpenAI:
+def _uses_system_tls_bundle(target: ModelPingTarget) -> bool:
+    if target.provider.lower() != "openai_compatible":
+        return False
+    try:
+        parsed = urlsplit(target.base_url)
+    except ValueError:
+        return False
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    return parsed.scheme.lower() == "https" and (
+        hostname == "home.arpa" or hostname.endswith(".home.arpa")
+    )
+
+
+def _openai_client(
+    target: ModelPingTarget, *, http_client: httpx.Client | None = None
+) -> OpenAI:
     api_key = _target_api_key(target)
     if not api_key and target.provider == "openai":
         api_key = _clean_str(getattr(settings, "openai_api_key", ""))
@@ -240,15 +257,29 @@ def _openai_client(target: ModelPingTarget) -> OpenAI:
     }
     if target.base_url:
         kwargs["base_url"] = target.base_url
+    if http_client is not None:
+        kwargs["http_client"] = http_client
     return OpenAI(**kwargs)
 
 
 def _ping_openai_chat(target: ModelPingTarget) -> str:
-    response = _openai_client(target).chat.completions.create(
-        model=target.model,
-        messages=[{"role": "user", "content": PING_PROMPT}],
-        max_tokens=target.max_tokens,
-    )
+    http_client = None
+    if _uses_system_tls_bundle(target):
+        http_client = httpx.Client(
+            verify=ssl.create_default_context(),
+            timeout=target.timeout_seconds,
+        )
+    try:
+        response = _openai_client(
+            target, http_client=http_client
+        ).chat.completions.create(
+            model=target.model,
+            messages=[{"role": "user", "content": PING_PROMPT}],
+            max_tokens=target.max_tokens,
+        )
+    finally:
+        if http_client is not None:
+            http_client.close()
     choices = getattr(response, "choices", None) or []
     if not choices:
         return ""

--- a/tests/test_model_ping.py
+++ b/tests/test_model_ping.py
@@ -1,4 +1,6 @@
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -155,3 +157,48 @@ def test_ping_model_targets_reports_missing_target(monkeypatch):
 
     with pytest.raises(KeyError):
         asyncio.run(model_ping.ping_model_targets(target_id="missing"))
+
+
+def test_ping_openai_compatible_home_arpa_uses_system_tls_bundle(monkeypatch):
+    target = model_ping.ModelPingTarget(
+        id="local-qwen",
+        name="Local Qwen",
+        provider="openai_compatible",
+        base_url="https://llm.home.arpa/v1",
+        model="qwen3:8b",
+        timeout_seconds=7.5,
+    )
+    system_context = object()
+    http_client = Mock()
+    client_factory = Mock(return_value=http_client)
+    openai_client = Mock(
+        return_value=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=Mock(
+                        return_value=SimpleNamespace(
+                            choices=[
+                                SimpleNamespace(
+                                    message=SimpleNamespace(
+                                        content=model_ping.EXPECTED_PING_TEXT
+                                    )
+                                )
+                            ]
+                        )
+                    )
+                )
+            )
+        )
+    )
+    monkeypatch.setattr(
+        model_ping.ssl, "create_default_context", lambda: system_context
+    )
+    monkeypatch.setattr(model_ping.httpx, "Client", client_factory)
+    monkeypatch.setattr(model_ping, "_openai_client", openai_client)
+
+    response = model_ping._ping_openai_chat(target)
+
+    assert response == model_ping.EXPECTED_PING_TEXT
+    client_factory.assert_called_once_with(verify=system_context, timeout=7.5)
+    openai_client.assert_called_once_with(target, http_client=http_client)
+    http_client.close.assert_called_once_with()


### PR DESCRIPTION
## Summary
- Route HTTPS OpenAI-compatible `.home.arpa` model pings through an `httpx` client using the system CA bundle.
- Keep certificate verification enabled and close the scoped client after the request.
- Add a regression test for the local TLS path.

## Root Cause
OpenAI's default `certifi` bundle did not include the internal Lollie CA even though it is trusted by the operating system, causing the local model ping to fail TLS verification.

## Validation
- `make format`
- `make lint`
- `make test` (`1913 passed, 65 warnings`)