### PR TITLE
Skip unhealthy Norllama sidecars

### DIFF
--- a/scripts/norllama/deploy_gateway.sh
+++ b/scripts/norllama/deploy_gateway.sh
@@ -14,6 +14,7 @@ spark_service="${NORLLAMA_SPARK_SERVICE:-norllama-gateway.service}"
 
 deploy_mac=1
 deploy_sparks=0
+spark_restart_failed=0
 
 usage() {
   cat <<'EOF'
@@ -71,9 +72,19 @@ if [[ "$deploy_sparks" == "1" ]]; then
   for target in $spark_targets; do
     echo "Deploying Spark peer: ${target}:${spark_path}"
     scp -q "$source_path" "${target}:${spark_path}"
-    ssh "$target" \
-      "python3 -m py_compile '$spark_path' && sudo -n systemctl restart '$spark_service' && sleep 2 && curl -fsS --max-time 5 http://127.0.0.1:18151/healthz >/dev/null"
+    ssh "$target" "python3 -m py_compile '$spark_path'"
+    if ! ssh "$target" \
+      "sudo -n systemctl restart '$spark_service' && sleep 2 && curl -fsS --max-time 5 http://127.0.0.1:18151/healthz >/dev/null"; then
+      echo \
+        "Gateway source copied to ${target}, but ${spark_service} requires an operator-approved sudo restart." \
+        >&2
+      spark_restart_failed=1
+    fi
   done
+fi
+
+if [[ "$spark_restart_failed" == "1" ]]; then
+  exit 1
 fi
 
 echo "Norllama gateway deploy complete."

--- a/scripts/norllama/norllama_gateway.py
+++ b/scripts/norllama/norllama_gateway.py
@@ -5696,12 +5696,13 @@ class Handler(BaseHTTPRequestHandler):
 
     def native_rerank_candidates(self) -> tuple[list[str], list[dict], set[str]]:
         health_bases, health_rows = self.app.rerank_candidate_bases()
-        configured_local = [
-            normalize_base_url(base)
-            for base in self.app.rerank_bases
-            if normalize_base_url(base)
-        ]
-        ordered_local = unique_items([*health_bases, *configured_local])
+        ordered_local = unique_items(
+            [
+                normalize_base_url(base)
+                for base in health_bases
+                if normalize_base_url(base)
+            ]
+        )
         static_peer_bases: list[str] = []
         if int(getattr(self, "_peer_hop", 0)) < self.app.max_peer_hops:
             static_peer_bases = [
@@ -5750,12 +5751,13 @@ class Handler(BaseHTTPRequestHandler):
 
     def safety_candidates(self) -> tuple[list[str], list[dict], set[str]]:
         health_bases, health_rows = self.app.safety_candidate_bases()
-        configured_local = [
-            normalize_base_url(base)
-            for base in self.app.safety_bases
-            if normalize_base_url(base)
-        ]
-        ordered_local = unique_items([*health_bases, *configured_local])
+        ordered_local = unique_items(
+            [
+                normalize_base_url(base)
+                for base in health_bases
+                if normalize_base_url(base)
+            ]
+        )
         static_peer_bases: list[str] = []
         if int(getattr(self, "_peer_hop", 0)) < self.app.max_peer_hops:
             static_peer_bases = [

--- a/tests/test_norllama_gateway_activity.py
+++ b/tests/test_norllama_gateway_activity.py
@@ -264,6 +264,92 @@ def test_gateway_load_pressure_guard_does_not_probe_noninteractive_models():
     assert handler._activity_extra == {}
 
 
+@pytest.mark.parametrize(
+    ("candidate_method", "base_attribute"),
+    [
+        ("native_rerank_candidates", "rerank"),
+        ("safety_candidates", "safety"),
+    ],
+)
+def test_gateway_specialist_candidates_skip_unhealthy_local_sidecars(
+    candidate_method, base_attribute
+):
+    module = load_gateway_module()
+    app = module.App()
+    local_base = "http://127.0.0.1:8102"
+    peer_base = "http://192.168.2.150:18151"
+    setattr(app, f"{base_attribute}_bases", [local_base])
+    setattr(app, "peer_bases", [peer_base])
+    setattr(
+        app,
+        f"{base_attribute}_candidate_bases",
+        lambda: (
+            [],
+            [
+                {
+                    "base_url": local_base,
+                    "status": "error",
+                    "error": "connection refused",
+                }
+            ],
+        ),
+    )
+    handler = object.__new__(module.Handler)
+    handler.server = type("Server", (), {"app": app})()
+    handler._peer_hop = 0
+
+    candidates, rows, peer_bases = getattr(handler, candidate_method)()
+
+    assert candidates == [peer_base]
+    assert peer_bases == {peer_base}
+    assert rows[0]["base_url"] == local_base
+    assert rows[0]["status"] == "error"
+    assert rows[1] == {
+        "base_url": peer_base,
+        "status": "configured_peer",
+        "source": "peer_bases",
+    }
+
+
+@pytest.mark.parametrize(
+    ("candidate_method", "base_attribute"),
+    [
+        ("native_rerank_candidates", "rerank"),
+        ("safety_candidates", "safety"),
+    ],
+)
+def test_gateway_specialist_candidates_prefer_healthy_local_sidecars(
+    candidate_method, base_attribute
+):
+    module = load_gateway_module()
+    app = module.App()
+    local_base = "http://127.0.0.1:8102"
+    peer_base = "http://192.168.2.150:18151"
+    setattr(app, f"{base_attribute}_bases", [local_base])
+    setattr(app, "peer_bases", [peer_base])
+    setattr(
+        app,
+        f"{base_attribute}_candidate_bases",
+        lambda: ([local_base], [{"base_url": local_base, "status": "ok"}]),
+    )
+    handler = object.__new__(module.Handler)
+    handler.server = type("Server", (), {"app": app})()
+    handler._peer_hop = 0
+
+    candidates, rows, peer_bases = getattr(handler, candidate_method)()
+
+    assert candidates == [local_base, peer_base]
+    assert peer_bases == {peer_base}
+    assert rows == [
+        {"base_url": local_base, "status": "ok"},
+        {
+            "base_url": peer_base,
+            "status": "configured_peer",
+            "source": "peer_bases",
+        },
+    ]
+
+
 def test_gateway_evict_target_bases_are_limited_to_known_workers():
     module = load_gateway_module()
 


### PR DESCRIPTION
## Summary

Skip unhealthy configured local rerank and safety sidecars before selecting Norllama peers. Healthy local sidecars remain the first choice.

The gateway deploy helper now stages the source on every Spark peer even when its systemd restart requires operator sudo, reports that state explicitly, and exits nonzero rather than claiming a complete rollout.

## Root cause

The gateway health-checked local specialist sidecars, then re-added failed configured addresses ahead of peer candidates. On the live front door this caused every rerank and safety request to attempt a refused localhost connection before reaching `spark-150`.

## Impact

Local-first rerank and safety work continue to use Norllama with no cloud proxy, but avoid the guaranteed failed hop when a local sidecar is unavailable. Operators also get an accurate partial-deployment result when a peer restart is not authorized.

## Validation

- `make format`
- `make lint`
- `bash -n scripts/norllama/deploy_gateway.sh`
- Actual `scripts/norllama/deploy_gateway.sh --sparks` exercise: both peers copied and compiled; both privileged restarts explicitly reported as blocked
- `./.venv/bin/pytest -q tests/test_norllama_gateway_activity.py tests/test_norllama_capability_execution_runner.py` (`46 passed`)
- `make test` (`1918 passed`, 7 warnings)
- Live safety, rerank, and OCR smoke through `https://llm.home.arpa` (`3/3` passed)
- Post-deploy rerank and safety probes: one attempt each to `spark-150`, `offline_local`, `cloud_proxy=false`
