### PR TITLE
Keep rollback service on brokered runtime tokens

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -131,6 +131,10 @@ or shell history. The machine-local `cred` bridge is a migration fallback;
 move these aliases to a networked Norman Keys backend with short-lived leases
 when that backend is available.
 
+The legacy `norman.service` rollback path must use the same identity file.
+Install `scripts/systemd/norman.service.d/10-runtime-env.conf` before removing
+the legacy plaintext token file.
+
 For each production deployment, confirm the unit resolves to the expected
 release and that the front door and local model lane remain healthy:
 

--- a/docs/releases/2026-07-16-kernel-bedrock-capacity-staging.md
+++ b/docs/releases/2026-07-16-kernel-bedrock-capacity-staging.md
@@ -63,6 +63,8 @@ The remaining runtime service tokens are resolved through the same encrypted
 credential path by `scripts/systemd/norman-production-launch`; their only
 plaintext host file contains non-secret service identities. A networked Norman
 Keys backend with short-lived leases remains the follow-up hardening target.
+The disabled legacy rollback unit has the same identity-file compatibility
+drop-in and credential launcher.
 
 ## Backend Rollout Gate
 

--- a/scripts/systemd/norman.service.d/10-runtime-env.conf
+++ b/scripts/systemd/norman.service.d/10-runtime-env.conf
@@ -1,0 +1,3 @@
+[Service]
+EnvironmentFile=
+EnvironmentFile=-/etc/norman/runtime-identities.env


### PR DESCRIPTION
## Summary
- make the disabled legacy rollback service source the non-secret runtime identity file
- preserve rollback compatibility after runtime tokens are moved into encrypted `cred` aliases
- document the required compatibility drop-in

## Validation
- `make format`
- `make lint`
- `sh -n scripts/systemd/norman-production-launch`
- `make test` (`1914 passed, 7 warnings`)