### PR TITLE
Preserve console job policy at run time

### DIFF
--- a/app/api/api_v1/routers/console_runtime.py
+++ b/app/api/api_v1/routers/console_runtime.py
@@ -877,7 +877,7 @@ async def run_console_runtime_job_once(
             planner_kind=payload.planner_kind,
             model=payload.model,
             max_output_tokens=payload.max_output_tokens,
-            route_policy=with_local_first_catalog_defaults(payload.route_policy),
+            route_policy=dict(payload.route_policy),
             metadata=payload.metadata,
             include_capabilities=payload.include_capabilities,
             live_execution_approved=payload.live_execution_approved,

--- a/tests/test_console_runtime_api.py
+++ b/tests/test_console_runtime_api.py
@@ -587,6 +587,43 @@ def test_console_runtime_api_runs_one_dry_run_worker_step(test_app):
     assert payload["snapshot"]["category_counts"]["tool"] == 2
 
 
+def test_console_runtime_api_preserves_explicit_cloud_policy_for_denial(test_app):
+    job_id = "job-api-cloud-policy-denied"
+    created = test_app.post(
+        "/api/v1/console-runtime/jobs",
+        json={
+            "job_id": job_id,
+            "objective": "Verify cloud policy denial before model invocation",
+            "route_policy": {
+                "provider": "bedrock",
+                "model": "anthropic.claude-test",
+                "allow_cloud_proxy": True,
+                "cloud_llm_disabled": True,
+            },
+        },
+    )
+    assert created.status_code == 200
+
+    response = test_app.post(
+        f"/api/v1/console-runtime/jobs/{job_id}/runs",
+        json={
+            "worker_id": "api-cloud-policy-test",
+            "dry_run": True,
+            "include_capabilities": False,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["route_blocked"] is True
+    assert payload["model_result"] is None
+    assert payload["job"]["status"] == "blocked"
+    assert "cloud LLM provider blocked by policy" in payload["blocked_reason"]
+    event_types = {event["event_type"] for event in payload["snapshot"]["events"]}
+    assert "policy.egress_blocked" in event_types
+    assert "model.requested" not in event_types
+
+
 @pytest.mark.asyncio
 async def test_console_runtime_api_run_endpoint_offloads_worker_to_thread(monkeypatch):
     from app.api.api_v1.routers import console_runtime


### PR DESCRIPTION
## What changed

Preserve an existing console-runtime job's `route_policy` when a worker run payload does not provide policy overrides.

## Why

The run endpoint was applying local-first defaults to an empty override payload. That replaced an explicit Bedrock job policy with local Norllama defaults, so cloud-policy denials were silently routed locally instead of being recorded as blocked before model invocation.

## Impact

Explicit provider and cloud policy in the job contract now reaches the worker intact. The worker remains responsible for its single policy normalization pass.

## Validation

- `make format`
- `make lint`
- `pytest tests/test_console_runtime_api.py -q` (`21 passed`)
- `make test` (`1914 passed, 65 warnings`)