### PR TITLE
Document production credential wrapper

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,6 +105,52 @@ sudo systemctl stop norman-release@<release-sha>
 The release checkout must contain `.venv-3.10` and the managed configuration
 environment before starting this unit.
 
+### Production Credential Wrapper
+
+Use `scripts/systemd/norman-production@.service` and
+`scripts/systemd/norman-production-launch` for a SHA-pinned production release.
+Install the launcher at `/usr/local/libexec/norman-production-launch` with mode
+`0755`, and install the unit at
+`/etc/systemd/system/norman-production@.service`. The unit is deliberately
+separate from the loopback canary and from the legacy `norman.service`.
+
+The unit reads only non-secret identities from
+`/etc/norman/runtime-identities.env`. Store the following logical aliases in
+the approved Norman Keys resolver or the encrypted `cred` migration vault:
+
+```text
+norman/prompt-proxy-token
+norman/console-runtime-service-token
+norman/keys-service-token
+```
+
+The unit loads a systemd encrypted credential containing the vault passphrase
+and the launcher resolves the aliases only into the child process. Do not add
+the token values to an environment file, a unit drop-in, a release checkout,
+or shell history. The machine-local `cred` bridge is a migration fallback;
+move these aliases to a networked Norman Keys backend with short-lived leases
+when that backend is available.
+
+For each production deployment, confirm the unit resolves to the expected
+release and that the front door and local model lane remain healthy:
+
+```bash
+systemctl is-active norman-production@<release-sha>
+curl -fsS http://127.0.0.1:8000/health
+curl -fsS https://norman.home.arpa/health
+curl -fsS https://llm.home.arpa/v1/models
+```
+
+To roll back a bad production release, stop and disable the SHA-specific unit,
+then re-enable and start the prior known-good unit. Keep the legacy service
+disabled unless it is the intentionally selected rollback target:
+
+```bash
+sudo systemctl stop norman-production@<bad-sha>
+sudo systemctl disable norman-production@<bad-sha>
+sudo systemctl enable --now norman-production@<known-good-sha>
+```
+
 ## Running the Application
 
 1. Start the Norman application:

--- a/docs/releases/2026-07-16-kernel-bedrock-capacity-staging.md
+++ b/docs/releases/2026-07-16-kernel-bedrock-capacity-staging.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-16
 Scope: Norman Kernel native Bedrock adapter, local-first routing, and Codex plan-capacity monitoring
-Status: console fleet deployed; backend rollout staged pending a brokered-configuration canary
+Status: production deployed with brokered configuration and local-first routing
 
 ## Released Console Surface
 
@@ -42,20 +42,27 @@ current dirty checkout to the Norman backend host.
 
 ## Managed Release Configuration
 
-The clean release candidate must receive its settings through a brokered
+The clean production release receives its settings through a brokered
 `NORMAN_CONFIG_SECRET` and an approved command or HTTP resolver. On this path
 Norman reads the YAML mapping in memory, does not create a release-local
 `config.yaml`, and fails closed if `admin_setup_key` is missing.
 
-`scripts/systemd/norman-release@.service` runs the release candidate only on
+`scripts/systemd/norman-release@.service` runs an isolated candidate only on
 `127.0.0.1:18000` and requires both the logical config secret name and a
 configured resolver before it starts. It is separate from the active
-`norman.service`; use it for the clean loopback canary first.
+`norman-production@<release-sha>.service`; use it for the clean loopback canary
+first.
 
-The live host does not currently expose a confirmed brokered configuration
-alias for this purpose. Leave `norman.service` on its existing healthy checkout
-until that alias and resolver are provisioned. Do not copy its repo-local
-config into the clean release checkout.
+The deployed production unit is SHA-pinned and resolves the runtime
+configuration from `norman/runtime-config`. It uses the encrypted `cred` vault
+only as a migration bridge. The release has no repo-local configuration or
+plaintext prompt-proxy token. Do not copy a legacy checkout configuration into
+a release checkout.
+
+The remaining runtime service tokens are resolved through the same encrypted
+credential path by `scripts/systemd/norman-production-launch`; their only
+plaintext host file contains non-secret service identities. A networked Norman
+Keys backend with short-lived leases remains the follow-up hardening target.
 
 ## Backend Rollout Gate
 
@@ -96,14 +103,17 @@ NORMAN_SECRET_CMD=<broker command with {name}>
 Use a logical secret such as `networking/bedrock`; do not create a repo-local
 plaintext credential file.
 
-## Restart And Smoke
+## Production Smoke
 
-Restart only the backend service after the dependency and source checks succeed:
+The production host runs `norman-production@57685d38.service`; the legacy
+`norman.service` is disabled. The active service, Caddy front door, and
+Norllama model metadata were verified:
 
 ```bash
-sudo systemctl restart norman.service
-sudo systemctl is-active norman.service
+sudo systemctl is-active norman-production@57685d38.service
 curl -fsS http://127.0.0.1:8000/health
+curl -fsS https://norman.home.arpa/health
+curl -fsS https://llm.home.arpa/v1/models
 ```
 
 Then run the authenticated Console Runtime dry-run and route-policy rejection smokes.
@@ -124,12 +134,14 @@ and require an explicit cloud policy for every Bedrock turn.
 
 ## Rollback
 
-Rollback is source-revision based:
+Rollback is unit and source-revision based:
 
-1. Return the host to the prior known-good release commit.
-2. Reinstall that revision's dependency set.
-3. Restart `norman.service` and verify `/health`.
-4. Set `allow_cloud_proxy=false` in the active route policy or disable the runtime
+1. Stop and disable the failing SHA-specific production unit.
+2. Enable and start the prior known-good SHA-specific production unit.
+3. Verify the direct and Caddy `/health` endpoints.
+4. Use legacy `norman.service` only if its credential wrapper is the intentionally
+   selected rollback target.
+5. Set `allow_cloud_proxy=false` in the active route policy or disable the runtime
    worker until the issue is diagnosed.
 
 The console fleet can remain on `2026.07.16.07`; its capacity monitor fails closed

--- a/scripts/systemd/norman-production-launch
+++ b/scripts/systemd/norman-production-launch
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+: "${CREDENTIALS_DIRECTORY:?systemd credentials directory is required}"
+
+credential() {
+  /usr/local/bin/cred \
+    --passphrase-file "$CREDENTIALS_DIRECTORY/norman-cred-passphrase" \
+    get "$1"
+}
+
+export NORMAN_PROMPT_PROXY_TOKEN="$(credential norman/prompt-proxy-token)"
+export CONSOLE_RUNTIME_SERVICE_TOKEN="$(credential norman/console-runtime-service-token)"
+export NORMAN_KEYS_SERVICE_TOKEN="$(credential norman/keys-service-token)"
+
+exec "$@"

--- a/scripts/systemd/norman-production@.service
+++ b/scripts/systemd/norman-production@.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Norman production release %i
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=kristopher
+Group=kristopher
+WorkingDirectory=/home/kristopher/releases/norman-%i
+EnvironmentFile=-/etc/norman/runtime-identities.env
+EnvironmentFile=-/etc/norman/release.env
+Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONDONTWRITEBYTECODE=1
+Environment=NORMAN_CONFIG_REQUESTER_ID=norman-production
+LoadCredentialEncrypted=norman-cred-passphrase:/etc/norman/credentials/norman-cred-passphrase.cred
+ExecStartPre=/bin/sh -c 'test -n "$NORMAN_CONFIG_SECRET"'
+ExecStartPre=/bin/sh -c 'test -n "$NORMAN_CONFIG_SECRET_CMD" || test -n "$NORMAN_SECRET_CMD" || test -n "$NORMAN_KEYS_URL" || test -n "$NORMAN_KEYS_API_BASE"'
+ExecStart=/usr/local/libexec/norman-production-launch /home/kristopher/releases/norman-%i/.venv-3.10/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000 --limit-concurrency 192 --backlog 256 --timeout-keep-alive 5
+Restart=always
+RestartSec=5
+LimitNOFILE=65536
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add repository-owned SHA-pinned production systemd unit and encrypted credential launcher
- document the `cred` migration aliases, health checks, and unit rollback
- update the July 16 release handoff to reflect the deployed local-first release

## Validation
- `sh -n scripts/systemd/norman-production-launch`
- `make format`
- `make lint`
- `make test` (`1914 passed, 65 warnings`)

The launcher resolves logical aliases only into the service child process; no token values are committed or added to plaintext environment files.