### PR TITLE
Remove legacy runtime token settings

### DIFF
--- a/scripts/sync_agent_console_template.py
+++ b/scripts/sync_agent_console_template.py
@@ -508,6 +508,10 @@ RUNTIME_BRIDGE_ENV_KEYS: tuple[str, ...] = (
     "NORMAN_CONSOLE_RUNTIME_TOKEN_SECRET",
     "NORMAN_CONSOLE_RUNTIME_SECRET_NAME",
 )
+RUNTIME_BRIDGE_LEGACY_TOKEN_KEYS: tuple[str, ...] = (
+    "NORMAN_CONSOLE_RUNTIME_TOKEN",
+    "NORMAN_API_TOKEN",
+)
 
 INSTANCE_LABEL_OVERRIDES = {
     "autocamera": "Autocamera",
@@ -2152,6 +2156,7 @@ def sync_instance_runtime_bridge_settings(
     if not bridge_settings:
         return False
     payload = json.dumps(bridge_settings, separators=(",", ":"))
+    remove_payload = json.dumps(RUNTIME_BRIDGE_LEGACY_TOKEN_KEYS, separators=(",", ":"))
     script = f"""
 python3 - <<'PY'
 from pathlib import Path
@@ -2160,8 +2165,15 @@ import re
 
 path = Path({instance.env_file!r})
 updates = json.loads({payload!r})
+remove_keys = json.loads({remove_payload!r})
 text = path.read_text(encoding="utf-8")
 changed = False
+for key in remove_keys:
+    pattern = re.compile(rf"^{{re.escape(key)}}=.*\\n?", re.M)
+    updated = pattern.sub("", text)
+    if updated != text:
+        text = updated
+        changed = True
 for key, value in updates.items():
     line = f"{{key}}={{value}}"
     pattern = re.compile(rf"^{{re.escape(key)}}=.*$", re.M)

--- a/tests/test_agent_console_template_masking.py
+++ b/tests/test_agent_console_template_masking.py
@@ -4840,6 +4840,10 @@ def test_runtime_bridge_sync_writes_broker_env_without_direct_token(
     rendered_command = " ".join(captured[0])
     assert "NORMAN_KEYS_TOKEN" in rendered_command
     assert "NORMAN_CONSOLE_RUNTIME_TOKEN_SECRET" in rendered_command
+    assert "remove_keys = json.loads" in rendered_command
+    assert "for key in remove_keys" in rendered_command
+    for key in module.RUNTIME_BRIDGE_LEGACY_TOKEN_KEYS:
+        assert key in rendered_command
     assert '"NORMAN_CONSOLE_RUNTIME_TOKEN":' not in rendered_command
     assert '"NORMAN_API_TOKEN":' not in rendered_command
 


### PR DESCRIPTION
## Summary
- Remove stale direct runtime-token assignments whenever brokered runtime settings are synced.
- Cover the cleanup loop with the existing runtime-bridge sync regression test.

## Root Cause
Existing console environment files retained legacy direct-token assignments. The console preferred that stale value over the Norman Keys alias, producing runtime-client 401s after the broker migration.

## Impact
Future fleet syncs converge consoles on the brokered `norman/console-runtime-token` path and remove the obsolete overrides without logging their values.

## Validation
- `make format`
- `make lint`
- `make test` (`1914 passed`)
- Toy Box `housebot-codex-web.service` web-only restart and authenticated local `/api/status` health check