### PR TITLE
Harden local-first capacity routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PYTEST_ARGS ?= -vv --ignore=tmp/pro_agent_norman_harness_pack
 TUI_BENCHMARK_DIR ?= /tmp/norman_tui_benchmarks
 TUI_BENCHMARK_SAMPLE ?= db/tui_context_shadow_benchmark_sample.json
 TUI_STATE_DB ?= $(HOME)/.codex-work/web-bridge/tui_state.sqlite3
+TUI_VLLM_SENSE_ENDPOINT ?= https://llm.home.arpa
 HISTORIC_SESSION_REPORT ?= $(TUI_BENCHMARK_DIR)/work_session_runbook_miner.json
 HISTORIC_SHADOW_PLANNER_HOLDOUT_AFTER ?= 2026-06-14
 ROUTE_RECEIPT_HARVEST_OWNERS ?=
@@ -33,7 +34,8 @@ tui-benchmarks:
 	./.venv/bin/python scripts/tui_capability_inventory.py --output-json $(TUI_BENCHMARK_DIR)/capability_inventory.json --output-md $(TUI_BENCHMARK_DIR)/capability_inventory.md
 	./.venv/bin/python scripts/tui_microtexture_audit.py --output-json $(TUI_BENCHMARK_DIR)/microtexture_audit.json --output-md $(TUI_BENCHMARK_DIR)/microtexture_audit.md
 	./.venv/bin/python scripts/work_domain_skill_benchmark.py --output-json $(TUI_BENCHMARK_DIR)/work_domain_skill_matrix.json --output-md $(TUI_BENCHMARK_DIR)/work_domain_skill_matrix.md
-	./.venv/bin/python scripts/local_runtime_health.py --output-json $(TUI_BENCHMARK_DIR)/local_runtime_health.json --output-md $(TUI_BENCHMARK_DIR)/local_runtime_health.md
+	./.venv/bin/python scripts/tui_vllm_sense.py --endpoint $(TUI_VLLM_SENSE_ENDPOINT) --no-autosense-lan --output $(TUI_BENCHMARK_DIR)/vllm_sense_live.json --markdown $(TUI_BENCHMARK_DIR)/vllm_sense_live.md
+	./.venv/bin/python scripts/local_runtime_health.py --vllm-sense-json $(TUI_BENCHMARK_DIR)/vllm_sense_live.json --output-json $(TUI_BENCHMARK_DIR)/local_runtime_health.json --output-md $(TUI_BENCHMARK_DIR)/local_runtime_health.md
 	./.venv/bin/python scripts/local_model_skill_floor.py --skill-matrix-json $(TUI_BENCHMARK_DIR)/work_domain_skill_matrix.json --ollama-sense-json $(TUI_BENCHMARK_DIR)/ollama_sense_live.json --vllm-sense-json $(TUI_BENCHMARK_DIR)/vllm_sense_live.json --output-json $(TUI_BENCHMARK_DIR)/local_model_skill_floors.json --output-md $(TUI_BENCHMARK_DIR)/local_model_skill_floors.md
 	./.venv/bin/python scripts/local_model_route_policy.py --skill-floors-json $(TUI_BENCHMARK_DIR)/local_model_skill_floors.json --skill-matrix-json $(TUI_BENCHMARK_DIR)/work_domain_skill_matrix.json --runtime-health-json $(TUI_BENCHMARK_DIR)/local_runtime_health.json --output-json $(TUI_BENCHMARK_DIR)/local_model_route_policy.json --output-md $(TUI_BENCHMARK_DIR)/local_model_route_policy.md
 	./.venv/bin/python scripts/planner_preroute_policy.py --route-policy-json $(TUI_BENCHMARK_DIR)/local_model_route_policy.json --output-json $(TUI_BENCHMARK_DIR)/planner_preroute_policy.json --output-md $(TUI_BENCHMARK_DIR)/planner_preroute_policy.md

--- a/docs/releases/2026-07-16-kernel-bedrock-capacity-staging.md
+++ b/docs/releases/2026-07-16-kernel-bedrock-capacity-staging.md
@@ -6,22 +6,26 @@ Status: production deployed with brokered configuration and local-first routing
 
 ## Released Console Surface
 
-The shared console fleet is on `UI v2026.07.16.07`. The fleet doctor reported 15
-active consoles with no failures or warnings after the web-console rollout.
+The shared console fleet is on `UI v2026.07.16.14`. The web-console rollout
+covers the reachable fleet.
 
 The console now:
 
-- polls the Codex `/usage` surface only while its ChatGPT-authenticated terminal is idle;
+- polls the Codex `/status` surface only while its ChatGPT-authenticated terminal is idle;
+- never sends `/usage` automatically, because it can consume a usage-limit reset;
 - retains aggregate capacity, reset, and forecast data without retaining terminal contents;
 - keeps ChatGPT plan, API, and Bedrock usage in separate ledgers;
 - prefers direct Codex Flex over the default Bedrock lane only for fresh personal
-  ChatGPT capacity above the configured reserve;
+  ChatGPT capacity above the configured reserve when the entire requested turn
+  fits the reset-aware forecast;
 - rechecks ChatGPT auth before making that automatic route choice and removes an
-  inherited `OPENAI_API_KEY` from ChatGPT-authenticated direct child processes.
+  inherited `OPENAI_API_KEY` from plan-authenticated or Bedrock child processes
+  whenever OpenAI API spending is disabled;
+- blocks OpenAI API spending and paid ChatGPT credit extensions by default, falling
+  back to Bedrock when the plan capacity cannot be verified.
 
 No capacity probe runs while a prompt, worker, or unfinished terminal draft is active.
-An unsupported `/usage` command is recorded as unavailable and retried only after a
-long backoff.
+An unsafe configured capacity command is recorded as unavailable and never sent.
 
 ## Backend Candidate
 

--- a/scripts/agent_console_template/agent_console_launch.sh
+++ b/scripts/agent_console_template/agent_console_launch.sh
@@ -135,8 +135,8 @@ if [[ -z "$CODEX_PROFILE_FLAG" ]]; then
     CODEX_PROFILE_HELP="$("$CODEX_BIN" --help 2>&1 || true)"
     HAS_PROFILE=0
     HAS_PROFILE_V2=0
-    grep -q -- "--profile" <<<"$CODEX_PROFILE_HELP" && HAS_PROFILE=1
-    grep -q -- "--profile-v2" <<<"$CODEX_PROFILE_HELP" && HAS_PROFILE_V2=1
+    grep -Eq -- '(^|[[:space:],])--profile($|[[:space:],])' <<<"$CODEX_PROFILE_HELP" && HAS_PROFILE=1
+    grep -Eq -- '(^|[[:space:],])--profile-v2($|[[:space:],])' <<<"$CODEX_PROFILE_HELP" && HAS_PROFILE_V2=1
     if [[ "$HAS_PROFILE" == "1" && "$HAS_PROFILE_V2" == "1" ]]; then
         CODEX_VERSION="$("$CODEX_BIN" --version 2>/dev/null | awk '{print $2; exit}')"
         IFS=. read -r CODEX_VERSION_MAJOR CODEX_VERSION_MINOR _ <<<"$CODEX_VERSION"

--- a/scripts/agent_console_template/agent_console_web.py
+++ b/scripts/agent_console_template/agent_console_web.py
@@ -72,7 +72,7 @@ AUTH_COOKIE_NAME = (
 AUTH_COOKIE_MAX_AGE = int(
     os.environ.get("NORMAN_CODEX_WEB_COOKIE_MAX_AGE", str(14 * 24 * 60 * 60))
 )
-DEFAULT_UI_VERSION = "2026.07.16.07"
+DEFAULT_UI_VERSION = "2026.07.16.14"
 UI_VERSION = (
     os.environ.get("NORMAN_CODEX_UI_VERSION", DEFAULT_UI_VERSION).strip()
     or DEFAULT_UI_VERSION
@@ -599,6 +599,37 @@ LOCAL_LLM_QUICK_MAX_OUTPUT_TOKENS = _early_env_int(
 LOCAL_LLM_SHORT_MAX_OUTPUT_TOKENS = _early_env_int(
     "NORMAN_LOCAL_LLM_SHORT_MAX_OUTPUT_TOKENS", 800, minimum=128
 )
+TUI_TOKEN_CAPACITY_PLAN_ENABLED = _early_env_flag(
+    "NORMAN_TUI_TOKEN_CAPACITY_PLAN_ENABLED", True
+)
+TUI_TOKEN_CAPACITY_MIN_OUTPUT_TOKENS = _early_env_int(
+    "NORMAN_TUI_TOKEN_CAPACITY_MIN_OUTPUT_TOKENS", 256, minimum=32
+)
+TUI_TOKEN_CAPACITY_CLOUD_MAX_OUTPUT_TOKENS = _early_env_int(
+    "NORMAN_TUI_TOKEN_CAPACITY_CLOUD_MAX_OUTPUT_TOKENS", 8192, minimum=256
+)
+TUI_TOKEN_CAPACITY_TOTAL_BUDGET_FACTOR = _early_env_float(
+    "NORMAN_TUI_TOKEN_CAPACITY_TOTAL_BUDGET_FACTOR", 2.0, minimum=1.0
+)
+TUI_TOKEN_CAPACITY_WINDOW_FRACTION = min(
+    1.0,
+    _early_env_float("NORMAN_TUI_TOKEN_CAPACITY_WINDOW_FRACTION", 1.0, minimum=0.1),
+)
+TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS = _early_env_int(
+    "NORMAN_TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS", 60 * 60, minimum=60
+)
+TUI_NORLLAMA_OUTPUT_TOKENS_PER_HOUR = _early_env_int(
+    "NORMAN_TUI_NORLLAMA_OUTPUT_TOKENS_PER_HOUR", 48_000, minimum=1_000
+)
+TUI_BEDROCK_OUTPUT_TOKENS_PER_HOUR = _early_env_int(
+    "NORMAN_TUI_BEDROCK_OUTPUT_TOKENS_PER_HOUR", 72_000, minimum=1_000
+)
+TUI_CODEX_OUTPUT_TOKENS_PER_HOUR = _early_env_int(
+    "NORMAN_TUI_CODEX_OUTPUT_TOKENS_PER_HOUR", 60_000, minimum=1_000
+)
+TUI_OPENAI_OUTPUT_TOKENS_PER_HOUR = _early_env_int(
+    "NORMAN_TUI_OPENAI_OUTPUT_TOKENS_PER_HOUR", 60_000, minimum=1_000
+)
 LOCAL_LLM_NUM_CTX = _early_env_int("NORMAN_LOCAL_LLM_NUM_CTX", 8192, minimum=512)
 LOCAL_LLM_SHORT_NUM_CTX = _early_env_int(
     "NORMAN_LOCAL_LLM_SHORT_NUM_CTX", 4096, minimum=512
@@ -623,6 +654,19 @@ LOCAL_PLANNER_PREFLIGHT_PROMPT_CHARS = _early_env_int(
 LOCAL_PLANNER_PREFLIGHT_MAX_CANDIDATES = _early_env_int(
     "NORMAN_LOCAL_PLANNER_PREFLIGHT_MAX_CANDIDATES", 2, minimum=1
 )
+WORKING_RECAP_ENABLED = _early_env_flag("NORMAN_CODEX_WORKING_RECAP_ENABLED", True)
+WORKING_RECAP_REFRESH_SECONDS = _early_env_int(
+    "NORMAN_CODEX_WORKING_RECAP_REFRESH_SECONDS", 120, minimum=60
+)
+WORKING_RECAP_LLM_TIMEOUT_SECONDS = _early_env_int(
+    "NORMAN_CODEX_WORKING_RECAP_LLM_TIMEOUT_SECONDS", 20, minimum=5
+)
+WORKING_RECAP_LLM_MAX_OUTPUT_TOKENS = _early_env_int(
+    "NORMAN_CODEX_WORKING_RECAP_LLM_MAX_OUTPUT_TOKENS", 220, minimum=64
+)
+WORKING_RECAP_HISTORY_ITEMS = _early_env_int(
+    "NORMAN_CODEX_WORKING_RECAP_HISTORY_ITEMS", 6, minimum=2
+)
 LOCAL_ROUTE_INTENT_CLASSIFIER_ENABLED = _early_env_flag(
     "NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_ENABLED", True
 )
@@ -630,7 +674,7 @@ LOCAL_ROUTE_INTENT_CLASSIFIER_TIMEOUT_SECONDS = _early_env_int(
     "NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_TIMEOUT_SECONDS", 8, minimum=2
 )
 LOCAL_ROUTE_INTENT_CLASSIFIER_MAX_OUTPUT_TOKENS = _early_env_int(
-    "NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_MAX_OUTPUT_TOKENS", 96, minimum=32
+    "NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_MAX_OUTPUT_TOKENS", 192, minimum=32
 )
 LOCAL_ROUTE_INTENT_CLASSIFIER_PROMPT_CHARS = _early_env_int(
     "NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_PROMPT_CHARS", 700, minimum=160
@@ -1827,8 +1871,8 @@ def resolve_codex_profile_config_flag() -> str:
     except (OSError, subprocess.TimeoutExpired):
         return "--profile"
     help_text = f"{completed.stdout}\n{completed.stderr}"
-    has_profile = "--profile" in help_text
-    has_profile_v2 = "--profile-v2" in help_text
+    has_profile = bool(re.search(r"(?<![\w-])--profile(?![\w-])", help_text))
+    has_profile_v2 = bool(re.search(r"(?<![\w-])--profile-v2(?![\w-])", help_text))
     if has_profile and has_profile_v2:
         try:
             version = subprocess.run(
@@ -1950,12 +1994,24 @@ CODEX_ACCOUNT_CAPACITY_PROBE_POLL_SECONDS = min(
         ),
     ),
 )
+CODEX_ACCOUNT_CAPACITY_STATUS_SUBMIT_SETTLE_SECONDS = min(
+    3.0,
+    max(
+        0.1,
+        float(
+            os.environ.get(
+                "NORMAN_CODEX_ACCOUNT_CAPACITY_STATUS_SUBMIT_SETTLE_SECONDS",
+                "0.6",
+            )
+        ),
+    ),
+)
 CODEX_ACCOUNT_CAPACITY_HISTORY_ITEMS = max(
     20, int(os.environ.get("NORMAN_CODEX_ACCOUNT_CAPACITY_HISTORY_ITEMS", "2880"))
 )
 CODEX_ACCOUNT_CAPACITY_COMMAND = (
-    os.environ.get("NORMAN_CODEX_ACCOUNT_CAPACITY_COMMAND", "/usage").strip()
-    or "/usage"
+    os.environ.get("NORMAN_CODEX_ACCOUNT_CAPACITY_COMMAND", "/status").strip()
+    or "/status"
 )
 CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND = os.environ.get(
     "NORMAN_CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND", ""
@@ -1967,9 +2023,72 @@ CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT = min(
     100,
     max(
         1,
-        int(os.environ.get("NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT", "10")),
+        int(os.environ.get("NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT", "25")),
     ),
 )
+CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED = _early_env_flag(
+    "NORMAN_CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED"
+)
+CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS = _early_env_int(
+    "NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS", 300, minimum=60
+)
+CODEX_SUBSCRIPTION_ROUTE_FORECAST_CAP_FRACTION = min(
+    1.0,
+    _early_env_float(
+        "NORMAN_CODEX_SUBSCRIPTION_ROUTE_FORECAST_CAP_FRACTION",
+        0.5,
+        minimum=0.1,
+    ),
+)
+CODEX_ALLOW_OPENAI_API_SPEND = os.environ.get(
+    "NORMAN_CODEX_ALLOW_OPENAI_API_SPEND", "0"
+).strip().lower() in {"1", "true", "yes", "on"}
+CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED = os.environ.get(
+    "NORMAN_CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED", "0"
+).strip().lower() in {"1", "true", "yes", "on"}
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ENABLED = os.environ.get(
+    "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ENABLED", "0"
+).strip().lower() in {"1", "true", "yes", "on"}
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_PERCENT_LEFT = min(
+    100,
+    max(
+        CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT,
+        int(
+            os.environ.get(
+                "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_PERCENT_LEFT",
+                "70",
+            )
+        ),
+    ),
+)
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_RESET_SECONDS = max(
+    30,
+    int(
+        os.environ.get(
+            "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_RESET_SECONDS", "240"
+        )
+    ),
+)
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MAX_RESET_SECONDS = max(
+    CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_RESET_SECONDS,
+    int(
+        os.environ.get(
+            "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MAX_RESET_SECONDS", "1200"
+        )
+    ),
+)
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ESTIMATED_OUTPUT_TOKENS = _early_env_int(
+    "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ESTIMATED_OUTPUT_TOKENS",
+    1200,
+    minimum=128,
+)
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_STATE_PATH = Path(
+    os.environ.get(
+        "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_STATE_PATH",
+        str(STATE_DIR / "subscription_self_improvement.json"),
+    )
+)
+SUBSCRIPTION_SELF_IMPROVEMENT_MARKER = "[norman-subscription-capacity-review-v1]"
 CODEX_ACCOUNT_CAPACITY_PROBE_LOCK = threading.Lock()
 CODEX_ACCOUNT_CAPACITY_PROBE_THREAD: threading.Thread | None = None
 BEDROCK_HEALTH_SMOKE_PATH = Path(
@@ -2518,6 +2637,7 @@ CONSOLE_RUNTIME_SNAPSHOT_LOCK = threading.Lock()
 CONSOLE_RUNTIME_ROUTE_OUTCOME_LOCK = threading.Lock()
 CONSOLE_RUNTIME_CAPABILITIES_LOCK = threading.Lock()
 CONSOLE_RUNTIME_LOCAL_FIRST_PROOF_LOCK = threading.Lock()
+WORKING_RECAP_LOCK = threading.Lock()
 KPI_LOCK = threading.RLock()
 KPI_COLLECTOR_STARTED = False
 ACTIVE_PROMPT_THREAD: threading.Thread | None = None
@@ -2545,6 +2665,7 @@ CONSOLE_RUNTIME_LAST_ERROR = CONSOLE_RUNTIME_TOKEN_RESOLUTION_ERROR
 CONSOLE_RUNTIME_LAST_ERROR_AT = (
     time.time() if CONSOLE_RUNTIME_TOKEN_RESOLUTION_ERROR else 0.0
 )
+WORKING_RECAP_ACTIVE_TURNS: set[str] = set()
 
 
 def _console_runtime_startup_defer_until() -> float:
@@ -6229,7 +6350,30 @@ def local_llm_num_ctx_for_budget(job_budget: Any = "") -> int:
     return max(512, LOCAL_LLM_NUM_CTX)
 
 
-def local_llm_max_output_tokens_for_budget(job_budget: Any = "") -> int:
+def local_llm_max_output_tokens_for_budget(
+    job_budget: Any = "",
+    *,
+    prompt: str = "",
+    detail: int = 2,
+    attachments: list[dict[str, Any]] | None = None,
+    model: str = "",
+    service_tier: str = "",
+    capacity_plan: dict[str, Any] | None = None,
+) -> int:
+    if TUI_TOKEN_CAPACITY_PLAN_ENABLED:
+        plan = normalize_provider_token_budget_plan(
+            capacity_plan
+            or provider_token_budget_plan(
+                prompt=prompt,
+                runtime="localllm",
+                model=model,
+                service_tier=service_tier,
+                job_budget=job_budget,
+                detail=detail,
+                attachments=attachments or [],
+            )
+        )
+        return max(1, _coerce_int(plan.get("execution_output_cap")))
     target = job_budget_timeout_seconds(normalize_job_budget(job_budget))
     if target <= 2 * 60:
         return max(
@@ -9245,9 +9389,9 @@ def _state_db_id(kind: str, payload: dict[str, Any]) -> str:
 def _state_db_connect() -> sqlite3.Connection | None:
     if not STATE_DB_ENABLED:
         return None
-    ensure_state_dir()
-    STATE_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     try:
+        ensure_state_dir()
+        STATE_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(STATE_DB_PATH), timeout=2)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
@@ -9491,7 +9635,7 @@ def _state_db_connect() -> sqlite3.Connection | None:
         )
         conn.commit()
         return conn
-    except sqlite3.Error:
+    except (OSError, sqlite3.Error):
         try:
             conn.close()  # type: ignore[name-defined]
         except Exception:
@@ -11478,6 +11622,12 @@ def local_route_intent_classifier_prompt(
             (
                 "Required keys: requested_action, operator_intent_class, lane, "
                 "local_eligible, cloud_needed, risk, confidence, reason."
+            ),
+            (
+                "Use only literal values from the allowed_* arrays below; do not "
+                "invent aliases such as status_check, non_mutating_inquiry, or "
+                "general_conversation. For a short status/update/check-in, use "
+                "requested_action=status, operator_intent_class=status, lane=scout."
             ),
             json.dumps(compact, sort_keys=True, ensure_ascii=True),
         ]
@@ -16104,14 +16254,26 @@ def console_runtime_kernel_primary_run_shape(
     detail: int = 0,
     job_budget: str = "",
 ) -> dict[str, Any]:
+    normalized_detail = normalize_response_detail(detail)
+    normalized_budget = normalize_job_budget(job_budget)
+    token_capacity_plan = provider_token_budget_plan(
+        prompt=str(prompt or ""),
+        runtime="localllm",
+        model=LOCAL_LLM_DEFAULT_MODEL,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+        cloud_authorized=False,
+        enforcement="kernel_hard",
+    )
     if prompt_is_literal_response_request(prompt):
         return {
             "task_kind": "literal_response",
             "planner_kind": "literal_response",
             "goal_phase_sequence": ["literal_response"],
             "max_steps": 1,
-            "max_output_tokens": 96,
+            "max_output_tokens": token_capacity_plan["execution_output_cap"],
             "output_shape_expected": "literal_response",
+            "token_capacity_plan": token_capacity_plan,
         }
     return {
         "task_kind": "visible_response",
@@ -16124,12 +16286,9 @@ def console_runtime_kernel_primary_run_shape(
                 10,
             ),
         ),
-        "max_output_tokens": estimate_turn_output_tokens(
-            normalize_response_detail(detail),
-            normalize_job_budget(job_budget),
-            str(prompt or ""),
-        ),
+        "max_output_tokens": token_capacity_plan["execution_output_cap"],
         "output_shape_expected": "complete",
+        "token_capacity_plan": token_capacity_plan,
     }
 
 
@@ -16140,6 +16299,9 @@ def console_runtime_turn_route_policy(
     model: str,
     service_tier: str,
     cost_route: dict[str, Any] | None = None,
+    detail: int = 0,
+    job_budget: str = "",
+    turn_plan: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     normalized_runtime = normalize_runtime(runtime)
     normalized_model = normalize_runtime_model(normalized_runtime, model)
@@ -16154,7 +16316,16 @@ def console_runtime_turn_route_policy(
         requested_runtime,
         route.get("requested_model") or model,
     )
-    run_shape = console_runtime_kernel_primary_run_shape(prompt)
+    run_shape = console_runtime_kernel_primary_run_shape(
+        prompt,
+        detail=detail,
+        job_budget=job_budget,
+    )
+    token_capacity_plan = normalize_provider_token_budget_plan(
+        turn_plan.get("token_capacity_plan")
+        if isinstance(turn_plan, dict)
+        else run_shape.get("token_capacity_plan")
+    )
     return {
         "runtime": "kernel_shadow",
         "visible_runtime": normalized_runtime,
@@ -16192,7 +16363,9 @@ def console_runtime_turn_route_policy(
         "output_shape_expected": run_shape["output_shape_expected"],
         "route_proof_required": bool(TUI_KERNEL_EXECUTION_ENABLED),
         "require_verifier_for_completion": bool(TUI_KERNEL_EXECUTION_ENABLED),
+        "local_token_budget": token_capacity_plan["local_token_budget"],
         "cloud_token_budget": 0,
+        "token_capacity_plan": token_capacity_plan,
         "cloud_escalation": normalized_runtime not in {"localllm", "local"},
         "selected_runtime": route.get("selected_runtime") or normalized_runtime,
         "selected_model": route.get("selected_model") or normalized_model,
@@ -16213,11 +16386,21 @@ def console_runtime_turn_metadata(
     job_budget: str,
     optimization_mode: str,
     timeout_seconds: int,
+    detail: int = 0,
     turn_plan: dict[str, Any] | None = None,
     turn_envelope: dict[str, Any] | None = None,
     cost_route: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    run_shape = console_runtime_kernel_primary_run_shape(prompt)
+    run_shape = console_runtime_kernel_primary_run_shape(
+        prompt,
+        detail=detail,
+        job_budget=job_budget,
+    )
+    token_capacity_plan = normalize_provider_token_budget_plan(
+        turn_plan.get("token_capacity_plan")
+        if isinstance(turn_plan, dict)
+        else run_shape.get("token_capacity_plan")
+    )
     return {
         "source": "agent_console_web",
         "kind": "tui_turn_shadow",
@@ -16246,7 +16429,9 @@ def console_runtime_turn_metadata(
         "planner_kind": run_shape["planner_kind"],
         "goal_phase_sequence": list(run_shape["goal_phase_sequence"]),
         "output_shape_expected": run_shape["output_shape_expected"],
+        "local_token_budget": token_capacity_plan["local_token_budget"],
         "cloud_token_budget": 0,
+        "token_capacity_plan": token_capacity_plan,
         "turn_plan": normalize_turn_plan_estimate(turn_plan),
         "turn_envelope": dict(turn_envelope or {}),
         "cost_route": dict(cost_route or {}),
@@ -16289,6 +16474,9 @@ def ensure_console_runtime_turn_shadow_job(
         job_budget=job_budget,
         optimization_mode=optimization_mode,
         timeout_seconds=timeout_seconds,
+        detail=(
+            _coerce_int(turn_plan.get("detail")) if isinstance(turn_plan, dict) else 0
+        ),
         turn_plan=turn_plan,
         turn_envelope=turn_envelope,
         cost_route=cost_route,
@@ -16299,6 +16487,15 @@ def ensure_console_runtime_turn_shadow_job(
         model=model,
         service_tier=service_tier,
         cost_route=cost_route,
+        detail=(
+            _coerce_int(turn_plan.get("detail")) if isinstance(turn_plan, dict) else 0
+        ),
+        job_budget=(
+            str(turn_plan.get("job_budget") or "")
+            if isinstance(turn_plan, dict)
+            else job_budget
+        ),
+        turn_plan=turn_plan,
     )
     objective = console_runtime_execution_objective(prompt, normalized_attachments)
     objective_summary = planner_understood_task(prompt, normalized_attachments)
@@ -16610,6 +16807,7 @@ def default_status_meta() -> dict[str, Any]:
         "resource_meter": {},
         "live_turn": default_live_turn(),
         "turn_plan": default_turn_plan_estimate(),
+        "working_recap": default_working_recap(),
     }
 
 
@@ -18511,6 +18709,9 @@ def default_usage_entry() -> dict[str, Any]:
         "broker_tool_rounds": 0,
         "broker_model_calls": 0,
         "broker_tool_budget_exhausted": False,
+        "broker_output_token_budget": 0,
+        "broker_output_budget_exhausted": False,
+        "token_capacity_plan": {},
         "zero_token_provider_failure": False,
         "context_preflight_accounting": {},
         "preflight_accounting_schema": "",
@@ -18925,10 +19126,17 @@ def normalize_usage_entry(value: Any) -> dict[str, Any]:
         "broker_tool_calls",
         "broker_tool_rounds",
         "broker_model_calls",
+        "broker_output_token_budget",
     ):
         payload[key] = _coerce_int(payload.get(key))
     payload["broker_tool_budget_exhausted"] = bool(
         payload.get("broker_tool_budget_exhausted")
+    )
+    payload["broker_output_budget_exhausted"] = bool(
+        payload.get("broker_output_budget_exhausted")
+    )
+    payload["token_capacity_plan"] = normalize_provider_token_budget_plan(
+        payload.get("token_capacity_plan")
     )
     if isinstance(payload.get("context_preflight_accounting"), dict):
         context_preflight_fields = usage_fields_from_context_preflight_accounting(
@@ -20285,6 +20493,354 @@ TURN_PLAN_PROMPT_MARKERS = (
 )
 
 
+TOKEN_CAPACITY_PROVIDER_CLASSES = {
+    "norllama",
+    "bedrock",
+    "codex_subscription",
+    "openai_direct",
+}
+
+
+def default_provider_token_budget_plan() -> dict[str, Any]:
+    return {
+        "schema": "norman.tui.token-capacity-plan.v1",
+        "provider_class": "",
+        "target_seconds": 0,
+        "estimated_input_tokens": 0,
+        "estimated_output_tokens": 0,
+        "soft_output_tokens_per_hour": 0,
+        "recent_output_tokens": 0,
+        "recent_observed_output_tokens_per_hour": 0,
+        "recent_sample_count": 0,
+        "recent_window_seconds": TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS,
+        "remaining_soft_output_tokens": 0,
+        "time_window_output_cap": 0,
+        "execution_output_cap": 0,
+        "execution_total_token_budget": 0,
+        "local_token_budget": 0,
+        "cloud_token_budget": 0,
+        "cloud_authorized": False,
+        "capacity_source": "unavailable",
+        "confidence": "unknown",
+        "enforcement": "none",
+        "subscription_capacity_state": "",
+        "subscription_capacity_percent_left": None,
+        "subscription_capacity_fresh": False,
+        "subscription_reset_seconds": 0,
+    }
+
+
+def normalize_provider_token_budget_plan(value: Any) -> dict[str, Any]:
+    payload = dict(default_provider_token_budget_plan())
+    if isinstance(value, dict):
+        payload.update(value)
+    provider_class = str(payload.get("provider_class") or "").strip().lower()
+    payload["provider_class"] = (
+        provider_class if provider_class in TOKEN_CAPACITY_PROVIDER_CLASSES else ""
+    )
+    for key in (
+        "target_seconds",
+        "estimated_input_tokens",
+        "estimated_output_tokens",
+        "soft_output_tokens_per_hour",
+        "recent_output_tokens",
+        "recent_observed_output_tokens_per_hour",
+        "recent_sample_count",
+        "recent_window_seconds",
+        "remaining_soft_output_tokens",
+        "time_window_output_cap",
+        "execution_output_cap",
+        "execution_total_token_budget",
+        "local_token_budget",
+        "cloud_token_budget",
+        "subscription_reset_seconds",
+    ):
+        payload[key] = max(0, _coerce_int(payload.get(key)))
+    payload["cloud_authorized"] = bool(payload.get("cloud_authorized"))
+    payload["subscription_capacity_fresh"] = bool(
+        payload.get("subscription_capacity_fresh")
+    )
+    capacity_percent = payload.get("subscription_capacity_percent_left")
+    payload["subscription_capacity_percent_left"] = (
+        min(100, max(0, _coerce_int(capacity_percent)))
+        if capacity_percent is not None
+        else None
+    )
+    payload["capacity_source"] = (
+        str(payload.get("capacity_source") or "unavailable").strip() or "unavailable"
+    )
+    payload["confidence"] = (
+        str(payload.get("confidence") or "unknown").strip().lower() or "unknown"
+    )
+    payload["enforcement"] = (
+        str(payload.get("enforcement") or "none").strip().lower() or "none"
+    )
+    payload["subscription_capacity_state"] = str(
+        payload.get("subscription_capacity_state") or ""
+    ).strip()
+    return payload
+
+
+def token_capacity_provider_class(
+    runtime: Any,
+    service_tier: Any = "",
+    *,
+    cost_route: dict[str, Any] | None = None,
+) -> str:
+    normalized_runtime = normalize_runtime(runtime)
+    route = dict(cost_route or {})
+    charge_basis = str(route.get("charge_basis") or "").strip().lower()
+    if normalized_runtime == "localllm":
+        return "norllama"
+    provider_surface = (
+        str(usage_provider_tags(service_tier).get("provider_surface") or "")
+        .strip()
+        .lower()
+    )
+    if provider_surface == "aws-bedrock" or normalized_runtime in {
+        "claude",
+        "deepseek",
+        "gptoss",
+        "kimi",
+        "qwen",
+    }:
+        return "bedrock"
+    if (normalized_runtime == "codex" and charge_basis == "codex_credits") or (
+        normalized_runtime == "codex"
+        and usage_charge_ledger_kind(
+            {
+                "runtime": normalized_runtime,
+                "service_tier": service_tier,
+            }
+        )
+        == "chatgpt_codex_credit_estimate"
+    ):
+        return "codex_subscription"
+    return "openai_direct"
+
+
+def token_capacity_policy_output_tokens_per_hour(provider_class: str) -> int:
+    return {
+        "norllama": TUI_NORLLAMA_OUTPUT_TOKENS_PER_HOUR,
+        "bedrock": TUI_BEDROCK_OUTPUT_TOKENS_PER_HOUR,
+        "codex_subscription": TUI_CODEX_OUTPUT_TOKENS_PER_HOUR,
+        "openai_direct": TUI_OPENAI_OUTPUT_TOKENS_PER_HOUR,
+    }.get(provider_class, TUI_OPENAI_OUTPUT_TOKENS_PER_HOUR)
+
+
+def token_capacity_provider_request_ceiling(provider_class: str) -> int:
+    if provider_class == "norllama":
+        return max(1, LOCAL_LLM_MAX_OUTPUT_TOKENS)
+    if provider_class == "bedrock":
+        return max(1, BEDROCK_CONVERSE_MAX_OUTPUT_TOKENS)
+    return TUI_TOKEN_CAPACITY_CLOUD_MAX_OUTPUT_TOKENS
+
+
+def token_capacity_usage_matches_provider(
+    entry: dict[str, Any], provider_class: str
+) -> bool:
+    normalized = normalize_usage_entry(entry)
+    runtime = normalize_runtime(normalized.get("runtime"))
+    surface = str(normalized.get("provider_surface") or "").strip().lower()
+    ledger_kind = str(normalized.get("charge_ledger_kind") or "").strip()
+    if provider_class == "norllama":
+        return runtime == "localllm" or surface in {"local", "norllama", "ollama"}
+    if provider_class == "bedrock":
+        return surface == "aws-bedrock" or runtime in {
+            "claude",
+            "deepseek",
+            "gptoss",
+            "kimi",
+            "qwen",
+        }
+    if provider_class == "codex_subscription":
+        return (
+            runtime == "codex"
+            and surface == "openai-direct"
+            and ledger_kind == "chatgpt_codex_credit_estimate"
+        )
+    return surface == "openai-direct" and ledger_kind != "chatgpt_codex_credit_estimate"
+
+
+def provider_token_budget_plan(
+    *,
+    prompt: str = "",
+    runtime: str,
+    model: str = "",
+    service_tier: str = "",
+    job_budget: str = "",
+    detail: int = 2,
+    attachments: list[dict[str, Any]] | None = None,
+    estimated_input_tokens: int | None = None,
+    estimated_output_tokens: int | None = None,
+    entries: list[dict[str, Any]] | None = None,
+    cost_route: dict[str, Any] | None = None,
+    cloud_authorized: bool | None = None,
+    enforcement: str = "",
+    now: int | None = None,
+) -> dict[str, Any]:
+    observed_now = _coerce_int(now) or now_ts()
+    normalized_runtime = normalize_runtime(runtime)
+    normalized_budget = normalize_job_budget(job_budget)
+    provider_class = token_capacity_provider_class(
+        normalized_runtime,
+        service_tier,
+        cost_route=cost_route,
+    )
+    target_seconds = job_budget_timeout_seconds(normalized_budget)
+    normalized_attachments = normalize_attachments(attachments or [])
+    input_tokens = (
+        max(0, int(estimated_input_tokens))
+        if estimated_input_tokens is not None
+        else _estimated_text_tokens(prompt)
+        + _estimated_attachment_tokens(normalized_attachments)
+    )
+    output_tokens = (
+        max(0, int(estimated_output_tokens))
+        if estimated_output_tokens is not None
+        else estimate_turn_output_tokens(
+            normalize_response_detail(detail), normalized_budget, prompt
+        )
+    )
+    literal_response = prompt_is_literal_response_request(prompt)
+    if literal_response:
+        output_tokens = min(96, output_tokens or 96)
+
+    all_entries = (
+        usage_entries_with_effective_deltas(
+            [normalize_usage_entry(item) for item in entries]
+        )
+        if entries is not None
+        else usage_entries_with_effective_deltas(load_usage_history())
+    )
+    recent_since = max(0, observed_now - TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS)
+    recent_entries = [
+        item
+        for item in all_entries
+        if token_capacity_usage_matches_provider(item, provider_class)
+        and _coerce_int(item.get("finished_at")) >= recent_since
+        and bool(item.get("success"))
+    ]
+    recent_output_tokens = sum(
+        max(0, _coerce_int(item.get("output_tokens"))) for item in recent_entries
+    )
+    timestamps = [
+        _coerce_int(item.get("finished_at"))
+        for item in recent_entries
+        if _coerce_int(item.get("finished_at"))
+    ]
+    observed_window_seconds = (
+        min(
+            TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS,
+            max(300, observed_now - min(timestamps)),
+        )
+        if timestamps
+        else 0
+    )
+    observed_output_tokens_per_hour = (
+        int(round(recent_output_tokens * 3600 / observed_window_seconds))
+        if observed_window_seconds
+        else 0
+    )
+    policy_output_tokens_per_hour = token_capacity_policy_output_tokens_per_hour(
+        provider_class
+    )
+    planned_window_cap = int(
+        policy_output_tokens_per_hour
+        * target_seconds
+        / 3600
+        * TUI_TOKEN_CAPACITY_WINDOW_FRACTION
+    )
+    remaining_soft_output_tokens = max(
+        0, policy_output_tokens_per_hour - recent_output_tokens
+    )
+    time_window_output_cap = min(planned_window_cap, remaining_soft_output_tokens)
+    provider_request_ceiling = token_capacity_provider_request_ceiling(provider_class)
+    minimum_output_tokens = (
+        96
+        if literal_response
+        else min(TUI_TOKEN_CAPACITY_MIN_OUTPUT_TOKENS, provider_request_ceiling)
+    )
+    bounded_window_cap = max(minimum_output_tokens, time_window_output_cap)
+    execution_output_cap = min(
+        provider_request_ceiling,
+        max(minimum_output_tokens, output_tokens or minimum_output_tokens),
+        bounded_window_cap,
+    )
+    execution_total_token_budget = max(
+        execution_output_cap,
+        int(math.ceil(execution_output_cap * TUI_TOKEN_CAPACITY_TOTAL_BUDGET_FACTOR)),
+    )
+    if cloud_authorized is None:
+        cloud_authorized = provider_class != "norllama"
+
+    capacity_source = "configured_policy"
+    confidence = "policy"
+    subscription_capacity: dict[str, Any] = {}
+    if provider_class == "codex_subscription":
+        subscription_capacity = codex_account_capacity_snapshot(
+            all_entries,
+            now=observed_now,
+        )
+        capacity_source = "configured_policy+subscription_forecast"
+        confidence = (
+            "subscription_observed"
+            if subscription_capacity.get("fresh")
+            else "subscription_stale"
+        )
+    elif recent_entries:
+        capacity_source = "configured_policy+observed_ledger"
+        confidence = "policy_with_observations"
+
+    if not enforcement:
+        enforcement = (
+            "request_hard" if provider_class in {"norllama", "bedrock"} else "advisory"
+        )
+    return normalize_provider_token_budget_plan(
+        {
+            "provider_class": provider_class,
+            "target_seconds": target_seconds,
+            "estimated_input_tokens": input_tokens,
+            "estimated_output_tokens": output_tokens,
+            "soft_output_tokens_per_hour": policy_output_tokens_per_hour,
+            "recent_output_tokens": recent_output_tokens,
+            "recent_observed_output_tokens_per_hour": observed_output_tokens_per_hour,
+            "recent_sample_count": len(recent_entries),
+            "recent_window_seconds": (
+                observed_window_seconds or TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS
+            ),
+            "remaining_soft_output_tokens": remaining_soft_output_tokens,
+            "time_window_output_cap": time_window_output_cap,
+            "execution_output_cap": execution_output_cap,
+            "execution_total_token_budget": execution_total_token_budget,
+            "local_token_budget": (
+                execution_total_token_budget if provider_class == "norllama" else 0
+            ),
+            "cloud_token_budget": (
+                execution_total_token_budget
+                if provider_class != "norllama" and cloud_authorized
+                else 0
+            ),
+            "cloud_authorized": bool(cloud_authorized),
+            "capacity_source": capacity_source,
+            "confidence": confidence,
+            "enforcement": enforcement,
+            "subscription_capacity_state": str(
+                subscription_capacity.get("state") or ""
+            ),
+            "subscription_capacity_percent_left": subscription_capacity.get(
+                "minimum_window_percent_left"
+            ),
+            "subscription_capacity_fresh": bool(subscription_capacity.get("fresh")),
+            "subscription_reset_seconds": _coerce_int(
+                (subscription_capacity.get("forecast") or {}).get(
+                    "earliest_reset_seconds"
+                )
+            ),
+        }
+    )
+
+
 def default_turn_plan_estimate() -> dict[str, Any]:
     return {
         "schema": "norman.tui.turn-plan-estimate.v1",
@@ -20317,6 +20873,7 @@ def default_turn_plan_estimate() -> dict[str, Any]:
         "timeout_seconds": 0,
         "attachment_count": 0,
         "success": False,
+        "token_capacity_plan": default_provider_token_budget_plan(),
     }
 
 
@@ -20348,6 +20905,9 @@ def normalize_turn_plan_estimate(value: Any) -> dict[str, Any]:
     )
     payload["cost_configured"] = bool(payload.get("cost_configured"))
     payload["success"] = bool(payload.get("success"))
+    payload["token_capacity_plan"] = normalize_provider_token_budget_plan(
+        payload.get("token_capacity_plan")
+    )
     for key in (
         "understood_task",
         "plan_summary",
@@ -20582,6 +21142,17 @@ def build_turn_plan_estimate(
     output_tokens = estimate_turn_output_tokens(
         normalized_detail, normalized_budget, prompt
     )
+    token_capacity_plan = provider_token_budget_plan(
+        prompt=prompt,
+        runtime=normalized_runtime,
+        model=normalized_model,
+        service_tier=normalized_tier,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+        attachments=normalized_attachments,
+        estimated_input_tokens=input_tokens,
+        estimated_output_tokens=output_tokens,
+    )
     cost = estimate_usage_cost(
         {
             "input_tokens": input_tokens,
@@ -20631,6 +21202,7 @@ def build_turn_plan_estimate(
                 timeout_seconds, normalized_budget
             ),
             "attachment_count": len(normalized_attachments),
+            "token_capacity_plan": token_capacity_plan,
         }
     )
 
@@ -21779,6 +22351,7 @@ def default_codex_account_capacity() -> dict[str, Any]:
     return {
         "schema": "norman.codex-account-capacity.v1",
         "source": "unavailable",
+        "observed_command": "",
         "observed_at": 0,
         "last_probe_at": 0,
         "auth_mode": "",
@@ -21789,6 +22362,8 @@ def default_codex_account_capacity() -> dict[str, Any]:
         "minimum_window_percent_left": None,
         "windows": [],
         "reset_hint": "",
+        "credits_available": None,
+        "usage_limit_resets_available": None,
         "last_error": "",
         "eligible_for_subscription_route": False,
         "forecast": {
@@ -21808,7 +22383,9 @@ def default_codex_account_capacity() -> dict[str, Any]:
     }
 
 
-def _codex_account_capacity_reset_seconds(value: Any) -> int:
+def _codex_account_capacity_reset_seconds(
+    value: Any, *, observed_at: int | None = None
+) -> int:
     text = str(value or "").strip().lower()
     if not text:
         return 0
@@ -21826,7 +22403,37 @@ def _codex_account_capacity_reset_seconds(value: Any) -> int:
             total += numeric * 60 * 60
         else:
             total += numeric * 60
-    return total
+    if total:
+        return total
+    match = re.search(
+        r"\b(?P<hour>\d{1,2}):(?P<minute>\d{2})\s+on\s+"
+        r"(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3,9})\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return 0
+    observed = _coerce_int(observed_at) or now_ts()
+    observed_dt = datetime.fromtimestamp(observed)
+    stamp = (
+        f"{match.group('day')} {match.group('month').title()} "
+        f"{observed_dt.year} {match.group('hour')}:{match.group('minute')}"
+    )
+    candidate: datetime | None = None
+    for pattern in ("%d %b %Y %H:%M", "%d %B %Y %H:%M"):
+        try:
+            candidate = datetime.strptime(stamp, pattern)
+            break
+        except ValueError:
+            continue
+    if candidate is None:
+        return 0
+    if candidate < observed_dt:
+        try:
+            candidate = candidate.replace(year=candidate.year + 1)
+        except ValueError:
+            return 0
+    return max(0, int(candidate.timestamp() - observed))
 
 
 def _codex_account_capacity_window_label(prefix: Any, line: Any) -> str:
@@ -21883,6 +22490,7 @@ def parse_codex_account_capacity_pane(
     )
     windows: list[dict[str, Any]] = []
     seen: set[tuple[str, int, str]] = set()
+    latest_window_index: int | None = None
     percentage_patterns = (
         (
             r"\b(?P<percent>\d{1,3})\s*%\s*(?:left|remaining|available)\b",
@@ -21899,10 +22507,16 @@ def parse_codex_account_capacity_pane(
         line = re.sub(r"\s+", " ", raw_line).strip()
         if not line:
             continue
+        if re.search(r"\bcontext(?:\s+window)?\b", line, flags=re.IGNORECASE):
+            continue
         reset_hint = _codex_account_capacity_reset_hint(line)
-        reset_seconds = _codex_account_capacity_reset_seconds(reset_hint)
+        reset_seconds = _codex_account_capacity_reset_seconds(
+            reset_hint, observed_at=observed
+        )
+        matched_capacity = False
         for pattern, reports_capacity_left in percentage_patterns:
             for match in re.finditer(pattern, line, flags=re.IGNORECASE):
+                matched_capacity = True
                 observed_percent = min(100, max(0, _coerce_int(match.group("percent"))))
                 percent_left = (
                     observed_percent
@@ -21924,6 +22538,35 @@ def parse_codex_account_capacity_pane(
                         "reset_seconds": reset_seconds,
                     }
                 )
+                latest_window_index = len(windows) - 1
+        if (
+            reset_hint
+            and not matched_capacity
+            and latest_window_index is not None
+            and not windows[latest_window_index]["reset_hint"]
+        ):
+            windows[latest_window_index]["reset_hint"] = reset_hint
+            windows[latest_window_index]["reset_seconds"] = (
+                _codex_account_capacity_reset_seconds(reset_hint, observed_at=observed)
+            )
+    credits_match = re.search(
+        r"\bcredits?\s*:\s*(?P<credits>[\d,]+)\s+credits?\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    resets_match = re.search(
+        r"\byou have\s+(?P<resets>\d+)\s+usage limit resets?\s+available\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if credits_match:
+        payload["credits_available"] = max(
+            0, _coerce_int(credits_match.group("credits").replace(",", ""))
+        )
+    if resets_match:
+        payload["usage_limit_resets_available"] = max(
+            0, _coerce_int(resets_match.group("resets"))
+        )
     lower = text.lower()
     explicit_limit = (
         "usage limit" in lower
@@ -21963,6 +22606,9 @@ def normalize_codex_account_capacity(
         payload.update(value)
     payload["schema"] = "norman.codex-account-capacity.v1"
     payload["source"] = str(payload.get("source") or "unavailable").strip().lower()
+    payload["observed_command"] = (
+        str(payload.get("observed_command") or "").strip().lower()
+    )
     payload["observed_at"] = max(0, _coerce_int(payload.get("observed_at")))
     payload["last_probe_at"] = max(0, _coerce_int(payload.get("last_probe_at")))
     payload["auth_mode"] = str(payload.get("auth_mode") or "").strip().lower()
@@ -21992,11 +22638,23 @@ def normalize_codex_account_capacity(
                     "reset_seconds": max(
                         0,
                         _coerce_int(raw_window.get("reset_seconds"))
-                        or _codex_account_capacity_reset_seconds(reset_hint),
+                        or _codex_account_capacity_reset_seconds(
+                            reset_hint, observed_at=payload["observed_at"]
+                        ),
                     ),
                 }
             )
     payload["windows"] = clean_windows
+    credits_available = payload.get("credits_available")
+    payload["credits_available"] = (
+        max(0, _coerce_int(credits_available))
+        if credits_available is not None
+        else None
+    )
+    resets_available = payload.get("usage_limit_resets_available")
+    payload["usage_limit_resets_available"] = (
+        max(0, _coerce_int(resets_available)) if resets_available is not None else None
+    )
     minimum = min((item["percent_left"] for item in clean_windows), default=None)
     payload["minimum_window_percent_left"] = minimum
     payload["capacity_percent_left"] = minimum
@@ -22113,6 +22771,103 @@ def codex_subscription_capacity_personal_lane() -> bool:
     )
 
 
+def codex_subscription_capacity_route_lane() -> bool:
+    if codex_subscription_capacity_personal_lane():
+        return True
+    return bool(
+        CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED
+        and semantic_agent_group(AGENT_SLUG, AGENT_GROUP) == "work"
+        and str(usage_billing_owner() or "").strip()
+    )
+
+
+def codex_subscription_capacity_reset_seconds(value: Any) -> int:
+    return min(
+        (
+            max(0, _coerce_int(item.get("reset_seconds")))
+            for item in (value.get("windows") if isinstance(value, dict) else [])
+            if isinstance(item, dict) and _coerce_int(item.get("reset_seconds")) > 0
+        ),
+        default=0,
+    )
+
+
+def codex_subscription_capacity_route_forecast(
+    capacity: dict[str, Any],
+    *,
+    prompt: Any = "",
+    job_budget: Any = "",
+    detail: Any = 2,
+    estimated_output_tokens: int | None = None,
+) -> dict[str, Any]:
+    """Build a conservative plan-capacity envelope, never a provider credit quote."""
+    snapshot = normalize_codex_account_capacity(capacity)
+    reset_seconds = codex_subscription_capacity_reset_seconds(snapshot)
+    normalized_budget = normalize_job_budget(job_budget)
+    target_seconds = job_budget_timeout_seconds(normalized_budget)
+    planned_output_tokens = (
+        max(0, _coerce_int(estimated_output_tokens))
+        if estimated_output_tokens is not None
+        else estimate_turn_output_tokens(
+            normalize_response_detail(detail),
+            normalized_budget,
+            str(prompt or ""),
+        )
+    )
+    policy_output_tokens_to_reset = (
+        int(
+            TUI_CODEX_OUTPUT_TOKENS_PER_HOUR
+            * reset_seconds
+            / 3600
+            * CODEX_SUBSCRIPTION_ROUTE_FORECAST_CAP_FRACTION
+        )
+        if reset_seconds
+        else 0
+    )
+    if policy_output_tokens_to_reset:
+        policy_output_tokens_to_reset = max(
+            TUI_TOKEN_CAPACITY_MIN_OUTPUT_TOKENS,
+            policy_output_tokens_to_reset,
+        )
+    observed_forecast = (
+        snapshot.get("forecast") if isinstance(snapshot.get("forecast"), dict) else {}
+    )
+    projected_tokens = max(
+        0,
+        _coerce_int(observed_forecast.get("projected_tokens_to_earliest_reset")),
+    )
+    projected_with_turn = projected_tokens + planned_output_tokens
+    reset_known = reset_seconds > 0
+    turn_fits_reset = reset_known and target_seconds <= reset_seconds
+    fits_policy_envelope = (
+        reset_known
+        and planned_output_tokens <= policy_output_tokens_to_reset
+        and projected_with_turn <= policy_output_tokens_to_reset
+    )
+    if not reset_known:
+        reason = "no subscription reset time was observed"
+    elif not turn_fits_reset:
+        reason = "planned turn extends beyond the subscription reset window"
+    elif not fits_policy_envelope:
+        reason = "planned turn exceeds the conservative subscription forecast"
+    else:
+        reason = "planned turn fits the conservative subscription reset forecast"
+    return {
+        "schema": "norman.codex-subscription-route-forecast.v1",
+        "reset_seconds": reset_seconds,
+        "target_seconds": target_seconds,
+        "estimated_output_tokens": planned_output_tokens,
+        "policy_output_tokens_to_reset": policy_output_tokens_to_reset,
+        "observed_projected_tokens_to_reset": projected_tokens,
+        "projected_tokens_to_reset_with_turn": projected_with_turn,
+        "reset_known": reset_known,
+        "turn_fits_reset": turn_fits_reset,
+        "fits_policy_envelope": fits_policy_envelope,
+        "reason": reason,
+        "credits_available_informational": snapshot.get("credits_available"),
+    }
+
+
 def codex_account_capacity_history(limit: int = 48) -> list[dict[str, Any]]:
     clean_limit = max(0, min(2880, _coerce_int(limit)))
     if clean_limit <= 0:
@@ -22143,6 +22898,10 @@ def codex_account_capacity_history(limit: int = 48) -> list[dict[str, Any]]:
                 "state": item.get("state"),
                 "minimum_window_percent_left": item.get("minimum_window_percent_left"),
                 "reset_hint": item.get("reset_hint"),
+                "credits_available": item.get("credits_available"),
+                "usage_limit_resets_available": item.get(
+                    "usage_limit_resets_available"
+                ),
                 "windows": item.get("windows"),
             }
         )
@@ -22177,12 +22936,21 @@ def codex_account_capacity_snapshot(
     )
     payload["eligible_for_subscription_route"] = bool(
         CODEX_SUBSCRIPTION_ROUTE_PREFERENCE_ENABLED
-        and codex_subscription_capacity_personal_lane()
+        and codex_subscription_capacity_route_lane()
         and payload["auth_mode"] == "chatgpt"
         and payload["fresh"]
         and payload["state"] == "available"
         and _coerce_int(payload.get("minimum_window_percent_left"))
         >= CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT
+        and codex_subscription_capacity_reset_seconds(payload)
+        >= CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS
+    )
+    payload["credit_extension_allowed"] = CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED
+    payload["plan_reserve_percent_left"] = CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT
+    payload["credit_extension_guard"] = (
+        "allowed"
+        if CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED
+        else "plan-capacity-required"
     )
     payload["history"] = codex_account_capacity_history()
     return payload
@@ -22223,7 +22991,13 @@ def _codex_account_capacity_probe_due(
         _coerce_int(capacity.get("observed_at")),
     )
     interval_seconds = CODEX_ACCOUNT_CAPACITY_POLL_INTERVAL_SECONDS
-    if str(capacity.get("source") or "").strip().lower() == "unsupported_command":
+    probe_command = _safe_codex_account_capacity_probe_command(
+        CODEX_ACCOUNT_CAPACITY_COMMAND
+    )
+    if (
+        str(capacity.get("source") or "").strip().lower() == "unsupported_command"
+        and str(capacity.get("observed_command") or "").strip().lower() == probe_command
+    ):
         interval_seconds = CODEX_ACCOUNT_CAPACITY_UNSUPPORTED_BACKOFF_SECONDS
     return not last_probe_at or (observed_now - last_probe_at >= interval_seconds)
 
@@ -22291,7 +23065,9 @@ def _capture_codex_account_capacity_command(
     baseline_pane: Any = "",
 ) -> dict[str, Any]:
     baseline_hash = _pane_hash(baseline_pane)
-    send_text(command)
+    if str(command or "").strip().lower() != "/status":
+        return {}
+    send_codex_status_probe()
     deadline = time.time() + CODEX_ACCOUNT_CAPACITY_PROBE_TIMEOUT_SECONDS
     while time.time() < deadline:
         time.sleep(CODEX_ACCOUNT_CAPACITY_PROBE_POLL_SECONDS)
@@ -22322,6 +23098,12 @@ def _codex_account_capacity_command_unsupported(value: Any, command: str) -> boo
     )
 
 
+def _safe_codex_account_capacity_probe_command(command: Any) -> str:
+    """Permit the read-only inspection command, never an account reset command."""
+    clean_command = str(command or "").strip().lower()
+    return "/status" if clean_command == "/status" else ""
+
+
 def _clear_codex_account_capacity_command() -> None:
     send_keys("Escape")
     send_keys("C-u")
@@ -22343,29 +23125,28 @@ def _run_codex_account_capacity_probe() -> None:
             pane=pane, auth_mode=auth_mode, pending=False
         ):
             return
-        sent_command = True
-        payload = _capture_codex_account_capacity_command(
-            CODEX_ACCOUNT_CAPACITY_COMMAND,
-            observed_at=observed_at,
-            auth_mode=auth_mode,
-            baseline_pane=pane,
+        probe_command = _safe_codex_account_capacity_probe_command(
+            CODEX_ACCOUNT_CAPACITY_COMMAND
         )
-        unsupported_command = (
-            not payload
-            and _codex_account_capacity_command_unsupported(
-                capture_pane(), CODEX_ACCOUNT_CAPACITY_COMMAND
+        if not probe_command:
+            failure = True
+            payload = default_codex_account_capacity()
+            payload.update(
+                {
+                    "source": "probe_command_rejected",
+                    "observed_at": observed_at,
+                    "last_probe_at": observed_at,
+                    "auth_mode": auth_mode,
+                    "last_error": (
+                        "automatic capacity probing only permits /status; "
+                        "/usage can consume an account limit reset"
+                    ),
+                }
             )
-        )
-        fallback_command = CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND
-        if (
-            not payload
-            and not unsupported_command
-            and fallback_command
-            and fallback_command != CODEX_ACCOUNT_CAPACITY_COMMAND
-        ):
-            _clear_codex_account_capacity_command()
+        else:
+            sent_command = True
             payload = _capture_codex_account_capacity_command(
-                fallback_command,
+                probe_command,
                 observed_at=observed_at,
                 auth_mode=auth_mode,
                 baseline_pane=pane,
@@ -22373,27 +23154,32 @@ def _run_codex_account_capacity_probe() -> None:
             unsupported_command = (
                 not payload
                 and _codex_account_capacity_command_unsupported(
-                    capture_pane(), fallback_command
+                    capture_pane(), probe_command
                 )
             )
-        if not payload:
-            failure = True
-            payload = default_codex_account_capacity()
-            payload.update(
-                {
-                    "source": (
-                        "unsupported_command" if unsupported_command else "probe_failed"
-                    ),
-                    "observed_at": observed_at,
-                    "last_probe_at": observed_at,
-                    "auth_mode": auth_mode,
-                    "last_error": (
-                        "configured capacity command is unsupported by this Codex CLI"
-                        if unsupported_command
-                        else "interactive capacity command returned no aggregate limit"
-                    ),
-                }
-            )
+            if not payload:
+                failure = True
+                payload = default_codex_account_capacity()
+                payload.update(
+                    {
+                        "source": (
+                            "unsupported_command"
+                            if unsupported_command
+                            else "probe_failed"
+                        ),
+                        "observed_command": probe_command,
+                        "observed_at": observed_at,
+                        "last_probe_at": observed_at,
+                        "auth_mode": auth_mode,
+                        "last_error": (
+                            "configured capacity command is unsupported by this Codex CLI"
+                            if unsupported_command
+                            else "interactive capacity command returned no aggregate limit"
+                        ),
+                    }
+                )
+            else:
+                payload["observed_command"] = probe_command
     except Exception as exc:
         failure = True
         payload = default_codex_account_capacity()
@@ -22414,6 +23200,20 @@ def _run_codex_account_capacity_probe() -> None:
                 pass
     _persist_codex_account_capacity(payload)
     _record_codex_account_capacity_probe(payload, failed=failure)
+    if payload.get("source") == "interactive_usage":
+        try:
+            maybe_start_subscription_capacity_self_improvement(
+                codex_account_capacity_snapshot(auth_mode=auth_mode)
+            )
+        except Exception as exc:
+            append_audit_event(
+                event_type="chat.subscription-self-improvement-skipped",
+                summary="Could not evaluate subscription self-improvement work.",
+                detail=type(exc).__name__,
+                severity="warn",
+                actor_type="system",
+                thread_id=read_text(THREAD_ID_PATH),
+            )
 
 
 def maybe_schedule_codex_account_capacity_probe(
@@ -22454,6 +23254,9 @@ def codex_subscription_capacity_route_decision(
     runtime: Any,
     model: Any,
     service_tier: Any,
+    prompt: Any = "",
+    job_budget: Any = "",
+    detail: Any = 2,
     route_lock: bool = False,
     service_tier_recovery: dict[str, Any] | None = None,
     capacity: dict[str, Any] | None = None,
@@ -22466,12 +23269,19 @@ def codex_subscription_capacity_route_decision(
         if capacity is None
         else normalize_codex_account_capacity(capacity)
     )
+    route_forecast = codex_subscription_capacity_route_forecast(
+        snapshot,
+        prompt=prompt,
+        job_budget=job_budget,
+        detail=detail,
+    )
     summary = {
         "state": snapshot.get("state"),
         "fresh": bool(snapshot.get("fresh")),
         "observed_at": _coerce_int(snapshot.get("observed_at")),
         "minimum_window_percent_left": snapshot.get("minimum_window_percent_left"),
         "reset_hint": snapshot.get("reset_hint"),
+        "forecast": route_forecast,
     }
     decision = {
         "enabled": CODEX_SUBSCRIPTION_ROUTE_PREFERENCE_ENABLED,
@@ -22494,8 +23304,8 @@ def codex_subscription_capacity_route_decision(
     if normalized_runtime != "codex":
         decision["reason"] = "non-Codex runtime selected"
         return decision
-    if not codex_subscription_capacity_personal_lane():
-        decision["reason"] = "console is not a personal subscription lane"
+    if not codex_subscription_capacity_route_lane():
+        decision["reason"] = "console is not an enabled subscription lane"
         return decision
     if snapshot.get("auth_mode") != "chatgpt":
         decision["reason"] = "Codex is not signed in with ChatGPT"
@@ -22510,6 +23320,18 @@ def codex_subscription_capacity_route_decision(
         CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT
     ):
         decision["reason"] = "subscription capacity is below the routing reserve"
+        return decision
+    if (
+        _coerce_int(route_forecast.get("reset_seconds"))
+        < CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS
+    ):
+        decision["reason"] = "subscription reset window is unavailable or too near"
+        return decision
+    if not route_forecast.get("turn_fits_reset"):
+        decision["reason"] = str(route_forecast.get("reason") or "")
+        return decision
+    if not route_forecast.get("fits_policy_envelope"):
+        decision["reason"] = str(route_forecast.get("reason") or "")
         return decision
     execution_tier = service_tier_execution_tier(normalized_tier)
     if execution_tier != "default" or not codex_profile_v2_for_service_tier(
@@ -22526,12 +23348,284 @@ def codex_subscription_capacity_route_decision(
     decision.update(
         {
             "selected": True,
-            "reason": "fresh ChatGPT subscription capacity preferred over Bedrock",
+            "reason": (
+                "fresh ChatGPT subscription capacity fits the reset-aware "
+                "forecast and is preferred over Bedrock"
+            ),
             "selected_model": direct_model,
             "selected_service_tier": "flex",
         }
     )
     return decision
+
+
+def codex_openai_direct_execution_decision(
+    service_tier: Any,
+    *,
+    auth_mode: Any = "",
+    prompt: Any = "",
+    job_budget: Any = "",
+    detail: Any = 2,
+    estimated_output_tokens: int | None = None,
+) -> dict[str, Any]:
+    normalized_tier = normalize_service_tier(service_tier)
+    provider_surface = (
+        str(usage_provider_tags(normalized_tier).get("provider_surface") or "")
+        .strip()
+        .lower()
+    )
+    observed_auth_mode = str(auth_mode or stored_codex_auth_mode()).strip().lower()
+    decision = {
+        "allowed": True,
+        "provider_surface": provider_surface,
+        "auth_mode": observed_auth_mode,
+        "api_spend_override": CODEX_ALLOW_OPENAI_API_SPEND,
+        "credit_extension_allowed": CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED,
+        "reason_code": "not_applicable",
+        "reason": "selected route does not use OpenAI direct",
+    }
+    if provider_surface != "openai-direct":
+        return decision
+    if observed_auth_mode == "chatgpt":
+        if CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED:
+            decision.update(
+                {
+                    "reason_code": "chatgpt_credit_extension_allowed",
+                    "reason": "verified ChatGPT subscription authentication",
+                }
+            )
+            return decision
+        capacity = codex_account_capacity_snapshot(auth_mode=observed_auth_mode)
+        minimum_percent_left = _coerce_int(capacity.get("minimum_window_percent_left"))
+        reset_seconds = codex_subscription_capacity_reset_seconds(capacity)
+        route_forecast = codex_subscription_capacity_route_forecast(
+            capacity,
+            prompt=prompt,
+            job_budget=job_budget,
+            detail=detail,
+            estimated_output_tokens=estimated_output_tokens,
+        )
+        decision["capacity"] = {
+            "state": capacity.get("state"),
+            "fresh": bool(capacity.get("fresh")),
+            "minimum_window_percent_left": capacity.get("minimum_window_percent_left"),
+            "reset_seconds": reset_seconds,
+            "plan_reserve_percent_left": CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT,
+            "forecast": route_forecast,
+        }
+        if (
+            bool(capacity.get("fresh"))
+            and capacity.get("state") == "available"
+            and minimum_percent_left >= CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT
+            and reset_seconds >= CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS
+            and bool(route_forecast.get("turn_fits_reset"))
+            and bool(route_forecast.get("fits_policy_envelope"))
+        ):
+            decision.update(
+                {
+                    "reason_code": "chatgpt_plan_capacity_verified",
+                    "reason": (
+                        "verified ChatGPT plan capacity is above the no-credit "
+                        "extension reserve"
+                    ),
+                }
+            )
+            return decision
+        decision.update(
+            {
+                "allowed": False,
+                "reason_code": "chatgpt_credit_extension_guard",
+                "reason": (
+                    "paid ChatGPT credit extension is disabled and fresh "
+                    "above-reserve plan capacity or a reset-aware turn forecast "
+                    "was not verified"
+                ),
+            }
+        )
+        return decision
+    if CODEX_ALLOW_OPENAI_API_SPEND:
+        decision.update(
+            {
+                "reason_code": "api_spend_override",
+                "reason": "explicit OpenAI API spend override",
+            }
+        )
+        return decision
+    decision.update(
+        {
+            "allowed": False,
+            "reason_code": "api_spend_disabled",
+            "reason": (
+                "OpenAI direct is blocked because Codex is not authenticated with "
+                "ChatGPT and API spending is disabled."
+            ),
+        }
+    )
+    return decision
+
+
+def codex_openai_direct_execution_block_message(decision: dict[str, Any]) -> str:
+    if decision.get("reason_code") == "chatgpt_credit_extension_guard":
+        return (
+            "OpenAI direct request blocked before launch: paid ChatGPT credit "
+            "extension is disabled and fresh subscription plan capacity above the "
+            "reserve or reset-aware turn forecast was not verified. No OpenAI API "
+            "request was sent. No paid ChatGPT credit extension was sent. Use "
+            "Norllama or Bedrock."
+        )
+    auth_mode = str(decision.get("auth_mode") or "unknown").strip() or "unknown"
+    return (
+        "OpenAI direct request blocked before launch: this console is authenticated "
+        f"as {auth_mode}, not ChatGPT, and API spending is disabled. "
+        "No OpenAI API request was sent. Use Norllama or Bedrock, sign in with "
+        "ChatGPT, or explicitly enable NORMAN_CODEX_ALLOW_OPENAI_API_SPEND."
+    )
+
+
+def is_subscription_capacity_self_improvement_prompt(prompt: Any) -> bool:
+    return SUBSCRIPTION_SELF_IMPROVEMENT_MARKER in str(prompt or "")
+
+
+def subscription_capacity_self_improvement_prompt() -> str:
+    return "\n".join(
+        [
+            SUBSCRIPTION_SELF_IMPROVEMENT_MARKER,
+            "Run one bounded, read-only self-improvement review of this Norman "
+            "workspace.",
+            "Inspect code, tests, and current local state only. Do not edit files, "
+            "run networked commands, use connectors, restart services, deploy, or "
+            "access secrets.",
+            "Return a concise ranked packet: the most valuable verified improvement, "
+            "supporting evidence with file references, a safe next implementation "
+            "step, and the focused verification command.",
+        ]
+    )
+
+
+def codex_subscription_self_improvement_decision(
+    capacity: dict[str, Any] | None = None,
+    *,
+    require_idle: bool = True,
+    now: int | None = None,
+) -> dict[str, Any]:
+    observed_now = _coerce_int(now) or now_ts()
+    snapshot = (
+        codex_account_capacity_snapshot(now=observed_now)
+        if capacity is None
+        else normalize_codex_account_capacity(capacity, now=observed_now)
+    )
+    route_forecast = codex_subscription_capacity_route_forecast(
+        snapshot,
+        prompt=subscription_capacity_self_improvement_prompt(),
+        job_budget="2m",
+        detail=2,
+        estimated_output_tokens=CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ESTIMATED_OUTPUT_TOKENS,
+    )
+    reset_seconds = _coerce_int(route_forecast.get("reset_seconds"))
+    decision = {
+        "eligible": False,
+        "reason": "subscription self-improvement is disabled",
+        "auth_mode": str(snapshot.get("auth_mode") or "").strip().lower(),
+        "capacity_percent_left": snapshot.get("minimum_window_percent_left"),
+        "reset_seconds": reset_seconds,
+        "reset_window_id": (
+            str((observed_now + reset_seconds) // 300) if reset_seconds else ""
+        ),
+        "forecast": route_forecast,
+    }
+    if not CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ENABLED:
+        return decision
+    if not codex_subscription_capacity_personal_lane():
+        decision["reason"] = "console is not a personal subscription lane"
+        return decision
+    if decision["auth_mode"] != "chatgpt" or stored_codex_auth_mode() != "chatgpt":
+        decision["reason"] = "ChatGPT authentication is not currently verified"
+        return decision
+    if not snapshot.get("fresh") or snapshot.get("state") != "available":
+        decision["reason"] = "subscription capacity is unavailable or stale"
+        return decision
+    if (
+        _coerce_int(snapshot.get("minimum_window_percent_left"))
+        < CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_PERCENT_LEFT
+    ):
+        decision["reason"] = (
+            "subscription capacity is below the self-improvement reserve"
+        )
+        return decision
+    if not (
+        CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_RESET_SECONDS
+        <= reset_seconds
+        <= CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MAX_RESET_SECONDS
+    ):
+        decision["reason"] = "subscription reset is outside the opportunistic window"
+        return decision
+    if not route_forecast.get("turn_fits_reset") or not route_forecast.get(
+        "fits_policy_envelope"
+    ):
+        decision["reason"] = str(route_forecast.get("reason") or "")
+        return decision
+    if require_idle:
+        meta = load_status_meta()
+        if (
+            bool(meta.get("pending"))
+            or bool(normalize_queue(meta.get("queued_prompts")))
+            or prompt_runtime_alive()
+            or prompt_thread_alive()
+        ):
+            decision["reason"] = "console is not idle"
+            return decision
+    decision.update(
+        {
+            "eligible": True,
+            "reason": "fresh subscription capacity is available near reset",
+        }
+    )
+    return decision
+
+
+def maybe_start_subscription_capacity_self_improvement(
+    capacity: dict[str, Any] | None = None,
+) -> bool:
+    decision = codex_subscription_self_improvement_decision(capacity)
+    if not decision["eligible"]:
+        return False
+    state = read_json(CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_STATE_PATH, {})
+    reset_window_id = str(decision["reset_window_id"])
+    if str(state.get("last_reset_window_id") or "") == reset_window_id:
+        return False
+    accepted, _snapshot = start_web_prompt(
+        subscription_capacity_self_improvement_prompt(),
+        "balanced",
+        2,
+        "2m",
+        runtime="codex",
+        service_tier="flex",
+        route_lock=True,
+        optimization_mode="raw",
+        source="system",
+    )
+    if not accepted:
+        return False
+    payload = {
+        "last_reset_window_id": reset_window_id,
+        "last_started_at": now_ts(),
+        "capacity_percent_left": decision["capacity_percent_left"],
+        "reset_seconds": decision["reset_seconds"],
+    }
+    write_json(CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_STATE_PATH, payload)
+    append_audit_event(
+        event_type="chat.subscription-self-improvement-started",
+        summary="Started a read-only self-improvement review before subscription reset.",
+        detail=(
+            f"{decision['capacity_percent_left']}% capacity remained with "
+            f"{decision['reset_seconds']} seconds to reset."
+        ),
+        severity="info",
+        actor_type="system",
+        thread_id=read_text(THREAD_ID_PATH),
+        payload=payload,
+    )
+    return True
 
 
 def usage_snapshot(
@@ -25563,6 +26657,7 @@ def save_status_meta(meta: dict[str, Any]) -> dict[str, Any]:
         )
     payload["live_turn"] = normalize_live_turn(payload.get("live_turn"))
     payload["turn_plan"] = normalize_turn_plan_estimate(payload.get("turn_plan"))
+    payload["working_recap"] = normalize_working_recap(payload.get("working_recap"))
     payload["updated_at"] = now_ts()
     write_json(STATUS_PATH, payload)
     return payload
@@ -25970,6 +27065,7 @@ def queue_prompt(
     interlace_mode: str = "",
     optimization_mode: str = "",
     cost_route: dict[str, Any] | None = None,
+    source: str = "",
 ) -> dict[str, Any]:
     duplicate_queue_position = 0
     duplicate_queue_state = ""
@@ -25977,7 +27073,7 @@ def queue_prompt(
         meta = load_status_meta()
         queue = normalize_queue(meta.get("queued_prompts"))
         normalized_relay = normalize_relay_callback(relay_callback)
-        source = normalize_queue_source("", normalized_relay, prompt)
+        source = normalize_queue_source(source, normalized_relay, prompt)
         position = len(queue) + 1
         normalized_attachments = normalize_attachments(attachments)
         normalized_service_tier = normalize_service_tier(service_tier)
@@ -26552,6 +27648,27 @@ def send_text(text: str) -> None:
     finally:
         run(tmux_cmd("delete-buffer", "-b", buffer_name))
     record_action("tmux-send", f"Sent raw text to tmux: {summarize_text(text, 140)}")
+
+
+def send_codex_status_probe() -> None:
+    """Submit /status after its paste has settled in older Codex TUI builds."""
+    if not ensure_session():
+        raise RuntimeError(f"{WORKER_SESSION_LABEL.capitalize()} could not be started.")
+    buffer_name = f"{SESSION}-status-{int(time.time() * 1000)}"
+    try:
+        run(
+            tmux_cmd("load-buffer", "-b", buffer_name, "-"),
+            input_text="/status",
+            check=True,
+        )
+        run(
+            tmux_cmd("paste-buffer", "-d", "-b", buffer_name, "-t", f"{SESSION}:0.0"),
+            check=True,
+        )
+        time.sleep(CODEX_ACCOUNT_CAPACITY_STATUS_SUBMIT_SETTLE_SECONDS)
+        run(tmux_cmd("send-keys", "-t", f"{SESSION}:0.0", "Enter"), check=True)
+    finally:
+        run(tmux_cmd("delete-buffer", "-b", buffer_name))
 
 
 def send_keys(*keys: str) -> None:
@@ -28039,7 +29156,7 @@ def bedrock_context_pack_plan(
         requested_model = normalized_model
     profile_v2 = codex_profile_v2_for_service_tier(normalized_service_tier)
     clean_session_id = str(session_id or "").strip()
-    if not BEDROCK_CONTEXT_PACK_ENABLED or not profile_v2 or not clean_session_id:
+    if not BEDROCK_CONTEXT_PACK_ENABLED or not clean_session_id:
         return {"should_pack": False, "reason": "not-applicable"}
 
     history = load_history(limit=MAX_HISTORY_ITEMS)
@@ -28160,6 +29277,7 @@ def bedrock_context_pack_plan(
 def bedrock_context_pack_prompt_context(plan: dict[str, Any]) -> str:
     if not plan or not plan.get("should_pack"):
         return ""
+    runtime_label = "Bedrock" if plan.get("profile_v2") else "Codex"
     history = [item for item in plan.get("history") or [] if isinstance(item, dict)]
     recent = history[-CONTEXT_PACK_RECENT_TURNS:]
     older_count = max(0, len(history) - len(recent))
@@ -28167,8 +29285,11 @@ def bedrock_context_pack_prompt_context(plan: dict[str, Any]) -> str:
     thread_scope = str(plan.get("thread_scope") or "")
     lines = [
         "",
-        "Bedrock compact-context handoff:",
-        "- This turn starts a fresh Bedrock thread because the previous Bedrock thread is high-context and low-yield risk.",
+        "Cloud compact-context handoff:",
+        (
+            f"- This turn starts a fresh {runtime_label} thread because the previous "
+            f"{runtime_label} thread is high-context and low-yield risk."
+        ),
         f"- Previous thread: {session_id or 'unknown'}"
         + (f" · scope: {thread_scope}" if thread_scope else ""),
         (
@@ -28229,7 +29350,62 @@ def _execute_codex_prompt(
     normalized_optimization_mode = normalize_optimization_mode(optimization_mode)
     normalized_budget = normalize_job_budget(job_budget)
     normalized_timeout = normalize_job_timeout_seconds(timeout_seconds, job_budget)
+    direct_execution = codex_openai_direct_execution_decision(
+        normalized_service_tier,
+        prompt=prompt,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+    )
+    if not direct_execution["allowed"]:
+        blocked_message = codex_openai_direct_execution_block_message(direct_execution)
+        return (
+            "",
+            blocked_message,
+            read_text(THREAD_ID_PATH),
+            normalize_usage_entry(
+                {
+                    "runtime": "codex",
+                    "model": model,
+                    "service_tier": normalized_service_tier,
+                    "provider_error_kind": "openai_api_spend_blocked",
+                    "provider_error_text": blocked_message,
+                }
+            ),
+        )
+    if is_subscription_capacity_self_improvement_prompt(prompt):
+        self_improvement = codex_subscription_self_improvement_decision(
+            require_idle=False
+        )
+        if not self_improvement["eligible"]:
+            blocked_message = (
+                "Subscription self-improvement review skipped before launch: "
+                f"{self_improvement['reason']}."
+            )
+            return (
+                "",
+                blocked_message,
+                read_text(THREAD_ID_PATH),
+                normalize_usage_entry(
+                    {
+                        "runtime": "codex",
+                        "model": model,
+                        "service_tier": normalized_service_tier,
+                        "provider_error_kind": "subscription_capacity_unavailable",
+                        "provider_error_text": blocked_message,
+                    }
+                ),
+            )
     target_timeout = job_budget_timeout_seconds(normalized_budget)
+    token_capacity_plan = provider_token_budget_plan(
+        prompt=prompt,
+        runtime="codex",
+        model=model,
+        service_tier=normalized_service_tier,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+        attachments=attachments,
+        enforcement="advisory",
+    )
     warning_checkpoints = deadline_warning_checkpoints(
         target_timeout, normalized_timeout
     )
@@ -28255,11 +29431,19 @@ def _execute_codex_prompt(
         if normalized_optimization_mode != "raw"
         else {"should_pack": False, "mode": "raw"}
     )
+    read_only_self_improvement = is_subscription_capacity_self_improvement_prompt(
+        prompt
+    )
+    sandbox_args = (
+        ["--sandbox", "read-only", "--ask-for-approval", "never"]
+        if read_only_self_improvement
+        else ["--dangerously-bypass-approvals-and-sandbox"]
+    )
     cmd = [
         CODEX_BIN,
         "exec",
         "--json",
-        "--dangerously-bypass-approvals-and-sandbox",
+        *sandbox_args,
         *codex_profile_v2_config_args(normalized_service_tier),
         "-m",
         normalized_model,
@@ -28276,16 +29460,28 @@ def _execute_codex_prompt(
         compact_context = bedrock_context_pack_prompt_context(context_pack_plan)
         if compact_context:
             old_session_id = session_id
+            context_pack_event_type = (
+                "chat.bedrock-context-packed"
+                if context_pack_plan.get("profile_v2")
+                else "chat.codex-context-packed"
+            )
+            context_pack_runtime_label = (
+                "Bedrock" if context_pack_plan.get("profile_v2") else "Codex"
+            )
             execution_prompt = f"{execution_prompt}\n{compact_context}".strip()
             session_id = ""
             write_text(THREAD_ID_PATH, "")
             write_text(THREAD_SCOPE_PATH, "")
             append_audit_event(
-                event_type="chat.bedrock-context-packed",
-                summary="Starting a fresh Bedrock thread with compact context handoff.",
+                event_type=context_pack_event_type,
+                summary=(
+                    f"Starting a fresh {context_pack_runtime_label} thread with "
+                    "compact context handoff."
+                ),
                 detail=(
                     f"Previous thread {old_session_id} exceeded context pack threshold; "
-                    "resume was skipped to reduce low-yield Bedrock turns."
+                    f"resume was skipped to reduce low-yield {context_pack_runtime_label} "
+                    "turns."
                 ),
                 severity="warn",
                 actor_type="system",
@@ -28364,12 +29560,39 @@ def _execute_codex_prompt(
 
     env = dict(os.environ)
     env["CODEX_HOME"] = CODEX_HOME
+    launch_direct_execution = codex_openai_direct_execution_decision(
+        normalized_service_tier,
+        prompt=prompt,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+    )
+    if not launch_direct_execution["allowed"]:
+        blocked_message = codex_openai_direct_execution_block_message(
+            launch_direct_execution
+        )
+        return (
+            "",
+            blocked_message,
+            read_text(THREAD_ID_PATH),
+            normalize_usage_entry(
+                {
+                    "runtime": "codex",
+                    "model": normalized_model,
+                    "service_tier": normalized_service_tier,
+                    "provider_error_kind": "openai_api_spend_blocked",
+                    "provider_error_text": blocked_message,
+                    "token_capacity_plan": token_capacity_plan,
+                }
+            ),
+        )
     if (
-        execution_service_tier in DIRECT_SERVICE_TIERS
-        and stored_codex_auth_mode() == "chatgpt"
+        not CODEX_ALLOW_OPENAI_API_SPEND
+        or launch_direct_execution["auth_mode"] == "chatgpt"
     ):
-        # A subscription-preferred launch must not inherit an ambient API key.
+        # Never let an inherited API key turn a Bedrock or plan-authenticated
+        # process into an OpenAI Platform charge.
         env.pop("OPENAI_API_KEY", None)
+        env.pop("CODEX_API_KEY", None)
     apply_codex_provider_environment(env, normalized_service_tier)
     checkpoint_interrupted = False
     deadline_checkpoint_interrupted = False
@@ -28527,6 +29750,7 @@ def _execute_codex_prompt(
         {
             **usage,
             **preflight_usage_fields,
+            "token_capacity_plan": token_capacity_plan,
             **codex_provider_diagnostics(
                 proc=proc,
                 events=codex_events,
@@ -29354,6 +30578,18 @@ def _execute_bedrock_converse_prompt(
     normalized_budget = normalize_job_budget(job_budget)
     normalized_timeout = normalize_job_timeout_seconds(timeout_seconds, job_budget)
     normalized_model = normalize_runtime_model("claude", model)
+    token_capacity_plan = provider_token_budget_plan(
+        prompt=prompt,
+        runtime="claude",
+        model=normalized_model,
+        service_tier=service_tier,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+        attachments=attachments,
+        cloud_authorized=True,
+        enforcement="request_hard",
+    )
+    execution_output_cap = token_capacity_plan["execution_output_cap"]
     thread_id = read_text(THREAD_ID_PATH) or f"bedrock-converse-{started_at}"
     tuned_prompt = build_prompt_with_attachments(
         prompt,
@@ -29409,7 +30645,7 @@ def _execute_bedrock_converse_prompt(
         {"role": "user", "content": [{"text": execution_prompt}]}
     ]
     tool_config = {"tools": bedrock_converse_tool_specs()}
-    inference_config = {"maxTokens": BEDROCK_CONVERSE_MAX_OUTPUT_TOKENS}
+    inference_config = {"maxTokens": execution_output_cap}
     response_text = ""
     error_text = ""
     usage = normalize_usage_entry(
@@ -29421,6 +30657,8 @@ def _execute_bedrock_converse_prompt(
             "service_tier": service_tier,
             "started_at": started_at,
             "thread_id": thread_id,
+            "provider_max_output_tokens": execution_output_cap,
+            "token_capacity_plan": token_capacity_plan,
         }
     )
     total_input = 0
@@ -29430,8 +30668,21 @@ def _execute_bedrock_converse_prompt(
     tool_rounds = 0
     model_calls = 0
     tool_budget_exhausted = False
+    output_budget_exhausted = False
     try:
         for _ in range(max(1, tool_budget + 1)):
+            remaining_output_tokens = execution_output_cap - total_output
+            if remaining_output_tokens <= 0:
+                output_budget_exhausted = True
+                response_text = (
+                    "BLOCKED — output-token capacity budget reached before the "
+                    "brokered runtime completed. Continue with the recorded "
+                    "evidence in a new turn or choose a longer job budget."
+                )
+                break
+            inference_config = {
+                "maxTokens": min(execution_output_cap, remaining_output_tokens)
+            }
             model_calls += 1
             response = call_bedrock_converse(
                 model_id=normalized_model,
@@ -29577,11 +30828,17 @@ def _execute_bedrock_converse_prompt(
             "broker_tool_rounds": tool_rounds,
             "broker_model_calls": model_calls,
             "broker_tool_budget_exhausted": tool_budget_exhausted,
+            "broker_output_token_budget": execution_output_cap,
+            "broker_output_budget_exhausted": output_budget_exhausted,
             "provider_yield_kind": "broker_tool_budget_checkpoint"
             if tool_budget_exhausted
+            else "broker_output_budget_checkpoint"
+            if output_budget_exhausted
             else "",
             "provider_yield_reasons": [f"broker tool budget reached: {tool_budget}"]
             if tool_budget_exhausted
+            else [f"broker output-token budget reached: {execution_output_cap}"]
+            if output_budget_exhausted
             else [],
         }
     )
@@ -30891,6 +32148,501 @@ def local_llm_response_text(payload: dict[str, Any]) -> str:
     return ""
 
 
+def _working_recap_sanitize_text(value: Any, limit: int = 240) -> str:
+    text = " ".join(str(value or "").replace("\r", "\n").split())
+    if not text:
+        return ""
+
+    def redact(match: re.Match[str]) -> str:
+        return f"{match.group('prefix')}[redacted]"
+
+    for pattern in (SENSITIVE_ASSIGNMENT_RE, SENSITIVE_QUERY_RE, SENSITIVE_BEARER_RE):
+        text = pattern.sub(redact, text)
+    return summarize_text(text, max(24, int(limit or 240)))
+
+
+def default_working_recap() -> dict[str, Any]:
+    return {
+        "schema": "norman.tui.working-recap.v1",
+        "turn_key": "",
+        "status": "idle",
+        "headline": "",
+        "now": "",
+        "milestones": [],
+        "next": "",
+        "updated_at": 0,
+        "last_attempt_at": 0,
+        "last_llm_at": 0,
+        "refreshing": False,
+        "source": "waiting",
+        "model": "",
+        "history": [],
+    }
+
+
+def _working_recap_history_entry(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "at": _coerce_int(value.get("updated_at")) or now_ts(),
+        "headline": _working_recap_sanitize_text(value.get("headline"), 180),
+        "now": _working_recap_sanitize_text(value.get("now"), 280),
+        "milestones": [
+            _working_recap_sanitize_text(item, 180)
+            for item in value.get("milestones") or []
+            if _working_recap_sanitize_text(item, 180)
+        ][:3],
+        "next": _working_recap_sanitize_text(value.get("next"), 220),
+        "source": str(value.get("source") or "deterministic").strip().lower()
+        or "deterministic",
+    }
+
+
+def _working_recap_history_signature(value: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        str(value.get("headline") or ""),
+        str(value.get("now") or ""),
+        tuple(str(item) for item in value.get("milestones") or []),
+        str(value.get("next") or ""),
+    )
+
+
+def normalize_working_recap(value: Any) -> dict[str, Any]:
+    payload = dict(default_working_recap())
+    if isinstance(value, dict):
+        payload.update(value)
+    payload["turn_key"] = str(payload.get("turn_key") or "").strip()[:96]
+    payload["status"] = str(payload.get("status") or "idle").strip().lower() or "idle"
+    if payload["status"] not in {"idle", "running", "complete"}:
+        payload["status"] = "running" if payload["turn_key"] else "idle"
+    payload["headline"] = _working_recap_sanitize_text(payload.get("headline"), 240)
+    payload["now"] = _working_recap_sanitize_text(payload.get("now"), 360)
+    payload["milestones"] = [
+        _working_recap_sanitize_text(item, 200)
+        for item in payload.get("milestones") or []
+        if _working_recap_sanitize_text(item, 200)
+    ][:3]
+    payload["next"] = _working_recap_sanitize_text(payload.get("next"), 260)
+    for key in ("updated_at", "last_attempt_at", "last_llm_at"):
+        payload[key] = _coerce_int(payload.get(key))
+    payload["refreshing"] = bool(payload.get("refreshing"))
+    payload["source"] = str(payload.get("source") or "waiting").strip().lower()
+    if payload["source"] not in {"waiting", "deterministic", "local_llm"}:
+        payload["source"] = "deterministic"
+    payload["model"] = _working_recap_sanitize_text(payload.get("model"), 96)
+    history: list[dict[str, Any]] = []
+    for item in payload.get("history") or []:
+        if not isinstance(item, dict):
+            continue
+        entry = _working_recap_history_entry(item)
+        if not entry["now"] and not entry["milestones"] and not entry["next"]:
+            continue
+        if history and _working_recap_history_signature(history[-1]) == (
+            _working_recap_history_signature(entry)
+        ):
+            history[-1]["at"] = max(history[-1]["at"], entry["at"])
+            continue
+        history.append(entry)
+    payload["history"] = history[-WORKING_RECAP_HISTORY_ITEMS:]
+    return payload
+
+
+def working_recap_turn_key(meta: dict[str, Any]) -> str:
+    started_at = _coerce_int(meta.get("last_started_at"))
+    prompt = str(meta.get("running_prompt") or "").strip()
+    if not started_at or not prompt:
+        return ""
+    digest = hashlib.sha256(prompt.encode("utf-8", errors="replace")).hexdigest()[:12]
+    return f"{started_at}-{digest}"
+
+
+def working_recap_task_category(plan: dict[str, Any]) -> str:
+    labels = {
+        str(item or "").strip().lower()
+        for item in plan.get("skill_labels") or []
+        if str(item or "").strip()
+    }
+    if "approval boundary check" in labels:
+        return "deployment or approval-boundary work"
+    if "code edit" in labels and "verification" in labels:
+        return "targeted implementation and verification"
+    if "code edit" in labels:
+        return "targeted implementation work"
+    if "verification" in labels:
+        return "system verification"
+    if "attachment review" in labels:
+        return "attached-material review"
+    if "cost accounting" in labels:
+        return "routing and cost review"
+    return "the active request"
+
+
+def working_recap_headline(plan: dict[str, Any]) -> str:
+    understood = _working_recap_sanitize_text(plan.get("understood_task"), 220)
+    if understood:
+        return understood
+    return f"Working through {working_recap_task_category(plan)}."
+
+
+def working_recap_live_activity(live: dict[str, Any]) -> tuple[str, list[str]]:
+    event_count = _coerce_int(live.get("event_count"))
+    tool_started = _coerce_int(live.get("tool_started_count"))
+    tool_finished = _coerce_int(live.get("tool_finished_count"))
+    decision_count = _coerce_int(live.get("decision_count"))
+    file_count = _coerce_int(live.get("file_interaction_count"))
+    status = str(live.get("last_tool_status") or "").strip().lower()
+    milestones: list[str] = []
+    if event_count:
+        milestones.append(
+            f"Observed {event_count} live event{'s' if event_count != 1 else ''}."
+        )
+    if tool_started:
+        if status in {"tool-finished", "finished", "complete", "completed"}:
+            milestones.append(
+                f"Completed {tool_finished or 1} tool checkpoint"
+                f"{'s' if (tool_finished or 1) != 1 else ''}."
+            )
+        else:
+            milestones.append(
+                f"Tool activity is in progress ({tool_finished}/{tool_started} complete)."
+            )
+    if file_count:
+        milestones.append(
+            f"Reviewed {file_count} workspace file{'s' if file_count != 1 else ''}."
+        )
+    elif decision_count:
+        milestones.append(
+            f"Recorded {decision_count} planning checkpoint"
+            f"{'s' if decision_count != 1 else ''}."
+        )
+    if status in {"tool-started", "started", "running"}:
+        now = "A live tool step is running; the next recap will fold in its result."
+    elif tool_finished:
+        now = "A tool checkpoint finished; the worker is evaluating what it found."
+    elif event_count:
+        now = "The worker is moving through live planning and execution signals."
+    else:
+        now = "The worker is preparing the first concrete step."
+    return now, milestones[:3]
+
+
+def deterministic_working_recap(
+    meta: dict[str, Any],
+    *,
+    queue_depth: int = 0,
+    observed_at: int = 0,
+) -> dict[str, Any]:
+    now = observed_at or now_ts()
+    plan = normalize_turn_plan_estimate(meta.get("turn_plan"))
+    live = normalize_live_turn(meta.get("live_turn"))
+    task_category = working_recap_task_category(plan)
+    activity_now, activity_milestones = working_recap_live_activity(live)
+    rate_limited = (
+        bool(meta.get("rate_limit_active"))
+        or str(meta.get("state") or "").lower() == "rate_limited"
+    )
+    handoff_running = str(meta.get("queue_handoff_state") or "").lower() == "running"
+    milestones = [
+        (
+            "Plan ready: "
+            + ", ".join(
+                _working_recap_sanitize_text(label, 56)
+                for label in plan.get("skill_labels") or []
+                if _working_recap_sanitize_text(label, 56)
+            )[:3]
+            + "."
+        )
+        if plan.get("skill_labels")
+        else f"Scope classified as {task_category}."
+    ]
+    milestones.extend(activity_milestones)
+    if queue_depth:
+        milestones.append(
+            f"{queue_depth} follow-up{'s' if queue_depth != 1 else ''} remain queued."
+        )
+    if rate_limited:
+        now_text = "Provider backoff is active; the worker will retry automatically."
+        next_text = "Wait for the retry window, then continue from the preserved turn."
+    elif handoff_running:
+        now_text = (
+            "A safe-checkpoint handoff is active; the earlier reply remains preserved."
+        )
+        next_text = "Finish the active handoff, then return the new reply."
+    else:
+        now_text = activity_now
+        plan_steps = [
+            _working_recap_sanitize_text(step, 180)
+            for step in plan.get("plan_steps") or []
+            if _working_recap_sanitize_text(step, 180)
+        ]
+        if _coerce_int(live.get("tool_started_count")) > _coerce_int(
+            live.get("tool_finished_count")
+        ):
+            next_text = "Use the current tool result to decide the next safe action."
+        elif len(plan_steps) > 1:
+            next_text = plan_steps[1]
+        elif plan_steps:
+            next_text = plan_steps[0]
+        else:
+            next_text = "Turn the current evidence into a concise reply."
+    recap = normalize_working_recap(
+        {
+            "turn_key": working_recap_turn_key(meta),
+            "status": "running",
+            "headline": working_recap_headline(plan),
+            "now": now_text,
+            "milestones": milestones[:3],
+            "next": next_text,
+            "updated_at": now,
+            "source": "deterministic",
+        }
+    )
+    return recap
+
+
+def working_recap_with_history(
+    recap: dict[str, Any], previous: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    normalized = normalize_working_recap(recap)
+    prior = normalize_working_recap(previous or {})
+    history = list(prior.get("history") or [])
+    entry = _working_recap_history_entry(normalized)
+    if entry["now"] or entry["milestones"] or entry["next"]:
+        if history and _working_recap_history_signature(history[-1]) == (
+            _working_recap_history_signature(entry)
+        ):
+            history[-1]["at"] = entry["at"]
+            history[-1]["source"] = entry["source"]
+        else:
+            history.append(entry)
+    normalized["history"] = history[-WORKING_RECAP_HISTORY_ITEMS:]
+    return normalize_working_recap(normalized)
+
+
+def working_recap_llm_packet(
+    meta: dict[str, Any], recap: dict[str, Any], *, queue_depth: int = 0
+) -> dict[str, Any]:
+    plan = normalize_turn_plan_estimate(meta.get("turn_plan"))
+    live = normalize_live_turn(meta.get("live_turn"))
+    started_at = _coerce_int(meta.get("last_started_at"))
+    return {
+        "task_class": working_recap_task_category(plan),
+        "route": {
+            "runtime": normalize_runtime(meta.get("running_runtime")),
+            "model": _working_recap_sanitize_text(meta.get("running_model"), 96),
+        },
+        "elapsed_seconds": max(0, now_ts() - started_at) if started_at else 0,
+        "queue_depth": max(0, int(queue_depth or 0)),
+        "live": {
+            "event_count": _coerce_int(live.get("event_count")),
+            "tool_started": _coerce_int(live.get("tool_started_count")),
+            "tool_finished": _coerce_int(live.get("tool_finished_count")),
+            "decision_count": _coerce_int(live.get("decision_count")),
+            "file_count": _coerce_int(live.get("file_interaction_count")),
+            "tool_state": (
+                "running"
+                if str(live.get("last_tool_status") or "").lower()
+                in {"tool-started", "started", "running"}
+                else "completed"
+                if _coerce_int(live.get("tool_finished_count"))
+                else "waiting"
+            ),
+        },
+        "deterministic_recap": {
+            "now": recap.get("now"),
+            "milestones": recap.get("milestones"),
+            "next": recap.get("next"),
+        },
+    }
+
+
+def working_recap_local_llm(
+    meta: dict[str, Any], recap: dict[str, Any], *, queue_depth: int = 0
+) -> tuple[dict[str, Any], str]:
+    if not WORKING_RECAP_ENABLED or not LOCAL_LLM_EXECUTION_ENABLED:
+        return {}, ""
+    packet = working_recap_llm_packet(meta, recap, queue_depth=queue_depth)
+    prompt = "\n".join(
+        [
+            "You write a short, factual progress recap for Norman's running TUI.",
+            "Use only this sanitized status packet. It deliberately contains no user prompt, terminal output, or secrets.",
+            "Do not invent completed work, access, commands, findings, or future outcomes.",
+            "Return JSON only with this exact shape:",
+            '{"now":"one short sentence","milestones":["up to three factual short sentences"],"next":"one short sentence"}',
+            "Keep each string readable in a compact operator panel.",
+            "STATUS_PACKET:",
+            json.dumps(packet, sort_keys=True),
+        ]
+    )
+    model = normalize_runtime_model("localllm", LOCAL_LLM_ROUTE_DEFAULT_MODEL)
+    endpoints = local_llm_candidate_endpoints(model, foreground=True)
+    for endpoint in endpoints:
+        try:
+            payload, _url, _adapter = local_llm_generate_once(
+                endpoint,
+                model,
+                prompt,
+                timeout_seconds=WORKING_RECAP_LLM_TIMEOUT_SECONDS,
+                max_output_tokens=WORKING_RECAP_LLM_MAX_OUTPUT_TOKENS,
+                num_ctx=LOCAL_LLM_SHORT_NUM_CTX,
+            )
+        except Exception:
+            continue
+        response = strip_local_planner_reasoning(local_llm_response_text(payload))
+        if not response:
+            continue
+        match = re.search(r"\{.*\}", response, flags=re.DOTALL)
+        if not match:
+            continue
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        candidate = normalize_working_recap(
+            {
+                "turn_key": recap.get("turn_key"),
+                "status": "running",
+                "headline": recap.get("headline"),
+                "now": parsed.get("now"),
+                "milestones": parsed.get("milestones"),
+                "next": parsed.get("next"),
+                "updated_at": now_ts(),
+                "source": "local_llm",
+                "model": model,
+            }
+        )
+        if candidate["now"] or candidate["milestones"] or candidate["next"]:
+            return candidate, model
+    return {}, ""
+
+
+def _working_recap_refresh_worker(turn_key: str) -> None:
+    try:
+        with STATUS_LOCK:
+            meta = load_status_meta()
+            if (
+                not bool(meta.get("pending"))
+                or working_recap_turn_key(meta) != turn_key
+            ):
+                return
+            previous = normalize_working_recap(meta.get("working_recap"))
+            deterministic = deterministic_working_recap(
+                meta,
+                queue_depth=len(normalize_queue(meta.get("queued_prompts"))),
+            )
+        generated, model = working_recap_local_llm(
+            meta,
+            deterministic,
+            queue_depth=len(normalize_queue(meta.get("queued_prompts"))),
+        )
+        refreshed_at = now_ts()
+        with STATUS_LOCK:
+            current = load_status_meta()
+            if (
+                not bool(current.get("pending"))
+                or working_recap_turn_key(current) != turn_key
+            ):
+                return
+            current_recap = normalize_working_recap(current.get("working_recap"))
+            base = deterministic_working_recap(
+                current,
+                queue_depth=len(normalize_queue(current.get("queued_prompts"))),
+                observed_at=refreshed_at,
+            )
+            base.update(
+                {
+                    "last_attempt_at": current_recap.get("last_attempt_at"),
+                    "last_llm_at": current_recap.get("last_llm_at"),
+                    "refreshing": False,
+                    "history": current_recap.get("history") or previous.get("history"),
+                }
+            )
+            if generated:
+                base.update(
+                    {
+                        "now": generated.get("now") or base["now"],
+                        "milestones": generated.get("milestones") or base["milestones"],
+                        "next": generated.get("next") or base["next"],
+                        "source": "local_llm",
+                        "model": model,
+                        "last_llm_at": refreshed_at,
+                    }
+                )
+            recap = working_recap_with_history(base, current_recap)
+            current["working_recap"] = recap
+            save_status_meta(current)
+    finally:
+        with WORKING_RECAP_LOCK:
+            WORKING_RECAP_ACTIVE_TURNS.discard(turn_key)
+
+
+def ensure_working_recap(
+    meta: dict[str, Any], *, pending: bool, queue_depth: int
+) -> dict[str, Any]:
+    current = normalize_working_recap(meta.get("working_recap"))
+    turn_key = working_recap_turn_key(meta)
+    if not pending or not turn_key:
+        if current["status"] == "running":
+            current["status"] = "complete"
+            current["refreshing"] = False
+        return normalize_working_recap(current)
+
+    deterministic = deterministic_working_recap(
+        meta, queue_depth=queue_depth, observed_at=now_ts()
+    )
+    needs_seed = current.get("turn_key") != turn_key
+    needs_early_refresh = (
+        current.get("source") == "deterministic"
+        and not _coerce_int(current.get("last_llm_at"))
+        and _working_recap_history_signature(current)
+        != _working_recap_history_signature(deterministic)
+    )
+    if needs_seed or needs_early_refresh:
+        deterministic.update(
+            {
+                "last_attempt_at": 0 if needs_seed else current.get("last_attempt_at"),
+                "last_llm_at": 0 if needs_seed else current.get("last_llm_at"),
+                "refreshing": False,
+                "history": [] if needs_seed else current.get("history"),
+            }
+        )
+        current = working_recap_with_history(deterministic, current)
+        with STATUS_LOCK:
+            latest = load_status_meta()
+            if working_recap_turn_key(latest) == turn_key:
+                latest["working_recap"] = current
+                save_status_meta(latest)
+
+    now = now_ts()
+    refreshing_stale = current.get("refreshing") and now - _coerce_int(
+        current.get("last_attempt_at")
+    ) > max(WORKING_RECAP_LLM_TIMEOUT_SECONDS * 2, 60)
+    due = WORKING_RECAP_ENABLED and (
+        not _coerce_int(current.get("last_attempt_at"))
+        or now - _coerce_int(current.get("last_attempt_at"))
+        >= WORKING_RECAP_REFRESH_SECONDS
+        or refreshing_stale
+    )
+    if due:
+        with WORKING_RECAP_LOCK:
+            if turn_key not in WORKING_RECAP_ACTIVE_TURNS:
+                WORKING_RECAP_ACTIVE_TURNS.add(turn_key)
+                current["refreshing"] = True
+                current["last_attempt_at"] = now
+                with STATUS_LOCK:
+                    latest = load_status_meta()
+                    if working_recap_turn_key(latest) == turn_key:
+                        latest["working_recap"] = current
+                        save_status_meta(latest)
+                threading.Thread(
+                    target=_working_recap_refresh_worker,
+                    args=(turn_key,),
+                    daemon=True,
+                    name=f"working-recap-{turn_key[-6:]}",
+                ).start()
+    return normalize_working_recap(current)
+
+
 def local_llm_execution_candidate_models(primary_model: Any) -> list[str]:
     primary = normalize_runtime_model("localllm", primary_model)
     candidates = [primary] if primary else []
@@ -31315,7 +33067,25 @@ def _execute_local_llm_prompt(
     final_output_shape = "empty"
     request_timeout = local_llm_foreground_timeout_seconds(timeout_seconds, job_budget)
     request_num_ctx = local_llm_num_ctx_for_budget(job_budget)
-    request_max_output_tokens = local_llm_max_output_tokens_for_budget(job_budget)
+    token_capacity_plan = provider_token_budget_plan(
+        prompt=prompt,
+        runtime="localllm",
+        model=normalized_model,
+        service_tier=service_tier,
+        job_budget=job_budget,
+        detail=detail,
+        attachments=attachments,
+        enforcement="request_hard",
+    )
+    request_max_output_tokens = local_llm_max_output_tokens_for_budget(
+        job_budget,
+        prompt=prompt,
+        detail=detail,
+        attachments=attachments,
+        model=normalized_model,
+        service_tier=service_tier,
+        capacity_plan=token_capacity_plan,
+    )
     if not error_text:
         for candidate_model in candidate_models:
             endpoints = candidate_endpoints.get(candidate_model) or []
@@ -31482,6 +33252,7 @@ def _execute_local_llm_prompt(
             "provider_timeout_seconds": request_timeout,
             "provider_num_ctx": request_num_ctx,
             "provider_max_output_tokens": request_max_output_tokens,
+            "token_capacity_plan": token_capacity_plan,
             "provider_error_text": summarize_text(error_text, 800),
             "output_shape": final_output_shape,
             **token_counts,
@@ -31764,18 +33535,31 @@ def console_runtime_kernel_primary_skip_reason(
     if normalize_attachments(attachments):
         return "attachments are not yet passed through the kernel visible-response path"
     normalized_runtime = normalize_runtime(runtime)
+    if is_subscription_capacity_self_improvement_prompt(prompt):
+        return "subscription self-improvement review must use direct Codex"
     if normalized_runtime == "localllm":
         return ""
+    if prompt_requires_cloud_or_tools(prompt):
+        return "prompt appears to require workspace tools"
     meta = load_status_meta()
     cost_route = meta.get("running_cost_route") if isinstance(meta, dict) else {}
     selected_runtime = normalize_runtime(
         cost_route.get("selected_runtime") if isinstance(cost_route, dict) else ""
     )
-    if selected_runtime == "localllm" or prompt_is_local_first_candidate(prompt):
-        if prompt_requires_cloud_or_tools(prompt):
-            return "prompt appears to require workspace tools"
+    route_lock = coerce_boolish(
+        cost_route.get("route_lock")
+        or cost_route.get("strict_route")
+        or cost_route.get("operator_model_override")
+        if isinstance(cost_route, dict)
+        else False
+    )
+    if route_lock:
+        return "operator route lock keeps the selected runtime"
+    if selected_runtime == "localllm" or prompt_is_local_final_response_candidate(
+        prompt
+    ):
         return ""
-    return "prompt was not classified as a local-first visible-response candidate"
+    return "Norllama is advisory preflight; selected cloud runtime is final authority"
 
 
 def console_runtime_kernel_owned_turn_active(skip_reason: str) -> bool:
@@ -32577,6 +34361,9 @@ def _execute_console_runtime_kernel_prompt(
         detail=detail,
         job_budget=job_budget,
     )
+    token_capacity_plan = normalize_provider_token_budget_plan(
+        run_shape.get("token_capacity_plan")
+    )
     payload = {
         "worker_id": f"tui-kernel-primary-{HOST_NAME}-{SESSION}"[:96],
         "dry_run": False,
@@ -32584,7 +34371,7 @@ def _execute_console_runtime_kernel_prompt(
         "continuous": True,
         "max_steps": run_shape["max_steps"],
         "max_runtime_seconds": max_runtime_seconds,
-        "local_token_budget": 0,
+        "local_token_budget": token_capacity_plan["local_token_budget"],
         "cloud_token_budget": 0,
         "goal_phase_sequence": list(run_shape["goal_phase_sequence"]),
         "planner_kind": run_shape["planner_kind"],
@@ -32619,6 +34406,9 @@ def _execute_console_runtime_kernel_prompt(
             "planner_kind": run_shape["planner_kind"],
             "goal_phase_sequence": list(run_shape["goal_phase_sequence"]),
             "output_shape_expected": run_shape["output_shape_expected"],
+            "local_token_budget": token_capacity_plan["local_token_budget"],
+            "cloud_token_budget": 0,
+            "token_capacity_plan": token_capacity_plan,
             "model_timeout_seconds": model_timeout,
             "provider_timeout_seconds": model_timeout,
         },
@@ -32646,7 +34436,9 @@ def _execute_console_runtime_kernel_prompt(
             "planner_kind": run_shape["planner_kind"],
             "goal_phase_sequence": list(run_shape["goal_phase_sequence"]),
             "output_shape_expected": run_shape["output_shape_expected"],
+            "local_token_budget": token_capacity_plan["local_token_budget"],
             "cloud_token_budget": 0,
+            "token_capacity_plan": token_capacity_plan,
             "model_timeout_seconds": model_timeout,
             "provider_timeout_seconds": model_timeout,
         },
@@ -32741,6 +34533,7 @@ def _execute_console_runtime_kernel_prompt(
     )
     usage["success"] = bool(response_text)
     usage["output_shape"] = output_shape
+    usage["token_capacity_plan"] = token_capacity_plan
     if not response_text and error_text:
         usage["kernel_failure_reason"] = summarize_text(error_text, 700)
     if result.get("model_failed"):
@@ -32848,6 +34641,10 @@ def _prompt_worker(
                 if isinstance(current_meta.get("running_cost_route"), dict)
                 else {}
             )
+            if running_cost_route:
+                running_cost_route["token_capacity_plan"] = turn_plan[
+                    "token_capacity_plan"
+                ]
             turn_envelope = build_turn_control_envelope(
                 prompt=prompt,
                 attachments=attachments,
@@ -34664,8 +36461,9 @@ def prompt_is_route_status_diagnostic(prompt: Any) -> bool:
         return False
     asks_status = bool(
         "?" in str(prompt or "")
-        or re.search(
-            r"\b(?:are|can|could|did|does|do|how|is|should|was|were|what|which|why)\b",
+        or re.match(
+            r"^\s*(?:(?:please|hey|hi)\s*[,:\-]?\s*)?"
+            r"(?:are|can|could|did|does|do|how|is|should|was|were|what|which|why)\b",
             lower,
         )
         or any(
@@ -34794,6 +36592,37 @@ def prompt_is_local_first_candidate(prompt: Any) -> bool:
     return any(marker in lower for marker in LOCAL_FIRST_SAFE_MARKERS)
 
 
+def prompt_is_local_final_response_candidate(prompt: Any) -> bool:
+    """Return whether Norllama may author the visible final response.
+
+    Local models remain useful for routing, prompt reduction, and drafts. Final
+    authority is intentionally narrower: a literal canary or an explicitly
+    self-contained, tool-free transformation. Status, planning, review, and
+    current-state questions must stay on the selected cloud/tool runtime.
+    """
+
+    if prompt_is_literal_response_request(prompt):
+        return True
+    if prompt_is_self_contained_response_request(prompt):
+        return True
+    lower = f" {prompt_core_request(str(prompt or '')).lower()} "
+    has_transform = bool(
+        re.search(
+            r"\b(?:classify|extract|rewrite|summari[sz]e|translate)\b",
+            lower,
+        )
+    )
+    has_explicit_local_scope = bool(
+        " following " in lower
+        or re.search(r"\b[a-z0-9_.:-]+\s*=\s*[^,\s.]+", lower)
+        or re.search(
+            r"\b(?:do not|don't|dont|without|no)\s+(?:use\s+)?tools?\b",
+            lower,
+        )
+    )
+    return bool(has_transform and has_explicit_local_scope)
+
+
 def cost_route_decision_for_prompt(
     *,
     prompt: str,
@@ -34832,6 +36661,8 @@ def cost_route_decision_for_prompt(
         "local_model": LOCAL_LLM_DEFAULT_MODEL,
         "local_min_text_b": LOCAL_LLM_MIN_TEXT_B,
         "local_lane": "",
+        "local_preflight_candidate": prompt_is_local_first_candidate(prompt),
+        "local_final_authority": False,
         "requested_action": requested_action,
         "operator_intent_class": intent_class,
         "mutation_risk": mutation_risk,
@@ -34882,6 +36713,7 @@ def cost_route_decision_for_prompt(
     if prompt_requires_cloud_or_tools(prompt):
         decision["reason"] = "prompt appears to require tools or workspace context"
         return decision
+    local_final_candidate = prompt_is_local_final_response_candidate(prompt)
     classifier_promoted = False
     classifier_lane = ""
     if not prompt_is_local_first_candidate(prompt):
@@ -34909,6 +36741,17 @@ def cost_route_decision_for_prompt(
                 f"; classifier {status}: {reason}" if status or reason else ""
             )
             return decision
+    if not local_final_candidate:
+        decision.update(
+            {
+                "route_source": "local_preflight_cloud_authority",
+                "reason": (
+                    "Norllama is retained for advisory preflight and drafting; "
+                    "the selected cloud runtime is final authority for this prompt"
+                ),
+            }
+        )
+        return decision
     local_lane = local_llm_prompt_lane(
         prompt,
         requested_action=requested_action,
@@ -35011,6 +36854,7 @@ def cost_route_decision_for_prompt(
             "selected_runtime": "localllm",
             "selected_model": local_model,
             "selected_service_tier": normalized_service_tier,
+            "local_final_authority": True,
             "route_source": "local_first_intent_classifier"
             if classifier_promoted
             else "local_first_policy",
@@ -35041,6 +36885,7 @@ def start_web_prompt(
     interlace_mode: str = "",
     route_lock: bool = False,
     optimization_mode: str = "",
+    source: str = "",
 ) -> tuple[bool, dict[str, Any]]:
     clean = prompt.strip()
     if not clean:
@@ -35161,6 +37006,9 @@ def start_web_prompt(
         runtime=cost_route_decision.get("selected_runtime"),
         model=cost_route_decision.get("selected_model"),
         service_tier=cost_route_decision.get("selected_service_tier"),
+        prompt=clean,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
         route_lock=route_lock,
         service_tier_recovery=service_tier_recovery,
     )
@@ -35194,10 +37042,10 @@ def start_web_prompt(
         )
         append_audit_event(
             event_type="chat.subscription-capacity-preferred",
-            summary="Fresh ChatGPT subscription capacity preferred over Bedrock.",
+            summary="Reset-aware ChatGPT subscription capacity preferred over Bedrock.",
             detail=(
                 "A default Bedrock Codex turn was moved to direct Flex after an "
-                "idle interactive capacity observation."
+                "idle capacity observation and reset-window forecast."
             ),
             severity="info",
             actor_type="system",
@@ -35225,6 +37073,73 @@ def start_web_prompt(
         normalized_runtime = selected_runtime
         normalized_model = selected_model
         normalized_service_tier = selected_service_tier
+    if normalized_runtime == "codex":
+        direct_execution = codex_openai_direct_execution_decision(
+            normalized_service_tier,
+            prompt=clean,
+            job_budget=normalized_budget,
+            detail=normalized_detail,
+        )
+        if not direct_execution["allowed"]:
+            if direct_execution.get(
+                "reason_code"
+            ) == "chatgpt_credit_extension_guard" and codex_profile_v2_for_service_tier(
+                "default"
+            ):
+                fallback_reason = str(direct_execution.get("reason") or "")
+                normalized_service_tier = "default"
+                normalized_model = normalize_runtime_model(
+                    "codex",
+                    codex_model_for_service_tier(
+                        normalized_service_tier, normalized_model
+                    ),
+                )
+                append_audit_event(
+                    event_type="chat.chatgpt-credit-extension-bedrock-fallback",
+                    summary="Protected ChatGPT credits by keeping the turn on Bedrock.",
+                    detail=fallback_reason,
+                    severity="info",
+                    actor_type="system",
+                    thread_id=read_text(THREAD_ID_PATH),
+                    payload={
+                        "runtime": normalized_runtime,
+                        "model": normalized_model,
+                        "service_tier": normalized_service_tier,
+                        "decision": direct_execution,
+                    },
+                )
+            else:
+                blocked_message = codex_openai_direct_execution_block_message(
+                    direct_execution
+                )
+                append_audit_event(
+                    event_type="chat.openai-api-spend-blocked",
+                    summary="Blocked a direct OpenAI request before queueing.",
+                    detail=blocked_message,
+                    severity="warn",
+                    actor_type="system",
+                    thread_id=read_text(THREAD_ID_PATH),
+                    payload={
+                        "runtime": normalized_runtime,
+                        "model": normalized_model,
+                        "service_tier": normalized_service_tier,
+                        "decision": direct_execution,
+                    },
+                )
+                snapshot = current_snapshot()
+                snapshot["openai_api_spend_blocked"] = True
+                snapshot["openai_api_spend_error"] = blocked_message
+                return False, snapshot
+    cost_route_decision["token_capacity_plan"] = provider_token_budget_plan(
+        prompt=clean,
+        runtime=normalized_runtime,
+        model=normalized_model,
+        service_tier=normalized_service_tier,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+        attachments=normalized_attachments,
+        cost_route=cost_route_decision,
+    )
     turn_envelope = build_turn_control_envelope(
         prompt=clean,
         attachments=normalized_attachments,
@@ -35242,7 +37157,7 @@ def start_web_prompt(
     turn_envelope["cost_route"] = dict(cost_route_decision)
     turn_envelope["requested_runtime"] = requested_runtime
     normalized_interlace_mode = normalize_queue_interlace_mode(interlace_mode)
-    normalized_source = normalize_queue_source("", normalized_relay_callback, clean)
+    normalized_source = normalize_queue_source(source, normalized_relay_callback, clean)
     recover_stale_prompt_state()
     should_queue = True
     deduplicated_existing = False
@@ -35546,6 +37461,7 @@ def start_web_prompt(
         interlace_mode=normalized_interlace_mode,
         optimization_mode=normalized_optimization_mode,
         cost_route=cost_route_decision,
+        source=normalized_source,
     )
     queued_snapshot["queued_cost_route"] = cost_route_decision
     if normalized_relay_callback and not queued_snapshot.get("deduplicated_prompt"):
@@ -35885,6 +37801,11 @@ def current_snapshot() -> dict[str, Any]:
             meta["status_message"] = snapshot_status
         save_status_meta(meta)
     running_prompt = str(meta.get("running_prompt") or "")
+    working_recap = ensure_working_recap(
+        meta,
+        pending=pending,
+        queue_depth=queue_depth,
+    )
     raw_resource_meter = load_resource_meter_file() or meta.get("resource_meter")
     resource_meter = normalize_resource_meter(
         raw_resource_meter,
@@ -36112,6 +38033,7 @@ def current_snapshot() -> dict[str, Any]:
             meta.get("live_turn"), pending=pending, observed_at=snapshot_at
         ),
         "turn_plan": normalize_turn_plan_estimate(meta.get("turn_plan")),
+        "working_recap": working_recap,
         "resource_meter": resource_meter,
         "bbs": current_bbs_summary(),
         "permissions_mode": "danger-full-access",
@@ -36253,6 +38175,7 @@ def snapshot_marker(snapshot: dict[str, Any]) -> tuple[Any, ...]:
         json.dumps(snapshot.get("runtime_capabilities") or {}, sort_keys=True),
         json.dumps(snapshot.get("local_first_proof") or {}, sort_keys=True),
         json.dumps(snapshot.get("live_turn") or {}, sort_keys=True),
+        json.dumps(snapshot.get("working_recap") or {}, sort_keys=True),
         json.dumps(snapshot.get("running_cost_route") or {}, sort_keys=True),
         json.dumps(snapshot.get("last_cost_route") or {}, sort_keys=True),
         (snapshot.get("runtime") or {}).get("next_after"),
@@ -45089,6 +47012,15 @@ class Handler(BaseHTTPRequestHandler):
         linear-gradient(90deg, color-mix(in srgb, var(--warn) 6%, transparent), transparent 54%),
         color-mix(in srgb, var(--surface-2) 52%, transparent);
     }}
+    .message.pending.live-status.working-on-message {{
+      max-width: min(88%, 780px);
+      padding: 10px 12px 11px;
+      border-color: color-mix(in srgb, var(--warn) 24%, var(--border));
+      background:
+        linear-gradient(180deg, color-mix(in srgb, var(--surface) 38%, transparent), transparent 76%),
+        linear-gradient(90deg, color-mix(in srgb, var(--warn) 7%, transparent), transparent 58%),
+        color-mix(in srgb, var(--surface-2) 54%, transparent);
+    }}
     .message.queued {{
       border-style: dashed;
       background: var(--surface-2);
@@ -45187,6 +47119,7 @@ class Handler(BaseHTTPRequestHandler):
     }}
     .message-route-chip,
     .message-cost-chip,
+    .message-value-chip,
     .message-estimate-chip {{
       display: inline-flex;
       align-items: center;
@@ -45245,6 +47178,26 @@ class Handler(BaseHTTPRequestHandler):
       border-color: color-mix(in srgb, #38bdf8 30%, var(--border));
       color: color-mix(in srgb, #38bdf8 62%, var(--text));
       background: color-mix(in srgb, #38bdf8 9%, var(--surface-2));
+    }}
+    .message-value-chip[data-value-tone="good"] {{
+      border-color: color-mix(in srgb, #22c55e 34%, var(--border));
+      color: color-mix(in srgb, #22c55e 66%, var(--text));
+      background: color-mix(in srgb, #22c55e 10%, var(--surface-2));
+    }}
+    .message-value-chip[data-value-tone="plan"] {{
+      border-color: color-mix(in srgb, #38bdf8 32%, var(--border));
+      color: color-mix(in srgb, #38bdf8 64%, var(--text));
+      background: color-mix(in srgb, #38bdf8 9%, var(--surface-2));
+    }}
+    .message-value-chip[data-value-tone="watch"] {{
+      border-color: color-mix(in srgb, var(--warn) 48%, var(--border));
+      color: color-mix(in srgb, var(--warn) 74%, var(--text));
+      background: color-mix(in srgb, var(--warn) 12%, var(--surface-2));
+    }}
+    .message-value-chip[data-value-tone="heavy"] {{
+      border-color: color-mix(in srgb, var(--danger) 48%, var(--border));
+      color: color-mix(in srgb, var(--danger) 74%, var(--text));
+      background: color-mix(in srgb, var(--danger) 12%, var(--surface-2));
     }}
     .message-estimate-chip[data-estimate-tone="quiet"] {{
       border-color: color-mix(in srgb, #22c55e 22%, var(--border));
@@ -45517,6 +47470,179 @@ class Handler(BaseHTTPRequestHandler):
       letter-spacing: 0.18em;
       font-size: 0.72rem;
       line-height: 1;
+    }}
+    .message.pending.live-status .message-body.working-on-body::before,
+    .message.pending.live-status .message-body.working-on-body::after {{
+      content: none;
+      display: none;
+    }}
+    .working-on-panel {{
+      display: grid;
+      gap: 8px;
+      max-width: min(100%, 82ch);
+      color: color-mix(in srgb, var(--text) 90%, var(--muted));
+    }}
+    .working-on-panel-head {{
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      min-width: 0;
+    }}
+    .working-on-kicker {{
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: color-mix(in srgb, var(--warn) 68%, var(--text));
+      font-family: var(--font-ui-wide);
+      font-size: 0.62rem;
+      font-weight: 760;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }}
+    .working-on-kicker::before {{
+      content: "";
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: color-mix(in srgb, var(--warn) 78%, white 8%);
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--warn) 10%, transparent);
+      animation: working-recap-pulse 1.8s ease-in-out infinite;
+    }}
+    .working-on-source {{
+      min-width: 0;
+      color: color-mix(in srgb, var(--muted) 74%, var(--text));
+      font-family: var(--font-label);
+      font-size: 0.62rem;
+      font-variant-numeric: tabular-nums;
+      text-align: right;
+      white-space: nowrap;
+    }}
+    .working-on-headline {{
+      color: color-mix(in srgb, var(--text) 94%, var(--agent-accent));
+      font-family: var(--font-reading);
+      font-size: 0.98rem;
+      font-weight: 680;
+      line-height: 1.3;
+    }}
+    .working-on-now {{
+      margin: 0;
+      color: color-mix(in srgb, var(--text) 82%, var(--muted));
+      font-size: 0.84rem;
+      line-height: 1.45;
+    }}
+    .working-on-milestones {{
+      display: grid;
+      gap: 4px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }}
+    .working-on-milestones li {{
+      position: relative;
+      padding-left: 13px;
+      color: color-mix(in srgb, var(--muted) 46%, var(--text));
+      font-size: 0.76rem;
+      line-height: 1.34;
+    }}
+    .working-on-milestones li::before {{
+      content: "";
+      position: absolute;
+      top: 0.48rem;
+      left: 1px;
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background: color-mix(in srgb, var(--agent-accent) 70%, var(--warn));
+    }}
+    .working-on-footer {{
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 5px 10px;
+      padding-top: 7px;
+      border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+      color: var(--muted);
+      font-family: var(--font-label);
+      font-size: 0.7rem;
+      line-height: 1.35;
+    }}
+    .working-on-next {{
+      flex: 1 1 280px;
+      min-width: 0;
+      color: color-mix(in srgb, var(--text) 78%, var(--muted));
+    }}
+    .working-on-elapsed {{
+      color: color-mix(in srgb, var(--muted) 74%, var(--text));
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }}
+    .working-on-timeline {{
+      margin-top: 1px;
+      color: var(--muted);
+      font-family: var(--font-body);
+      font-size: 0.72rem;
+    }}
+    .working-on-timeline summary {{
+      display: inline-flex;
+      align-items: center;
+      min-height: 24px;
+      cursor: pointer;
+      color: color-mix(in srgb, var(--text) 72%, var(--muted));
+      font-family: var(--font-label);
+      font-size: 0.68rem;
+      user-select: none;
+    }}
+    .working-on-timeline summary:hover,
+    .working-on-timeline summary:focus-visible {{
+      color: color-mix(in srgb, var(--text) 94%, var(--agent-accent));
+    }}
+    .working-on-timeline ol {{
+      display: grid;
+      gap: 7px;
+      margin: 5px 0 0;
+      padding: 7px 0 0 11px;
+      border-left: 1px solid color-mix(in srgb, var(--border) 64%, transparent);
+      list-style: none;
+    }}
+    .working-on-timeline li {{
+      display: grid;
+      gap: 2px;
+      min-width: 0;
+    }}
+    .working-on-timeline-stamp {{
+      color: color-mix(in srgb, var(--muted) 80%, var(--text));
+      font-family: var(--font-label);
+      font-size: 0.64rem;
+      font-variant-numeric: tabular-nums;
+    }}
+    .working-on-timeline-copy {{
+      color: color-mix(in srgb, var(--text) 74%, var(--muted));
+      line-height: 1.38;
+    }}
+    @keyframes working-recap-pulse {{
+      0%, 100% {{ opacity: 0.72; transform: scale(0.9); }}
+      50% {{ opacity: 1; transform: scale(1.08); }}
+    }}
+    @media (prefers-reduced-motion: reduce) {{
+      .working-on-kicker::before {{
+        animation: none;
+      }}
+    }}
+    @media (max-width: 640px) {{
+      .message.pending.live-status.working-on-message {{
+        max-width: 100%;
+      }}
+      .working-on-panel-head {{
+        align-items: flex-start;
+      }}
+      .working-on-source {{
+        max-width: 44%;
+        white-space: normal;
+      }}
+      .working-on-headline {{
+        font-size: 0.92rem;
+      }}
     }}
     .message-body > :first-child,
     .raw-view > :first-child {{
@@ -55881,6 +58007,7 @@ class Handler(BaseHTTPRequestHandler):
         last_error: String(last?.error || ""),
         queue_depth: Number(snapshot?.queue_depth || 0),
         live_turn: liveTurnRenderSignature(snapshot?.live_turn),
+        working_recap: snapshot?.working_recap || {{}},
       }});
     }}
 
@@ -56243,6 +58370,7 @@ class Handler(BaseHTTPRequestHandler):
         running_started_at: Number(snapshot?.last_started_at || 0),
         model_process_alive: Boolean(snapshot?.model_process_alive),
         live_turn: liveTurnRenderSignature(snapshot?.live_turn),
+        working_recap: snapshot?.working_recap || {{}},
         running_attachments: attachmentSignature(snapshot?.running_attachments),
         queued: queued.map((item) => ({{
           queued_at: Number(item?.queued_at || 0),
@@ -58935,7 +61063,153 @@ class Handler(BaseHTTPRequestHandler):
             ? "estimated"
             : totalTokens >= USAGE_POOR_YIELD_MIN_TOKENS
               ? "warn"
-            : "tokens",
+              : "tokens",
+        usd,
+        highUsd: cost.highUsd,
+        ledgerKind: rawLedgerKind,
+        displayUnit,
+        totalTokens,
+        isCodexCreditEstimate,
+      }};
+    }}
+
+    function turnCostFeedbackDescriptor(usage, snapshot = state.snapshot) {{
+      const cost = usageCostDescriptor(usage, snapshot);
+      if (!cost) {{
+        return null;
+      }}
+      const runtime = String(usage?.runtime || "").trim().toLowerCase();
+      const providerSurface = String(usage?.provider_surface || "").trim().toLowerCase();
+      const model = String(usage?.model || "").trim();
+      const localRoute = ["localllm", "codexspark"].includes(runtime)
+        || runtime.includes("norllama")
+        || runtime.includes("ollama")
+        || runtime.includes("spark")
+        || ["local", "norllama", "ollama"].includes(providerSurface);
+      const avoidedTokens = Math.max(
+        0,
+        Number(
+          usage?.cloud_tokens_avoided_estimate
+          || usage?.cloud_tokens_avoided_floor
+          || 0
+        )
+      );
+      const contextSavedTokens = Math.max(
+        0,
+        Number(usage?.context_pack_saved_tokens || 0)
+      );
+      const savingsTokens = Math.max(avoidedTokens, contextSavedTokens);
+      const netAvoidedTokens = Number(
+        usage?.cloud_preflight_net_token_delta_estimate || 0
+      );
+      const savingsMeta = savingsTokens > 0
+        ? `~${{formatCompactMetric(savingsTokens)}} cloud tok avoided`
+        : "";
+      const savingsTitle = [
+        "Estimated cloud input tokens avoided through local preflight, local tools, or context packing.",
+        savingsTokens ? `${{formatCount(savingsTokens)}} cloud tokens avoided` : "",
+        contextSavedTokens
+          ? `${{formatCount(contextSavedTokens)}} context tokens compacted`
+          : "",
+        netAvoidedTokens
+          ? `${{formatCount(netAvoidedTokens)}} net avoided after local preflight`
+          : "",
+        "This is a token-avoidance estimate, not an invoice saving.",
+      ].filter(Boolean).join(" · ");
+      if (savingsTokens >= 20_000) {{
+        return {{
+          label: `Big save · ${{formatCompactMetric(savingsTokens)}} tok`,
+          meta: "cloud avoided",
+          tone: "good",
+          title: [savingsTitle, cost.title].filter(Boolean).join(" · "),
+        }};
+      }}
+      if (savingsTokens >= 2_000) {{
+        return {{
+          label: `Saved · ${{formatCompactMetric(savingsTokens)}} tok`,
+          meta: "cloud avoided",
+          tone: "good",
+          title: [savingsTitle, cost.title].filter(Boolean).join(" · "),
+        }};
+      }}
+      if (localRoute) {{
+        return {{
+          label: "Good · local",
+          meta: "no cloud bill",
+          tone: "good",
+          title: [
+            "Completed on a local/Norllama route. No metered cloud-provider charge was recorded for this turn.",
+            "This does not include local hardware, electricity, or depreciation.",
+            cost.title,
+          ].filter(Boolean).join(" · "),
+        }};
+      }}
+      if (cost.isCodexCreditEstimate) {{
+        return {{
+          label: "Plan credits",
+          meta: cost.label || "usage estimated",
+          tone: "plan",
+          title: [
+            "Completed on the personal ChatGPT/Codex subscription lane.",
+            "This is an estimated plan-credit use, not a credit-card charge or a known balance deduction.",
+            cost.title,
+          ].filter(Boolean).join(" · "),
+        }};
+      }}
+      const estimatedUsd = Math.max(0, Number(cost.highUsd || cost.usd || 0));
+      if (estimatedUsd > 0) {{
+        if (estimatedUsd >= 0.75) {{
+          return {{
+            label: "Heavy",
+            meta: `~${{formatCompactUsd(estimatedUsd)}} cloud est`,
+            tone: "heavy",
+            title: [
+              "Large estimated cloud-provider turn. This is a local rate-card estimate, not an invoice.",
+              cost.title,
+            ].filter(Boolean).join(" · "),
+          }};
+        }}
+        if (estimatedUsd >= 0.15) {{
+          return {{
+            label: "High",
+            meta: `~${{formatCompactUsd(estimatedUsd)}} cloud est`,
+            tone: "watch",
+            title: [
+              "Higher estimated cloud-provider turn. This is a local rate-card estimate, not an invoice.",
+              cost.title,
+            ].filter(Boolean).join(" · "),
+          }};
+        }}
+        if (estimatedUsd >= 0.03) {{
+          return {{
+            label: "Watch",
+            meta: `~${{formatCompactUsd(estimatedUsd)}} cloud est`,
+            tone: "watch",
+            title: [
+              "Moderate estimated cloud-provider turn. This is a local rate-card estimate, not an invoice.",
+              cost.title,
+            ].filter(Boolean).join(" · "),
+          }};
+        }}
+        return {{
+          label: "Good",
+          meta: `~${{formatCompactUsd(estimatedUsd)}} cloud est`,
+          tone: "good",
+          title: [
+            "Low estimated cloud-provider turn. This is a local rate-card estimate, not an invoice.",
+            cost.title,
+          ].filter(Boolean).join(" · "),
+        }};
+      }}
+      const heavyTokens = cost.totalTokens >= 50_000;
+      return {{
+        label: heavyTokens ? "Token heavy" : "Tracked",
+        meta: `${{formatCompactMetric(cost.totalTokens)}} tok`,
+        tone: heavyTokens ? "watch" : "quiet",
+        title: [
+          "Token use is tracked, but no provider-price estimate is configured for this turn.",
+          cost.title,
+        ].filter(Boolean).join(" · "),
       }};
     }}
 
@@ -61492,6 +63766,33 @@ class Handler(BaseHTTPRequestHandler):
           ? `${{formatCompactUsd(lowUsd)}}-${{formatCompactUsd(highUsd)}}`
           : formatCompactUsd(highUsd)
         : `${{formatCompactMetric(inputTokens + outputTokens)}} tok`;
+      const billingTags = billing.tags && typeof billing.tags === "object"
+        ? billing.tags
+        : {{}};
+      const plannedOwner = String(
+        billingTags.billing_owner || snapshot?.accounting?.billing_owner || ""
+      ).trim().toLowerCase();
+      const plannedGroup = String(
+        billingTags.agent_group || snapshot?.accounting?.agent_group || ""
+      ).trim().toLowerCase();
+      const plannedAuthMode = String(
+        billingTags.codex_auth_mode || snapshot?.accounting?.codex_auth_mode || ""
+      ).trim().toLowerCase();
+      const plannedLocalRoute = ["localllm", "codexspark"].includes(selectedRuntime)
+        || selectedRuntime.includes("norllama")
+        || selectedRuntime.includes("ollama")
+        || selectedRuntime.includes("spark");
+      const plannedSubscriptionRoute = selectedRuntime === "codex"
+        && plannedOwner === "kristopher"
+        && plannedGroup !== "work"
+        && plannedAuthMode === "chatgpt";
+      const plannedSpendLabel = plannedLocalRoute
+        ? "Planned local · no cloud bill"
+        : plannedSubscriptionRoute
+          ? `Planned ${PLAN_CREDIT_LABEL} · ~${{formatCompactMetric(creditEstimate.credits)}} cr`
+          : hasUsd
+            ? `Planned cloud · ~${{nextCostLabel}}`
+            : "Planned token target";
       const resolvedLabel = selectedTier === effectiveTier
         ? serviceTierOption(selectedTier).short_label || selectedTier
         : `${{serviceTierOption(selectedTier).short_label || selectedTier}}→${{serviceTierOption(effectiveTier).short_label || effectiveTier}}`;
@@ -61517,13 +63818,20 @@ class Handler(BaseHTTPRequestHandler):
         ? "1 call"
         : `~${{turns.toFixed(1).replace(/\\.0$/, "")}} calls`;
       const label = [
+        plannedSpendLabel,
         `Target ${{jobBudgetControlLabel(preferences.jobBudget)}}`,
         visibleTurnLabel,
-        `next ~${{nextCostLabel}}`,
         `${{optimizationModeControlLabel(optimizationMode)}} / ${{resolvedLabel}}`,
       ].filter(Boolean).join(" · ");
       const title = [
         "Projected next prompt target and cost; local estimate, not invoice.",
+        plannedLocalRoute
+          ? "Planned local/Norllama route has no metered cloud-provider charge. Local hardware and electricity are not included."
+          : plannedSubscriptionRoute
+            ? `Planned personal ${PLAN_CREDIT_LABEL} estimate. It is not a credit-card charge or a known balance deduction.`
+            : hasUsd
+              ? `Planned cloud rate-card estimate ~${{nextCostLabel}}.`
+              : "No provider price card is available for this planned route.",
         "Work window is the primary control; depth affects answer effort; spend path is an emergency override.",
         `Window ${{jobBudgetLabel(preferences.jobBudget)}} estimates ${{turnLabel}}.`,
         `Input estimate ${{formatCount(inputTokens)}} tokens, cached ${{formatCount(cachedTokens)}}, output ${{formatCount(outputTokens)}}.`,
@@ -62146,6 +64454,32 @@ class Handler(BaseHTTPRequestHandler):
         meta,
         tone,
         title,
+        action: "system",
+      }};
+    }}
+
+    function spendFeedbackCapsuleState(snapshot) {{
+      const usage = snapshot && typeof snapshot === "object" ? snapshot.usage || {{}} : {{}};
+      const lastTurn = usage && typeof usage === "object" && usage.last_turn && typeof usage.last_turn === "object"
+        ? usage.last_turn
+        : null;
+      const feedback = turnCostFeedbackDescriptor(lastTurn, snapshot);
+      if (!feedback) {{
+        return null;
+      }}
+      return {{
+        id: "turn-spend",
+        label: "Spend",
+        value: feedback.label,
+        meta: feedback.meta,
+        tone: feedback.tone === "good"
+          ? "ok"
+          : feedback.tone === "heavy"
+            ? "alert"
+            : feedback.tone === "watch"
+              ? "warn"
+              : "active",
+        title: feedback.title,
         action: "system",
       }};
     }}
@@ -64486,6 +66820,10 @@ class Handler(BaseHTTPRequestHandler):
         capsules.push(sentinelCapsule);
       }}
       capsules.push(routeCostState(snapshot));
+      const spendFeedbackCapsule = spendFeedbackCapsuleState(snapshot);
+      if (spendFeedbackCapsule) {{
+        capsules.push(spendFeedbackCapsule);
+      }}
       capsules.push(billingCapsuleState(snapshot));
       const driftCapsule = driftCapsuleState(snapshot);
       if (driftCapsule) {{
@@ -67809,6 +70147,9 @@ class Handler(BaseHTTPRequestHandler):
       if (cleanRole.includes("pending")) {{
         article.classList.add("live-status");
       }}
+      if (options.workingRecap) {{
+        article.classList.add("working-on-message");
+      }}
       if (options.liveStatusStage) {{
         article.dataset.liveStatusStage = String(options.liveStatusStage || "");
       }}
@@ -67858,6 +70199,21 @@ class Handler(BaseHTTPRequestHandler):
         costNode.title = cost.title;
         costNode.setAttribute("aria-label", cost.title);
         metaWrap.appendChild(costNode);
+      }}
+      const costFeedback = turnCostFeedbackDescriptor(
+        options.usage,
+        options.usageSnapshot || state.snapshot
+      );
+      if (costFeedback && (cleanRole.includes("assistant") || cleanRole.includes("error"))) {{
+        const feedbackNode = document.createElement("span");
+        feedbackNode.className = "message-value-chip";
+        feedbackNode.dataset.valueTone = costFeedback.tone || "quiet";
+        feedbackNode.textContent = [costFeedback.label, costFeedback.meta]
+          .filter(Boolean)
+          .join(" · ");
+        feedbackNode.title = costFeedback.title;
+        feedbackNode.setAttribute("aria-label", costFeedback.title);
+        metaWrap.appendChild(feedbackNode);
       }}
       const effort = turnEffortLedgerDescriptor(options.historyItem || null, options.usage || null);
       if (effort && (cleanRole.includes("assistant") || cleanRole.includes("error"))) {{
@@ -67965,8 +70321,12 @@ class Handler(BaseHTTPRequestHandler):
 
       const text = document.createElement("div");
       text.className = "message-body";
-      const collapsedPrompt = collapsedPromptDescriptor(cleanRole, body, options);
-      if (collapsedPrompt) {{
+      if (cleanRole.includes("pending") && options.workingRecap) {{
+        text.classList.add("working-on-body");
+        text.replaceChildren(buildWorkingOnPanel(options.workingRecap, options.usageSnapshot || state.snapshot, body));
+      }} else {{
+        const collapsedPrompt = collapsedPromptDescriptor(cleanRole, body, options);
+        if (collapsedPrompt) {{
         text.innerHTML = `
           <button type="button" class="collapsed-prompt-toggle" aria-expanded="false">
             <span class="collapsed-prompt-badge">${{escapeHtml(collapsedPrompt.badge || "Text")}}</span>
@@ -67998,10 +70358,11 @@ class Handler(BaseHTTPRequestHandler):
             toggle.setAttribute("aria-expanded", opening ? "true" : "false");
           }});
         }}
-      }} else {{
-        text.innerHTML = cleanRole.includes("error")
-          ? renderErrorMarkup(body)
-          : renderRichText(body);
+        }} else {{
+          text.innerHTML = cleanRole.includes("error")
+            ? renderErrorMarkup(body)
+            : renderRichText(body);
+        }}
       }}
 
       article.appendChild(head);
@@ -68233,7 +70594,9 @@ class Handler(BaseHTTPRequestHandler):
         const elapsed = activityElapsed(snapshot);
         const modelState = snapshot.model_process_alive ? "model process alive" : "waiting for model process";
         const usageCopy = usageSummaryForActiveWork(snapshot);
-        const liveExpanded = liveStatusExpanded(snapshot, elapsed);
+        const workingRecap = workingRecapForSnapshot(snapshot);
+        const liveExpanded = liveStatusExpanded(snapshot, elapsed)
+          || Boolean(workingRecap.now || workingRecap.milestones.length || workingRecap.history.length > 1);
         const liveStatusBody = liveStatusBodyForSnapshot(snapshot, elapsed, usageCopy, modelState, liveExpanded);
         if (!runningPromptAlreadyVisible) {{
           appendMessage(
@@ -68261,6 +70624,8 @@ class Handler(BaseHTTPRequestHandler):
             sourcePrompt: snapshot.running_prompt || "",
             inlinePreviews: false,
             liveStatusStage: liveExpanded ? "expanded" : "initial",
+            workingRecap,
+            usageSnapshot: snapshot,
           }}
         );
       }}
@@ -68422,6 +70787,11 @@ class Handler(BaseHTTPRequestHandler):
       const tokens = Math.max(0, Number(plan.estimated_total_tokens || 0));
       const usd = Math.max(0, Number(plan.estimated_cost_usd || 0));
       const confidence = String(plan.estimate_confidence || "").trim();
+      const capacity = plan.token_capacity_plan && typeof plan.token_capacity_plan === "object"
+        ? plan.token_capacity_plan
+        : {{}};
+      const outputCap = Math.max(0, Number(capacity.execution_output_cap || 0));
+      const capacityProvider = String(capacity.provider_class || "").trim().replace(/_/g, " ");
       const parts = [];
       if (skillCount) {{
         parts.push(`${{formatCount(skillCount)}} skill${{skillCount === 1 ? "" : "s"}}`);
@@ -68436,6 +70806,9 @@ class Handler(BaseHTTPRequestHandler):
       }}
       if (usd && Boolean(plan.cost_configured)) {{
         parts.push(`~${{formatCompactUsd(usd)}} equiv`);
+      }}
+      if (outputCap) {{
+        parts.push(`${{capacityProvider || "provider"}} cap ${{formatCompactMetric(outputCap)}} out`);
       }}
       if (confidence && confidence !== "none") {{
         parts.push(`${{confidence}} confidence`);
@@ -68581,6 +70954,138 @@ class Handler(BaseHTTPRequestHandler):
         usageCopy ? `${{usageCopy}}.` : "",
         `${{modelState}}.`,
       ].filter(Boolean).join(" ");
+    }}
+
+    function workingRecapForSnapshot(snapshot = state.snapshot) {{
+      const recap = snapshot && typeof snapshot.working_recap === "object"
+        ? snapshot.working_recap
+        : {{}};
+      const milestones = Array.isArray(recap.milestones)
+        ? recap.milestones.map((item) => String(item || "").trim()).filter(Boolean).slice(0, 3)
+        : [];
+      const history = Array.isArray(recap.history)
+        ? recap.history
+          .filter((item) => item && typeof item === "object")
+          .map((item) => ({{
+            at: Number(item.at || 0),
+            now: String(item.now || "").trim(),
+            milestones: Array.isArray(item.milestones)
+              ? item.milestones.map((value) => String(value || "").trim()).filter(Boolean).slice(0, 3)
+              : [],
+            next: String(item.next || "").trim(),
+            source: String(item.source || "").trim().toLowerCase(),
+          }}))
+          .filter((item) => item.now || item.milestones.length || item.next)
+          .slice(-6)
+        : [];
+      return {{
+        status: String(recap.status || "").trim().toLowerCase(),
+        headline: String(recap.headline || "").trim(),
+        now: String(recap.now || "").trim(),
+        milestones,
+        next: String(recap.next || "").trim(),
+        updatedAt: Number(recap.updated_at || 0),
+        refreshing: Boolean(recap.refreshing),
+        source: String(recap.source || "").trim().toLowerCase(),
+        model: String(recap.model || "").trim(),
+        history,
+      }};
+    }}
+
+    function workingRecapSourceLabel(recap) {{
+      if (recap.refreshing) return "Refreshing local recap";
+      if (recap.source === "local_llm") return "Local recap";
+      return "Live recap";
+    }}
+
+    function buildWorkingOnPanel(recap, snapshot, fallbackBody = "") {{
+      const panel = document.createElement("section");
+      panel.className = "working-on-panel";
+      panel.setAttribute("aria-label", "Working on");
+
+      const top = document.createElement("div");
+      top.className = "working-on-panel-head";
+      const label = document.createElement("span");
+      label.className = "working-on-kicker";
+      label.textContent = "Working on";
+      top.appendChild(label);
+      const source = document.createElement("span");
+      source.className = "working-on-source";
+      source.textContent = workingRecapSourceLabel(recap);
+      if (recap.updatedAt) {{
+        source.title = `Last recap ${{formatTs(recap.updatedAt)}}${{recap.model ? ` via ${{recap.model}}` : ""}}`;
+      }}
+      top.appendChild(source);
+      panel.appendChild(top);
+
+      const headline = document.createElement("strong");
+      headline.className = "working-on-headline";
+      headline.textContent = recap.headline || "Preparing the active request.";
+      panel.appendChild(headline);
+
+      const now = document.createElement("p");
+      now.className = "working-on-now";
+      now.textContent = recap.now || fallbackBody || "The worker is preparing the first concrete step.";
+      panel.appendChild(now);
+
+      if (recap.milestones.length) {{
+        const milestones = document.createElement("ul");
+        milestones.className = "working-on-milestones";
+        for (const item of recap.milestones) {{
+          const milestone = document.createElement("li");
+          milestone.textContent = item;
+          milestones.appendChild(milestone);
+        }}
+        panel.appendChild(milestones);
+      }}
+
+      const footer = document.createElement("div");
+      footer.className = "working-on-footer";
+      if (recap.next) {{
+        const next = document.createElement("span");
+        next.className = "working-on-next";
+        next.textContent = `Next: ${{recap.next}}`;
+        footer.appendChild(next);
+      }}
+      const elapsed = activityElapsed(snapshot);
+      if (elapsed > 0) {{
+        const elapsedNode = document.createElement("span");
+        elapsedNode.className = "working-on-elapsed";
+        elapsedNode.textContent = `${{formatElapsedCompact(elapsed)}} elapsed`;
+        footer.appendChild(elapsedNode);
+      }}
+      if (footer.childElementCount) {{
+        panel.appendChild(footer);
+      }}
+
+      if (recap.history.length > 1) {{
+        const timeline = document.createElement("details");
+        timeline.className = "working-on-timeline";
+        const summary = document.createElement("summary");
+        const count = recap.history.length;
+        summary.textContent = `${{count}} recap update${{count === 1 ? "" : "s"}}`;
+        timeline.appendChild(summary);
+        const entries = document.createElement("ol");
+        for (const entry of recap.history.slice().reverse()) {{
+          const item = document.createElement("li");
+          const stamp = document.createElement("span");
+          stamp.className = "working-on-timeline-stamp";
+          stamp.textContent = entry.at ? formatTs(entry.at) : "Earlier";
+          item.appendChild(stamp);
+          const copy = document.createElement("span");
+          copy.className = "working-on-timeline-copy";
+          copy.textContent = [
+            entry.now,
+            ...(entry.milestones || []),
+            entry.next ? `Next: ${{entry.next}}` : "",
+          ].filter(Boolean).join(" ");
+          item.appendChild(copy);
+          entries.appendChild(item);
+        }}
+        timeline.appendChild(entries);
+        panel.appendChild(timeline);
+      }}
+      return panel;
     }}
 
     function routeDisplayName(runtime) {{
@@ -69272,6 +71777,7 @@ class Handler(BaseHTTPRequestHandler):
       const queued = queuedEntries(snapshot);
       if (snapshot.pending) {{
         const stage = inferWorkingStage(snapshot);
+        const workingRecap = workingRecapForSnapshot(snapshot);
         const elapsed = activityElapsed(snapshot);
         const handoffActive = String(snapshot.queue_handoff_state || "").toLowerCase() === "running";
         const startedParts = [];
@@ -69329,6 +71835,7 @@ class Handler(BaseHTTPRequestHandler):
           mode: "working",
           stripTitle: handoffActive ? "Interrupt handoff" : stage.line,
           stripDetail: [
+            workingRecap.now ? summarizePrompt(workingRecap.now, 112) : "",
             promptProfileText(snapshot.running_speed, snapshot.running_detail, snapshot.running_job_budget, snapshot.running_service_tier, snapshot.running_optimization_mode),
             startedParts.find((item) => item.includes("in flight")) || "",
             handoffActive ? "previous work preserved" : "",
@@ -69338,7 +71845,7 @@ class Handler(BaseHTTPRequestHandler):
             !elapsed && snapshot.last_started_at ? `started ${{formatTs(snapshot.last_started_at)}}` : "",
           ].filter(Boolean).join(" · "),
           peekTitle: handoffActive ? "Interrupt" : "Background",
-          simLine: `${{handoffActive ? "Interrupt handoff" : "Running"}}: ${{summarizePrompt(snapshot.running_prompt || "", 120)}}`,
+          simLine: `${{handoffActive ? "Interrupt handoff" : "Running"}}: ${{workingRecap.headline || summarizePrompt(snapshot.running_prompt || "", 120)}}`,
           simMeta: handoffActive
             ? [snapshot.queue_handoff_detail || "The queued prompt is running after a safe-checkpoint handoff.", ...startedParts, ...queuePreview]
             : [...startedParts, ...queuePreview],
@@ -69843,6 +72350,7 @@ class Handler(BaseHTTPRequestHandler):
       let statusText = snapshot.status_message || "Ready.";
       if (snapshot.pending && snapshot.running_prompt) {{
         const elapsed = activityElapsed(snapshot);
+        const workingRecap = workingRecapForSnapshot(snapshot);
         const handoffActive = String(snapshot.queue_handoff_state || "").toLowerCase() === "running";
         if (snapshot.rate_limit_active || snapshot.state === "rate_limited") {{
           statusText = [
@@ -69860,7 +72368,8 @@ class Handler(BaseHTTPRequestHandler):
           ].filter(Boolean).join(" · ");
         }} else {{
           statusText = [
-            `Running: ${{summarizePrompt(snapshot.running_prompt, 88)}}`,
+            `Running: ${{workingRecap.headline || summarizePrompt(snapshot.running_prompt, 88)}}`,
+            workingRecap.now ? summarizePrompt(workingRecap.now, 104) : "",
             elapsed > 0 ? `${{formatElapsedCompact(elapsed)}} elapsed` : "",
             promptProfileText(snapshot.running_speed, snapshot.running_detail, snapshot.running_job_budget, snapshot.running_service_tier, snapshot.running_optimization_mode),
             usageSummaryForActiveWork(snapshot),

--- a/scripts/build_norman_harness_pro_agent_pack.py
+++ b/scripts/build_norman_harness_pro_agent_pack.py
@@ -96,6 +96,7 @@ SCRIPT_FILES = (
     "scripts/sync_tui_microtextures.py",
     "scripts/systemd/norman-agent-console-sync-local.path",
     "scripts/systemd/norman-agent-console-sync-local.service",
+    "scripts/systemd/norman-agent-console-sync-personal-bedrock.conf",
     "scripts/systemd/norman-agent-console-sync-local.timer",
     "scripts/systemd/norman-bbs-doctor.path",
     "scripts/systemd/norman-bbs-doctor.service",

--- a/scripts/local_runtime_health.py
+++ b/scripts/local_runtime_health.py
@@ -18,9 +18,12 @@ SCHEMA = "norman.local-runtime-health.v1"
 DEFAULT_OUTPUT_JSON = Path("tmp/local_runtime_health.json")
 DEFAULT_OUTPUT_MD = Path("tmp/local_runtime_health.md")
 DEFAULT_OLLAMA_SENSE_JSON = Path("tmp/ollama_sense_live.json")
+DEFAULT_VLLM_SENSE_JSON = Path("tmp/vllm_sense_live.json")
 DEFAULT_OLLAMA_ENDPOINT = os.environ.get("OLLAMA_HOST", "http://127.0.0.1:11434")
-DEFAULT_VLLM_ENDPOINT = os.environ.get(
-    "NORMAN_SPARK_VLLM_BASE_URL", "http://127.0.0.1:8000"
+DEFAULT_VLLM_ENDPOINT = (
+    os.environ.get("NORMAN_SPARK_VLLM_BASE_URL", "").strip()
+    or os.environ.get("NORMAN_LOCAL_LLM_FRONTDOOR", "").strip()
+    or "https://llm.home.arpa"
 )
 
 
@@ -55,7 +58,7 @@ def load_optional_json(path: Path) -> dict[str, Any]:
         return {}
 
 
-def _best_usable_ollama_endpoint(report: dict[str, Any]) -> dict[str, Any]:
+def _best_usable_sensed_endpoint(report: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(report, dict):
         return {}
     best_endpoint = str(report.get("summary", {}).get("best_endpoint") or "").strip()
@@ -86,7 +89,7 @@ def _apply_ollama_sense_fallback(
     if row.get("routeable"):
         row["health_source"] = "direct_probe"
         return row
-    endpoint = _best_usable_ollama_endpoint(sense_report)
+    endpoint = _best_usable_sensed_endpoint(sense_report)
     if not endpoint:
         row["health_source"] = "direct_probe"
         return row
@@ -101,6 +104,31 @@ def _apply_ollama_sense_fallback(
         "model_count": len(models),
         "reason": "",
         "health_source": "ollama_sense_fallback",
+        "source_schema": str(sense_report.get("schema") or ""),
+        "endpoint_scope": str(endpoint.get("scope") or ""),
+        "latency_ms": int(endpoint.get("latency_ms") or 0),
+        "model_names": models,
+    }
+
+
+def _vllm_sense_runtime_row(sense_report: dict[str, Any]) -> dict[str, Any]:
+    endpoint = _best_usable_sensed_endpoint(sense_report)
+    if not endpoint:
+        return {}
+    endpoint_url = str(endpoint.get("endpoint") or "").strip().rstrip("/")
+    models = [str(model) for model in endpoint.get("models") or [] if str(model)]
+    return {
+        "runtime_class": "spark_vllm",
+        "provider": "vllm",
+        "endpoint": endpoint_url,
+        "models_url": f"{endpoint_url}/v1/models",
+        "command": "vllm",
+        "command_path": shutil.which("vllm") or "",
+        "status": "healthy",
+        "routeable": True,
+        "model_count": len(models),
+        "reason": "",
+        "health_source": "vllm_sense",
         "source_schema": str(sense_report.get("schema") or ""),
         "endpoint_scope": str(endpoint.get("scope") or ""),
         "latency_ms": int(endpoint.get("latency_ms") or 0),
@@ -146,9 +174,19 @@ def build_report(
     ollama_endpoint: str = DEFAULT_OLLAMA_ENDPOINT,
     vllm_endpoint: str = DEFAULT_VLLM_ENDPOINT,
     ollama_sense_report: dict[str, Any] | None = None,
+    vllm_sense_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     ollama = ollama_endpoint.rstrip("/")
     vllm = vllm_endpoint.rstrip("/")
+    vllm_row = _vllm_sense_runtime_row(vllm_sense_report or {})
+    if not vllm_row:
+        vllm_row = _runtime_row(
+            runtime_class="spark_vllm",
+            provider="vllm",
+            endpoint=vllm,
+            command="vllm",
+            models_url=f"{vllm}/v1/models",
+        )
     runtimes = [
         _apply_ollama_sense_fallback(
             _runtime_row(
@@ -160,13 +198,7 @@ def build_report(
             ),
             ollama_sense_report or {},
         ),
-        _runtime_row(
-            runtime_class="spark_vllm",
-            provider="vllm",
-            endpoint=vllm,
-            command="vllm",
-            models_url=f"{vllm}/v1/models",
-        ),
+        vllm_row,
     ]
     return {
         "schema": SCHEMA,
@@ -221,6 +253,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--ollama-sense-json", type=Path, default=DEFAULT_OLLAMA_SENSE_JSON
     )
+    parser.add_argument("--vllm-sense-json", type=Path, default=DEFAULT_VLLM_SENSE_JSON)
     parser.add_argument("--output-json", type=Path, default=DEFAULT_OUTPUT_JSON)
     parser.add_argument("--output-md", type=Path, default=DEFAULT_OUTPUT_MD)
     return parser.parse_args(argv)
@@ -232,6 +265,7 @@ def main(argv: list[str] | None = None) -> int:
         ollama_endpoint=args.ollama_endpoint,
         vllm_endpoint=args.vllm_endpoint,
         ollama_sense_report=load_optional_json(args.ollama_sense_json),
+        vllm_sense_report=load_optional_json(args.vllm_sense_json),
     )
     args.output_json.parent.mkdir(parents=True, exist_ok=True)
     args.output_json.write_text(

--- a/scripts/norman_codex_launch.sh
+++ b/scripts/norman_codex_launch.sh
@@ -125,11 +125,36 @@ STANDARD_AWS_PROFILE="${NORMAN_CODEX_STANDARD_AWS_PROFILE:-}"
 STANDARD_AWS_REGION="${NORMAN_CODEX_STANDARD_AWS_REGION:-}"
 CODEX_PROFILE_ARGS=()
 CODEX_SERVICE_TIER_ARGS=()
+CODEX_PROFILE_FLAG="${NORMAN_CODEX_PROFILE_CONFIG_FLAG:-}"
+if [[ -z "$CODEX_PROFILE_FLAG" ]]; then
+    CODEX_PROFILE_HELP="$("$CODEX_BIN" --help 2>&1 || true)"
+    HAS_PROFILE=0
+    HAS_PROFILE_V2=0
+    grep -Eq -- '(^|[[:space:],])--profile($|[[:space:],])' <<<"$CODEX_PROFILE_HELP" && HAS_PROFILE=1
+    grep -Eq -- '(^|[[:space:],])--profile-v2($|[[:space:],])' <<<"$CODEX_PROFILE_HELP" && HAS_PROFILE_V2=1
+    if [[ "$HAS_PROFILE" == "1" && "$HAS_PROFILE_V2" == "1" ]]; then
+        CODEX_VERSION="$("$CODEX_BIN" --version 2>/dev/null | awk '{print $2; exit}')"
+        IFS=. read -r CODEX_VERSION_MAJOR CODEX_VERSION_MINOR _ <<<"$CODEX_VERSION"
+        CODEX_VERSION_MAJOR="${CODEX_VERSION_MAJOR:-0}"
+        CODEX_VERSION_MINOR="${CODEX_VERSION_MINOR:-0}"
+        if (( CODEX_VERSION_MAJOR > 0 || CODEX_VERSION_MINOR >= 134 )); then
+            CODEX_PROFILE_FLAG="--profile"
+        else
+            CODEX_PROFILE_FLAG="--profile-v2"
+        fi
+    elif [[ "$HAS_PROFILE" == "1" ]]; then
+        CODEX_PROFILE_FLAG="--profile"
+    elif [[ "$HAS_PROFILE_V2" == "1" ]]; then
+        CODEX_PROFILE_FLAG="--profile-v2"
+    else
+        CODEX_PROFILE_FLAG="--profile"
+    fi
+fi
 
 case "${SERVICE_TIER,,}" in
 auto)
     if [[ -n "$STANDARD_PROFILE_V2" ]]; then
-        CODEX_PROFILE_ARGS=(--profile-v2 "$STANDARD_PROFILE_V2")
+        CODEX_PROFILE_ARGS=("$CODEX_PROFILE_FLAG" "$STANDARD_PROFILE_V2")
         MODEL="${STANDARD_MODEL:-$MODEL}"
         [[ -z "$STANDARD_AWS_PROFILE" ]] || export AWS_PROFILE="$STANDARD_AWS_PROFILE"
         [[ -z "$STANDARD_AWS_REGION" ]] || export AWS_REGION="$STANDARD_AWS_REGION"
@@ -137,7 +162,7 @@ auto)
     ;;
 default | standard | "")
     if [[ -n "$STANDARD_PROFILE_V2" ]]; then
-        CODEX_PROFILE_ARGS=(--profile-v2 "$STANDARD_PROFILE_V2")
+        CODEX_PROFILE_ARGS=("$CODEX_PROFILE_FLAG" "$STANDARD_PROFILE_V2")
         MODEL="${STANDARD_MODEL:-$MODEL}"
         [[ -z "$STANDARD_AWS_PROFILE" ]] || export AWS_PROFILE="$STANDARD_AWS_PROFILE"
         [[ -z "$STANDARD_AWS_REGION" ]] || export AWS_REGION="$STANDARD_AWS_REGION"

--- a/scripts/norman_codex_web.py
+++ b/scripts/norman_codex_web.py
@@ -71,10 +71,13 @@ AUTH_COOKIE_NAME = (
 AUTH_COOKIE_MAX_AGE = int(
     os.environ.get("NORMAN_CODEX_WEB_COOKIE_MAX_AGE", str(14 * 24 * 60 * 60))
 )
-DEFAULT_UI_VERSION = "2026.07.16.07"
+DEFAULT_UI_VERSION = "2026.07.16.14"
 UI_VERSION = (
     os.environ.get("NORMAN_CODEX_UI_VERSION", DEFAULT_UI_VERSION).strip()
     or DEFAULT_UI_VERSION
+)
+PLAN_CREDIT_LABEL = (
+    os.environ.get("NORMAN_PLAN_CREDIT_LABEL", "plan credits").strip() or "plan credits"
 )
 WEB_PROCESS_STARTED_AT = int(time.time())
 WEB_PROCESS_EVENT_LOCK = threading.Lock()
@@ -647,6 +650,80 @@ def int_env(name: str, default: int, *, minimum: int | None = None) -> int:
     return value
 
 
+def _token_capacity_float_env(name: str, default: float, *, minimum: float) -> float:
+    try:
+        value = float(str(os.environ.get(name, default)).strip())
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, value)
+
+
+TUI_TOKEN_CAPACITY_MIN_OUTPUT_TOKENS = int_env(
+    "NORMAN_TUI_TOKEN_CAPACITY_MIN_OUTPUT_TOKENS", 256, minimum=32
+)
+TUI_TOKEN_CAPACITY_CLOUD_MAX_OUTPUT_TOKENS = int_env(
+    "NORMAN_TUI_TOKEN_CAPACITY_CLOUD_MAX_OUTPUT_TOKENS", 8192, minimum=256
+)
+TUI_TOKEN_CAPACITY_TOTAL_BUDGET_FACTOR = _token_capacity_float_env(
+    "NORMAN_TUI_TOKEN_CAPACITY_TOTAL_BUDGET_FACTOR", 2.0, minimum=1.0
+)
+TUI_TOKEN_CAPACITY_WINDOW_FRACTION = min(
+    1.0,
+    _token_capacity_float_env(
+        "NORMAN_TUI_TOKEN_CAPACITY_WINDOW_FRACTION", 1.0, minimum=0.1
+    ),
+)
+TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS = int_env(
+    "NORMAN_TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS", 60 * 60, minimum=60
+)
+TUI_NORLLAMA_OUTPUT_TOKENS_PER_HOUR = int_env(
+    "NORMAN_TUI_NORLLAMA_OUTPUT_TOKENS_PER_HOUR", 48_000, minimum=1_000
+)
+TUI_BEDROCK_OUTPUT_TOKENS_PER_HOUR = int_env(
+    "NORMAN_TUI_BEDROCK_OUTPUT_TOKENS_PER_HOUR", 72_000, minimum=1_000
+)
+TUI_CODEX_OUTPUT_TOKENS_PER_HOUR = int_env(
+    "NORMAN_TUI_CODEX_OUTPUT_TOKENS_PER_HOUR", 60_000, minimum=1_000
+)
+TUI_OPENAI_OUTPUT_TOKENS_PER_HOUR = int_env(
+    "NORMAN_TUI_OPENAI_OUTPUT_TOKENS_PER_HOUR", 60_000, minimum=1_000
+)
+
+
+WORKING_RECAP_ENABLED = os.environ.get(
+    "NORMAN_CODEX_WORKING_RECAP_ENABLED", "1"
+).strip().lower() not in {"0", "false", "no", "off"}
+WORKING_RECAP_REFRESH_SECONDS = int_env(
+    "NORMAN_CODEX_WORKING_RECAP_REFRESH_SECONDS", 120, minimum=60
+)
+WORKING_RECAP_LLM_TIMEOUT_SECONDS = int_env(
+    "NORMAN_CODEX_WORKING_RECAP_LLM_TIMEOUT_SECONDS", 20, minimum=5
+)
+WORKING_RECAP_LLM_MAX_OUTPUT_TOKENS = int_env(
+    "NORMAN_CODEX_WORKING_RECAP_LLM_MAX_OUTPUT_TOKENS", 220, minimum=64
+)
+WORKING_RECAP_HISTORY_ITEMS = int_env(
+    "NORMAN_CODEX_WORKING_RECAP_HISTORY_ITEMS", 6, minimum=2
+)
+WORKING_RECAP_LOCAL_MODEL = (
+    os.environ.get("NORMAN_CODEX_WORKING_RECAP_MODEL")
+    or os.environ.get("NORMAN_LOCAL_LLM_MODEL")
+    or ""
+).strip()
+WORKING_RECAP_LOCAL_ENDPOINTS = tuple(
+    _dedupe_models(
+        endpoint
+        for raw in (
+            os.environ.get("NORMAN_CODEX_WORKING_RECAP_ENDPOINTS", ""),
+            os.environ.get("NORMAN_LOCAL_LLM_FRONTDOORS", ""),
+            "https://llm.home.arpa",
+            os.environ.get("NORMAN_LOCAL_LLM_ENDPOINTS", ""),
+        )
+        for endpoint in str(raw or "").split(",")
+    )
+)
+
+
 DIRECT_TIER_USAGE_LIMIT_RECOVERY_LOOKBACK = int_env(
     "NORMAN_CODEX_DIRECT_TIER_USAGE_LIMIT_RECOVERY_LOOKBACK", 24, minimum=1
 )
@@ -1110,6 +1187,50 @@ def resolve_codex_bin() -> str:
 
 
 CODEX_BIN = resolve_codex_bin()
+
+
+def resolve_codex_profile_config_flag() -> str:
+    configured = os.environ.get("NORMAN_CODEX_PROFILE_CONFIG_FLAG", "").strip()
+    if configured:
+        return configured
+    try:
+        completed = subprocess.run(
+            [CODEX_BIN, "exec", "--help"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "--profile"
+    help_text = f"{completed.stdout}\n{completed.stderr}"
+    has_profile = bool(re.search(r"(?<![\w-])--profile(?![\w-])", help_text))
+    has_profile_v2 = bool(re.search(r"(?<![\w-])--profile-v2(?![\w-])", help_text))
+    if has_profile and has_profile_v2:
+        try:
+            version = subprocess.run(
+                [CODEX_BIN, "--version"],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return "--profile-v2"
+        match = re.search(r"(\d+)\.(\d+)\.(\d+)", f"{version.stdout} {version.stderr}")
+        if match and tuple(int(part) for part in match.groups()) < (0, 134, 0):
+            return "--profile-v2"
+        return "--profile"
+    if has_profile:
+        return "--profile"
+    if has_profile_v2:
+        return "--profile-v2"
+    return "--profile"
+
+
+CODEX_PROFILE_CONFIG_FLAG = resolve_codex_profile_config_flag()
 OPENAI_BILLING_URL = (
     os.environ.get(
         "NORMAN_CODEX_OPENAI_BILLING_URL",
@@ -1206,12 +1327,24 @@ CODEX_ACCOUNT_CAPACITY_PROBE_POLL_SECONDS = min(
         ),
     ),
 )
+CODEX_ACCOUNT_CAPACITY_STATUS_SUBMIT_SETTLE_SECONDS = min(
+    3.0,
+    max(
+        0.1,
+        float(
+            os.environ.get(
+                "NORMAN_CODEX_ACCOUNT_CAPACITY_STATUS_SUBMIT_SETTLE_SECONDS",
+                "0.6",
+            )
+        ),
+    ),
+)
 CODEX_ACCOUNT_CAPACITY_HISTORY_ITEMS = max(
     20, int(os.environ.get("NORMAN_CODEX_ACCOUNT_CAPACITY_HISTORY_ITEMS", "2880"))
 )
 CODEX_ACCOUNT_CAPACITY_COMMAND = (
-    os.environ.get("NORMAN_CODEX_ACCOUNT_CAPACITY_COMMAND", "/usage").strip()
-    or "/usage"
+    os.environ.get("NORMAN_CODEX_ACCOUNT_CAPACITY_COMMAND", "/status").strip()
+    or "/status"
 )
 CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND = os.environ.get(
     "NORMAN_CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND", ""
@@ -1223,9 +1356,73 @@ CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT = min(
     100,
     max(
         1,
-        int(os.environ.get("NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT", "10")),
+        int(os.environ.get("NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT", "25")),
     ),
 )
+CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED = os.environ.get(
+    "NORMAN_CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED", "0"
+).strip().lower() in {"1", "true", "yes", "on"}
+CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS = max(
+    60,
+    int(os.environ.get("NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS", "300")),
+)
+CODEX_SUBSCRIPTION_ROUTE_FORECAST_CAP_FRACTION = min(
+    1.0,
+    _token_capacity_float_env(
+        "NORMAN_CODEX_SUBSCRIPTION_ROUTE_FORECAST_CAP_FRACTION",
+        0.5,
+        minimum=0.1,
+    ),
+)
+CODEX_ALLOW_OPENAI_API_SPEND = os.environ.get(
+    "NORMAN_CODEX_ALLOW_OPENAI_API_SPEND", "0"
+).strip().lower() in {"1", "true", "yes", "on"}
+CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED = os.environ.get(
+    "NORMAN_CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED", "0"
+).strip().lower() in {"1", "true", "yes", "on"}
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ENABLED = os.environ.get(
+    "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ENABLED", "0"
+).strip().lower() in {"1", "true", "yes", "on"}
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_PERCENT_LEFT = min(
+    100,
+    max(
+        CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT,
+        int(
+            os.environ.get(
+                "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_PERCENT_LEFT",
+                "70",
+            )
+        ),
+    ),
+)
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_RESET_SECONDS = max(
+    30,
+    int(
+        os.environ.get(
+            "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_RESET_SECONDS", "240"
+        )
+    ),
+)
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MAX_RESET_SECONDS = max(
+    CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_RESET_SECONDS,
+    int(
+        os.environ.get(
+            "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MAX_RESET_SECONDS", "1200"
+        )
+    ),
+)
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ESTIMATED_OUTPUT_TOKENS = int_env(
+    "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ESTIMATED_OUTPUT_TOKENS",
+    1200,
+    minimum=128,
+)
+CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_STATE_PATH = Path(
+    os.environ.get(
+        "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_STATE_PATH",
+        str(STATE_DIR / "subscription_self_improvement.json"),
+    )
+)
+SUBSCRIPTION_SELF_IMPROVEMENT_MARKER = "[norman-subscription-capacity-review-v1]"
 CODEX_ACCOUNT_CAPACITY_PROBE_LOCK = threading.Lock()
 CODEX_ACCOUNT_CAPACITY_PROBE_THREAD: threading.Thread | None = None
 BEDROCK_HEALTH_SMOKE_PATH = Path(
@@ -1308,11 +1505,13 @@ ATTACHMENTS_DIR = STATE_DIR / "attachments"
 
 PROMPT_LOCK = threading.Lock()
 STATUS_LOCK = threading.Lock()
+WORKING_RECAP_LOCK = threading.Lock()
 KPI_LOCK = threading.RLock()
 KPI_COLLECTOR_STARTED = False
 ACTIVE_PROMPT_THREAD: threading.Thread | None = None
 ACTIVE_CODEX_PROC: subprocess.Popen[str] | None = None
 ACTIVE_CODEX_LOCK = threading.Lock()
+WORKING_RECAP_ACTIVE_TURNS: set[str] = set()
 
 CANCELLED_WEB_REPLY_MESSAGE = (
     "Cancelled current web reply. The running model process was stopped before it "
@@ -3613,7 +3812,7 @@ def codex_profile_v2_config_args(value: Any) -> list[str]:
     profile = codex_profile_v2_for_service_tier(value)
     if not profile:
         return []
-    return ["--profile-v2", profile]
+    return [CODEX_PROFILE_CONFIG_FLAG, profile]
 
 
 def codex_aws_profile_for_service_tier(value: Any) -> str:
@@ -7798,9 +7997,9 @@ def _state_db_id(kind: str, payload: dict[str, Any]) -> str:
 def _state_db_connect() -> sqlite3.Connection | None:
     if not STATE_DB_ENABLED:
         return None
-    ensure_state_dir()
-    STATE_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     try:
+        ensure_state_dir()
+        STATE_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(STATE_DB_PATH), timeout=2)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
@@ -8018,7 +8217,7 @@ def _state_db_connect() -> sqlite3.Connection | None:
         )
         conn.commit()
         return conn
-    except sqlite3.Error:
+    except (OSError, sqlite3.Error):
         try:
             conn.close()  # type: ignore[name-defined]
         except Exception:
@@ -11246,6 +11445,7 @@ def default_status_meta() -> dict[str, Any]:
         "resource_meter": {},
         "live_turn": default_live_turn(),
         "turn_plan": default_turn_plan_estimate(),
+        "working_recap": default_working_recap(),
     }
 
 
@@ -13019,6 +13219,9 @@ def default_usage_entry() -> dict[str, Any]:
         "broker_tool_rounds": 0,
         "broker_model_calls": 0,
         "broker_tool_budget_exhausted": False,
+        "broker_output_token_budget": 0,
+        "broker_output_budget_exhausted": False,
+        "token_capacity_plan": {},
         "zero_token_provider_failure": False,
     }
 
@@ -13225,10 +13428,17 @@ def normalize_usage_entry(value: Any) -> dict[str, Any]:
         "broker_tool_calls",
         "broker_tool_rounds",
         "broker_model_calls",
+        "broker_output_token_budget",
     ):
         payload[key] = _coerce_int(payload.get(key))
     payload["broker_tool_budget_exhausted"] = bool(
         payload.get("broker_tool_budget_exhausted")
+    )
+    payload["broker_output_budget_exhausted"] = bool(
+        payload.get("broker_output_budget_exhausted")
+    )
+    payload["token_capacity_plan"] = normalize_provider_token_budget_plan(
+        payload.get("token_capacity_plan")
     )
     for key in (
         "raw_input_tokens",
@@ -14250,6 +14460,344 @@ TURN_PLAN_PROMPT_MARKERS = (
 )
 
 
+TOKEN_CAPACITY_PROVIDER_CLASSES = {
+    "norllama",
+    "bedrock",
+    "codex_subscription",
+    "openai_direct",
+}
+
+
+def default_provider_token_budget_plan() -> dict[str, Any]:
+    return {
+        "schema": "norman.tui.token-capacity-plan.v1",
+        "provider_class": "",
+        "target_seconds": 0,
+        "estimated_input_tokens": 0,
+        "estimated_output_tokens": 0,
+        "soft_output_tokens_per_hour": 0,
+        "recent_output_tokens": 0,
+        "recent_observed_output_tokens_per_hour": 0,
+        "recent_sample_count": 0,
+        "recent_window_seconds": TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS,
+        "remaining_soft_output_tokens": 0,
+        "time_window_output_cap": 0,
+        "execution_output_cap": 0,
+        "execution_total_token_budget": 0,
+        "local_token_budget": 0,
+        "cloud_token_budget": 0,
+        "cloud_authorized": False,
+        "capacity_source": "unavailable",
+        "confidence": "unknown",
+        "enforcement": "none",
+        "subscription_capacity_state": "",
+        "subscription_capacity_percent_left": None,
+        "subscription_capacity_fresh": False,
+        "subscription_reset_seconds": 0,
+    }
+
+
+def normalize_provider_token_budget_plan(value: Any) -> dict[str, Any]:
+    payload = dict(default_provider_token_budget_plan())
+    if isinstance(value, dict):
+        payload.update(value)
+    provider_class = str(payload.get("provider_class") or "").strip().lower()
+    payload["provider_class"] = (
+        provider_class if provider_class in TOKEN_CAPACITY_PROVIDER_CLASSES else ""
+    )
+    for key in (
+        "target_seconds",
+        "estimated_input_tokens",
+        "estimated_output_tokens",
+        "soft_output_tokens_per_hour",
+        "recent_output_tokens",
+        "recent_observed_output_tokens_per_hour",
+        "recent_sample_count",
+        "recent_window_seconds",
+        "remaining_soft_output_tokens",
+        "time_window_output_cap",
+        "execution_output_cap",
+        "execution_total_token_budget",
+        "local_token_budget",
+        "cloud_token_budget",
+        "subscription_reset_seconds",
+    ):
+        payload[key] = max(0, _coerce_int(payload.get(key)))
+    payload["cloud_authorized"] = bool(payload.get("cloud_authorized"))
+    payload["subscription_capacity_fresh"] = bool(
+        payload.get("subscription_capacity_fresh")
+    )
+    capacity_percent = payload.get("subscription_capacity_percent_left")
+    payload["subscription_capacity_percent_left"] = (
+        min(100, max(0, _coerce_int(capacity_percent)))
+        if capacity_percent is not None
+        else None
+    )
+    payload["capacity_source"] = (
+        str(payload.get("capacity_source") or "unavailable").strip() or "unavailable"
+    )
+    payload["confidence"] = (
+        str(payload.get("confidence") or "unknown").strip().lower() or "unknown"
+    )
+    payload["enforcement"] = (
+        str(payload.get("enforcement") or "none").strip().lower() or "none"
+    )
+    payload["subscription_capacity_state"] = str(
+        payload.get("subscription_capacity_state") or ""
+    ).strip()
+    return payload
+
+
+def token_capacity_provider_class(
+    runtime: Any,
+    service_tier: Any = "",
+    *,
+    cost_route: dict[str, Any] | None = None,
+) -> str:
+    normalized_runtime = normalize_runtime(runtime)
+    route = dict(cost_route or {})
+    charge_basis = str(route.get("charge_basis") or "").strip().lower()
+    if normalized_runtime == "localllm":
+        return "norllama"
+    provider_surface = (
+        str(usage_provider_tags(service_tier).get("provider_surface") or "")
+        .strip()
+        .lower()
+    )
+    if provider_surface == "aws-bedrock" or normalized_runtime in {
+        "claude",
+        "deepseek",
+        "gptoss",
+        "kimi",
+        "qwen",
+    }:
+        return "bedrock"
+    if (normalized_runtime == "codex" and charge_basis == "codex_credits") or (
+        normalized_runtime == "codex"
+        and usage_charge_ledger_kind(
+            {
+                "runtime": normalized_runtime,
+                "service_tier": service_tier,
+            }
+        )
+        == "chatgpt_codex_credit_estimate"
+    ):
+        return "codex_subscription"
+    return "openai_direct"
+
+
+def token_capacity_policy_output_tokens_per_hour(provider_class: str) -> int:
+    return {
+        "norllama": TUI_NORLLAMA_OUTPUT_TOKENS_PER_HOUR,
+        "bedrock": TUI_BEDROCK_OUTPUT_TOKENS_PER_HOUR,
+        "codex_subscription": TUI_CODEX_OUTPUT_TOKENS_PER_HOUR,
+        "openai_direct": TUI_OPENAI_OUTPUT_TOKENS_PER_HOUR,
+    }.get(provider_class, TUI_OPENAI_OUTPUT_TOKENS_PER_HOUR)
+
+
+def token_capacity_provider_request_ceiling(provider_class: str) -> int:
+    if provider_class == "bedrock":
+        return max(1, BEDROCK_CONVERSE_MAX_OUTPUT_TOKENS)
+    return TUI_TOKEN_CAPACITY_CLOUD_MAX_OUTPUT_TOKENS
+
+
+def token_capacity_usage_matches_provider(
+    entry: dict[str, Any], provider_class: str
+) -> bool:
+    normalized = normalize_usage_entry(entry)
+    runtime = normalize_runtime(normalized.get("runtime"))
+    surface = str(normalized.get("provider_surface") or "").strip().lower()
+    ledger_kind = str(normalized.get("charge_ledger_kind") or "").strip()
+    if provider_class == "norllama":
+        return runtime == "localllm" or surface in {"local", "norllama", "ollama"}
+    if provider_class == "bedrock":
+        return surface == "aws-bedrock" or runtime in {
+            "claude",
+            "deepseek",
+            "gptoss",
+            "kimi",
+            "qwen",
+        }
+    if provider_class == "codex_subscription":
+        return (
+            runtime == "codex"
+            and surface == "openai-direct"
+            and ledger_kind == "chatgpt_codex_credit_estimate"
+        )
+    return surface == "openai-direct" and ledger_kind != "chatgpt_codex_credit_estimate"
+
+
+def provider_token_budget_plan(
+    *,
+    prompt: str = "",
+    runtime: str,
+    model: str = "",
+    service_tier: str = "",
+    job_budget: str = "",
+    detail: int = 2,
+    attachments: list[dict[str, Any]] | None = None,
+    estimated_input_tokens: int | None = None,
+    estimated_output_tokens: int | None = None,
+    entries: list[dict[str, Any]] | None = None,
+    cost_route: dict[str, Any] | None = None,
+    cloud_authorized: bool | None = None,
+    enforcement: str = "",
+    now: int | None = None,
+) -> dict[str, Any]:
+    observed_now = _coerce_int(now) or now_ts()
+    normalized_runtime = normalize_runtime(runtime)
+    normalized_budget = normalize_job_budget(job_budget)
+    provider_class = token_capacity_provider_class(
+        normalized_runtime,
+        service_tier,
+        cost_route=cost_route,
+    )
+    target_seconds = job_budget_timeout_seconds(normalized_budget)
+    normalized_attachments = normalize_attachments(attachments or [])
+    input_tokens = (
+        max(0, int(estimated_input_tokens))
+        if estimated_input_tokens is not None
+        else _estimated_text_tokens(prompt)
+        + _estimated_attachment_tokens(normalized_attachments)
+    )
+    output_tokens = (
+        max(0, int(estimated_output_tokens))
+        if estimated_output_tokens is not None
+        else estimate_turn_output_tokens(
+            normalize_response_detail(detail), normalized_budget, prompt
+        )
+    )
+
+    all_entries = (
+        usage_entries_with_effective_deltas(
+            [normalize_usage_entry(item) for item in entries]
+        )
+        if entries is not None
+        else usage_entries_with_effective_deltas(load_usage_history())
+    )
+    recent_since = max(0, observed_now - TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS)
+    recent_entries = [
+        item
+        for item in all_entries
+        if token_capacity_usage_matches_provider(item, provider_class)
+        and _coerce_int(item.get("finished_at")) >= recent_since
+        and bool(item.get("success"))
+    ]
+    recent_output_tokens = sum(
+        max(0, _coerce_int(item.get("output_tokens"))) for item in recent_entries
+    )
+    timestamps = [
+        _coerce_int(item.get("finished_at"))
+        for item in recent_entries
+        if _coerce_int(item.get("finished_at"))
+    ]
+    observed_window_seconds = (
+        min(
+            TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS,
+            max(300, observed_now - min(timestamps)),
+        )
+        if timestamps
+        else 0
+    )
+    observed_output_tokens_per_hour = (
+        int(round(recent_output_tokens * 3600 / observed_window_seconds))
+        if observed_window_seconds
+        else 0
+    )
+    policy_output_tokens_per_hour = token_capacity_policy_output_tokens_per_hour(
+        provider_class
+    )
+    planned_window_cap = int(
+        policy_output_tokens_per_hour
+        * target_seconds
+        / 3600
+        * TUI_TOKEN_CAPACITY_WINDOW_FRACTION
+    )
+    remaining_soft_output_tokens = max(
+        0, policy_output_tokens_per_hour - recent_output_tokens
+    )
+    time_window_output_cap = min(planned_window_cap, remaining_soft_output_tokens)
+    provider_request_ceiling = token_capacity_provider_request_ceiling(provider_class)
+    minimum_output_tokens = min(
+        TUI_TOKEN_CAPACITY_MIN_OUTPUT_TOKENS, provider_request_ceiling
+    )
+    execution_output_cap = min(
+        provider_request_ceiling,
+        max(minimum_output_tokens, output_tokens or minimum_output_tokens),
+        max(minimum_output_tokens, time_window_output_cap),
+    )
+    execution_total_token_budget = max(
+        execution_output_cap,
+        int(math.ceil(execution_output_cap * TUI_TOKEN_CAPACITY_TOTAL_BUDGET_FACTOR)),
+    )
+    if cloud_authorized is None:
+        cloud_authorized = provider_class != "norllama"
+
+    capacity_source = "configured_policy"
+    confidence = "policy"
+    subscription_capacity: dict[str, Any] = {}
+    if provider_class == "codex_subscription":
+        subscription_capacity = codex_account_capacity_snapshot(
+            all_entries,
+            now=observed_now,
+        )
+        capacity_source = "configured_policy+subscription_forecast"
+        confidence = (
+            "subscription_observed"
+            if subscription_capacity.get("fresh")
+            else "subscription_stale"
+        )
+    elif recent_entries:
+        capacity_source = "configured_policy+observed_ledger"
+        confidence = "policy_with_observations"
+
+    if not enforcement:
+        enforcement = "request_hard" if provider_class == "bedrock" else "advisory"
+    return normalize_provider_token_budget_plan(
+        {
+            "provider_class": provider_class,
+            "target_seconds": target_seconds,
+            "estimated_input_tokens": input_tokens,
+            "estimated_output_tokens": output_tokens,
+            "soft_output_tokens_per_hour": policy_output_tokens_per_hour,
+            "recent_output_tokens": recent_output_tokens,
+            "recent_observed_output_tokens_per_hour": observed_output_tokens_per_hour,
+            "recent_sample_count": len(recent_entries),
+            "recent_window_seconds": (
+                observed_window_seconds or TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS
+            ),
+            "remaining_soft_output_tokens": remaining_soft_output_tokens,
+            "time_window_output_cap": time_window_output_cap,
+            "execution_output_cap": execution_output_cap,
+            "execution_total_token_budget": execution_total_token_budget,
+            "local_token_budget": (
+                execution_total_token_budget if provider_class == "norllama" else 0
+            ),
+            "cloud_token_budget": (
+                execution_total_token_budget
+                if provider_class != "norllama" and cloud_authorized
+                else 0
+            ),
+            "cloud_authorized": bool(cloud_authorized),
+            "capacity_source": capacity_source,
+            "confidence": confidence,
+            "enforcement": enforcement,
+            "subscription_capacity_state": str(
+                subscription_capacity.get("state") or ""
+            ),
+            "subscription_capacity_percent_left": subscription_capacity.get(
+                "minimum_window_percent_left"
+            ),
+            "subscription_capacity_fresh": bool(subscription_capacity.get("fresh")),
+            "subscription_reset_seconds": _coerce_int(
+                (subscription_capacity.get("forecast") or {}).get(
+                    "earliest_reset_seconds"
+                )
+            ),
+        }
+    )
+
+
 def default_turn_plan_estimate() -> dict[str, Any]:
     return {
         "schema": "norman.tui.turn-plan-estimate.v1",
@@ -14282,6 +14830,7 @@ def default_turn_plan_estimate() -> dict[str, Any]:
         "timeout_seconds": 0,
         "attachment_count": 0,
         "success": False,
+        "token_capacity_plan": default_provider_token_budget_plan(),
     }
 
 
@@ -14313,6 +14862,9 @@ def normalize_turn_plan_estimate(value: Any) -> dict[str, Any]:
     )
     payload["cost_configured"] = bool(payload.get("cost_configured"))
     payload["success"] = bool(payload.get("success"))
+    payload["token_capacity_plan"] = normalize_provider_token_budget_plan(
+        payload.get("token_capacity_plan")
+    )
     for key in (
         "understood_task",
         "plan_summary",
@@ -14536,6 +15088,17 @@ def build_turn_plan_estimate(
     output_tokens = estimate_turn_output_tokens(
         normalized_detail, normalized_budget, prompt
     )
+    token_capacity_plan = provider_token_budget_plan(
+        prompt=prompt,
+        runtime=normalized_runtime,
+        model=normalized_model,
+        service_tier=normalized_tier,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+        attachments=normalized_attachments,
+        estimated_input_tokens=input_tokens,
+        estimated_output_tokens=output_tokens,
+    )
     cost = estimate_usage_cost(
         {
             "input_tokens": input_tokens,
@@ -14585,6 +15148,7 @@ def build_turn_plan_estimate(
                 timeout_seconds, normalized_budget
             ),
             "attachment_count": len(normalized_attachments),
+            "token_capacity_plan": token_capacity_plan,
         }
     )
 
@@ -15671,6 +16235,7 @@ def default_codex_account_capacity() -> dict[str, Any]:
     return {
         "schema": "norman.codex-account-capacity.v1",
         "source": "unavailable",
+        "observed_command": "",
         "observed_at": 0,
         "last_probe_at": 0,
         "auth_mode": "",
@@ -15681,13 +16246,15 @@ def default_codex_account_capacity() -> dict[str, Any]:
         "minimum_window_percent_left": None,
         "windows": [],
         "reset_hint": "",
+        "credits_available": None,
+        "usage_limit_resets_available": None,
         "last_error": "",
         "eligible_for_subscription_route": False,
         "forecast": {},
     }
 
 
-def _capacity_reset_seconds(value: Any) -> int:
+def _capacity_reset_seconds(value: Any, *, observed_at: int | None = None) -> int:
     total = 0
     for amount, unit in re.findall(
         r"\b(\d+)\s*(days?|d|hours?|hrs?|hr|h|minutes?|mins?|min|m)\b",
@@ -15699,7 +16266,37 @@ def _capacity_reset_seconds(value: Any) -> int:
             total += _coerce_int(amount) * 60 * 60
         else:
             total += _coerce_int(amount) * 60
-    return total
+    if total:
+        return total
+    match = re.search(
+        r"\b(?P<hour>\d{1,2}):(?P<minute>\d{2})\s+on\s+"
+        r"(?P<day>\d{1,2})\s+(?P<month>[A-Za-z]{3,9})\b",
+        str(value or ""),
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return 0
+    observed = _coerce_int(observed_at) or now_ts()
+    observed_dt = datetime.fromtimestamp(observed)
+    stamp = (
+        f"{match.group('day')} {match.group('month').title()} "
+        f"{observed_dt.year} {match.group('hour')}:{match.group('minute')}"
+    )
+    candidate: datetime | None = None
+    for pattern in ("%d %b %Y %H:%M", "%d %B %Y %H:%M"):
+        try:
+            candidate = datetime.strptime(stamp, pattern)
+            break
+        except ValueError:
+            continue
+    if candidate is None:
+        return 0
+    if candidate < observed_dt:
+        try:
+            candidate = candidate.replace(year=candidate.year + 1)
+        except ValueError:
+            return 0
+    return max(0, int(candidate.timestamp() - observed))
 
 
 def _capacity_window_label(prefix: Any, line: Any) -> str:
@@ -15747,6 +16344,7 @@ def parse_codex_account_capacity_pane(
     )
     windows: list[dict[str, Any]] = []
     seen: set[tuple[str, int, str]] = set()
+    latest_window_index: int | None = None
     patterns = (
         (r"\b(?P<percent>\d{1,3})\s*%\s*(?:left|remaining|available)\b", True),
         (
@@ -15760,9 +16358,13 @@ def parse_codex_account_capacity_pane(
         line = re.sub(r"\s+", " ", raw_line).strip()
         if not line:
             continue
+        if re.search(r"\bcontext(?:\s+window)?\b", line, flags=re.IGNORECASE):
+            continue
         reset_hint = _capacity_reset_hint(line)
+        matched_capacity = False
         for pattern, reports_left in patterns:
             for match in re.finditer(pattern, line, flags=re.IGNORECASE):
+                matched_capacity = True
                 observed_percent = min(100, max(0, _coerce_int(match.group("percent"))))
                 percent_left = (
                     observed_percent if reports_left else 100 - observed_percent
@@ -15776,9 +16378,40 @@ def parse_codex_account_capacity_pane(
                             "label": label,
                             "percent_left": percent_left,
                             "reset_hint": reset_hint,
-                            "reset_seconds": _capacity_reset_seconds(reset_hint),
+                            "reset_seconds": _capacity_reset_seconds(
+                                reset_hint, observed_at=observed
+                            ),
                         }
                     )
+                    latest_window_index = len(windows) - 1
+        if (
+            reset_hint
+            and not matched_capacity
+            and latest_window_index is not None
+            and not windows[latest_window_index]["reset_hint"]
+        ):
+            windows[latest_window_index]["reset_hint"] = reset_hint
+            windows[latest_window_index]["reset_seconds"] = _capacity_reset_seconds(
+                reset_hint, observed_at=observed
+            )
+    credits_match = re.search(
+        r"\bcredits?\s*:\s*(?P<credits>[\d,]+)\s+credits?\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    resets_match = re.search(
+        r"\byou have\s+(?P<resets>\d+)\s+usage limit resets?\s+available\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if credits_match:
+        payload["credits_available"] = max(
+            0, _coerce_int(credits_match.group("credits").replace(",", ""))
+        )
+    if resets_match:
+        payload["usage_limit_resets_available"] = max(
+            0, _coerce_int(resets_match.group("resets"))
+        )
     lower = text.lower()
     explicit_limit = any(
         marker in lower
@@ -15818,6 +16451,9 @@ def normalize_codex_account_capacity(
         payload.update(value)
     payload["schema"] = "norman.codex-account-capacity.v1"
     payload["source"] = str(payload.get("source") or "unavailable").strip().lower()
+    payload["observed_command"] = (
+        str(payload.get("observed_command") or "").strip().lower()
+    )
     payload["observed_at"] = max(0, _coerce_int(payload.get("observed_at")))
     payload["last_probe_at"] = max(0, _coerce_int(payload.get("last_probe_at")))
     payload["auth_mode"] = str(payload.get("auth_mode") or "").strip().lower()
@@ -15844,11 +16480,24 @@ def normalize_codex_account_capacity(
                 "reset_seconds": max(
                     0,
                     _coerce_int(raw_window.get("reset_seconds"))
-                    or _capacity_reset_seconds(raw_window.get("reset_hint")),
+                    or _capacity_reset_seconds(
+                        raw_window.get("reset_hint"),
+                        observed_at=payload["observed_at"],
+                    ),
                 ),
             }
         )
     payload["windows"] = clean_windows
+    credits_available = payload.get("credits_available")
+    payload["credits_available"] = (
+        max(0, _coerce_int(credits_available))
+        if credits_available is not None
+        else None
+    )
+    resets_available = payload.get("usage_limit_resets_available")
+    payload["usage_limit_resets_available"] = (
+        max(0, _coerce_int(resets_available)) if resets_available is not None else None
+    )
     minimum = min((item["percent_left"] for item in clean_windows), default=None)
     payload["minimum_window_percent_left"] = minimum
     payload["capacity_percent_left"] = minimum
@@ -15955,6 +16604,103 @@ def codex_subscription_capacity_personal_lane() -> bool:
     )
 
 
+def codex_subscription_capacity_route_lane() -> bool:
+    if codex_subscription_capacity_personal_lane():
+        return True
+    return bool(
+        CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED
+        and semantic_agent_group(AGENT_SLUG, AGENT_GROUP) == "work"
+        and str(usage_billing_owner() or "").strip()
+    )
+
+
+def codex_subscription_capacity_reset_seconds(value: Any) -> int:
+    return min(
+        (
+            max(0, _coerce_int(item.get("reset_seconds")))
+            for item in (value.get("windows") if isinstance(value, dict) else [])
+            if isinstance(item, dict) and _coerce_int(item.get("reset_seconds")) > 0
+        ),
+        default=0,
+    )
+
+
+def codex_subscription_capacity_route_forecast(
+    capacity: dict[str, Any],
+    *,
+    prompt: Any = "",
+    job_budget: Any = "",
+    detail: Any = 2,
+    estimated_output_tokens: int | None = None,
+) -> dict[str, Any]:
+    """Build a conservative plan-capacity envelope, never a provider credit quote."""
+    snapshot = normalize_codex_account_capacity(capacity)
+    reset_seconds = codex_subscription_capacity_reset_seconds(snapshot)
+    normalized_budget = normalize_job_budget(job_budget)
+    target_seconds = job_budget_timeout_seconds(normalized_budget)
+    planned_output_tokens = (
+        max(0, _coerce_int(estimated_output_tokens))
+        if estimated_output_tokens is not None
+        else estimate_turn_output_tokens(
+            normalize_response_detail(detail),
+            normalized_budget,
+            str(prompt or ""),
+        )
+    )
+    policy_output_tokens_to_reset = (
+        int(
+            TUI_CODEX_OUTPUT_TOKENS_PER_HOUR
+            * reset_seconds
+            / 3600
+            * CODEX_SUBSCRIPTION_ROUTE_FORECAST_CAP_FRACTION
+        )
+        if reset_seconds
+        else 0
+    )
+    if policy_output_tokens_to_reset:
+        policy_output_tokens_to_reset = max(
+            TUI_TOKEN_CAPACITY_MIN_OUTPUT_TOKENS,
+            policy_output_tokens_to_reset,
+        )
+    observed_forecast = (
+        snapshot.get("forecast") if isinstance(snapshot.get("forecast"), dict) else {}
+    )
+    projected_tokens = max(
+        0,
+        _coerce_int(observed_forecast.get("projected_tokens_to_earliest_reset")),
+    )
+    projected_with_turn = projected_tokens + planned_output_tokens
+    reset_known = reset_seconds > 0
+    turn_fits_reset = reset_known and target_seconds <= reset_seconds
+    fits_policy_envelope = (
+        reset_known
+        and planned_output_tokens <= policy_output_tokens_to_reset
+        and projected_with_turn <= policy_output_tokens_to_reset
+    )
+    if not reset_known:
+        reason = "no subscription reset time was observed"
+    elif not turn_fits_reset:
+        reason = "planned turn extends beyond the subscription reset window"
+    elif not fits_policy_envelope:
+        reason = "planned turn exceeds the conservative subscription forecast"
+    else:
+        reason = "planned turn fits the conservative subscription reset forecast"
+    return {
+        "schema": "norman.codex-subscription-route-forecast.v1",
+        "reset_seconds": reset_seconds,
+        "target_seconds": target_seconds,
+        "estimated_output_tokens": planned_output_tokens,
+        "policy_output_tokens_to_reset": policy_output_tokens_to_reset,
+        "observed_projected_tokens_to_reset": projected_tokens,
+        "projected_tokens_to_reset_with_turn": projected_with_turn,
+        "reset_known": reset_known,
+        "turn_fits_reset": turn_fits_reset,
+        "fits_policy_envelope": fits_policy_envelope,
+        "reason": reason,
+        "credits_available_informational": snapshot.get("credits_available"),
+    }
+
+
 def codex_account_capacity_history(limit: int = 48) -> list[dict[str, Any]]:
     try:
         lines = CODEX_ACCOUNT_CAPACITY_HISTORY_PATH.read_text(
@@ -15975,6 +16721,10 @@ def codex_account_capacity_history(limit: int = 48) -> list[dict[str, Any]]:
                 "capacity_percent_left": item.get("capacity_percent_left"),
                 "minimum_window_percent_left": item.get("minimum_window_percent_left"),
                 "reset_hint": item.get("reset_hint"),
+                "credits_available": item.get("credits_available"),
+                "usage_limit_resets_available": item.get(
+                    "usage_limit_resets_available"
+                ),
                 "auth_mode": item.get("auth_mode"),
             }
         )
@@ -16009,12 +16759,21 @@ def codex_account_capacity_snapshot(
     )
     payload["eligible_for_subscription_route"] = bool(
         CODEX_SUBSCRIPTION_ROUTE_PREFERENCE_ENABLED
-        and codex_subscription_capacity_personal_lane()
+        and codex_subscription_capacity_route_lane()
         and payload["auth_mode"] == "chatgpt"
         and payload["fresh"]
         and payload["state"] == "available"
         and _coerce_int(payload.get("minimum_window_percent_left"))
         >= CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT
+        and codex_subscription_capacity_reset_seconds(payload)
+        >= CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS
+    )
+    payload["credit_extension_allowed"] = CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED
+    payload["plan_reserve_percent_left"] = CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT
+    payload["credit_extension_guard"] = (
+        "allowed"
+        if CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED
+        else "plan-capacity-required"
     )
     payload["history"] = codex_account_capacity_history()
     return payload
@@ -16030,6 +16789,8 @@ def _persist_codex_account_capacity(payload: dict[str, Any]) -> None:
             "capacity_percent_left": clean["capacity_percent_left"],
             "minimum_window_percent_left": clean["minimum_window_percent_left"],
             "reset_hint": clean["reset_hint"],
+            "credits_available": clean["credits_available"],
+            "usage_limit_resets_available": clean["usage_limit_resets_available"],
             "auth_mode": clean["auth_mode"],
         },
         sort_keys=True,
@@ -16068,7 +16829,9 @@ def _capture_codex_account_capacity_command(
     command: str, *, observed_at: int, auth_mode: str, baseline_pane: str
 ) -> dict[str, Any]:
     baseline_hash = _pane_hash(baseline_pane)
-    send_text(command)
+    if str(command or "").strip().lower() != "/status":
+        return {}
+    send_codex_status_probe()
     deadline = time.monotonic() + CODEX_ACCOUNT_CAPACITY_PROBE_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         time.sleep(CODEX_ACCOUNT_CAPACITY_PROBE_POLL_SECONDS)
@@ -16097,6 +16860,12 @@ def _codex_account_capacity_command_unsupported(value: Any, command: str) -> boo
     )
 
 
+def _safe_codex_account_capacity_probe_command(command: Any) -> str:
+    """Permit the read-only inspection command, never an account reset command."""
+    clean_command = str(command or "").strip().lower()
+    return "/status" if clean_command == "/status" else ""
+
+
 def _clear_codex_account_capacity_command() -> None:
     send_keys("Escape")
     send_keys("C-u")
@@ -16115,56 +16884,59 @@ def _run_codex_account_capacity_probe() -> None:
             pane=pane, auth_mode=auth_mode, pending=False
         ):
             return
-        sent_command = True
-        payload = _capture_codex_account_capacity_command(
-            CODEX_ACCOUNT_CAPACITY_COMMAND,
-            observed_at=observed_at,
-            auth_mode=auth_mode,
-            baseline_pane=pane,
+        probe_command = _safe_codex_account_capacity_probe_command(
+            CODEX_ACCOUNT_CAPACITY_COMMAND
         )
-        unsupported_command = (
-            not payload
-            and _codex_account_capacity_command_unsupported(
-                capture_pane(), CODEX_ACCOUNT_CAPACITY_COMMAND
-            )
-        )
-        if (
-            not payload
-            and not unsupported_command
-            and CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND
-            and CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND
-            != CODEX_ACCOUNT_CAPACITY_COMMAND
-        ):
-            _clear_codex_account_capacity_command()
-            payload = _capture_codex_account_capacity_command(
-                CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND,
-                observed_at=observed_at,
-                auth_mode=auth_mode,
-                baseline_pane=capture_pane(),
-            )
-            unsupported_command = (
-                not payload
-                and _codex_account_capacity_command_unsupported(
-                    capture_pane(), CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND
-                )
-            )
-        if not payload:
+        if not probe_command:
             payload = default_codex_account_capacity()
             payload.update(
                 {
-                    "source": (
-                        "unsupported_command" if unsupported_command else "probe_failed"
-                    ),
+                    "source": "probe_command_rejected",
                     "observed_at": observed_at,
                     "last_probe_at": observed_at,
                     "auth_mode": auth_mode,
                     "last_error": (
-                        "configured capacity command is unsupported by this Codex CLI"
-                        if unsupported_command
-                        else "interactive capacity command returned no aggregate limit"
+                        "automatic capacity probing only permits /status; "
+                        "/usage can consume an account limit reset"
                     ),
                 }
             )
+        else:
+            sent_command = True
+            payload = _capture_codex_account_capacity_command(
+                probe_command,
+                observed_at=observed_at,
+                auth_mode=auth_mode,
+                baseline_pane=pane,
+            )
+            unsupported_command = (
+                not payload
+                and _codex_account_capacity_command_unsupported(
+                    capture_pane(), probe_command
+                )
+            )
+            if not payload:
+                payload = default_codex_account_capacity()
+                payload.update(
+                    {
+                        "source": (
+                            "unsupported_command"
+                            if unsupported_command
+                            else "probe_failed"
+                        ),
+                        "observed_command": probe_command,
+                        "observed_at": observed_at,
+                        "last_probe_at": observed_at,
+                        "auth_mode": auth_mode,
+                        "last_error": (
+                            "configured capacity command is unsupported by this Codex CLI"
+                            if unsupported_command
+                            else "interactive capacity command returned no aggregate limit"
+                        ),
+                    }
+                )
+            else:
+                payload["observed_command"] = probe_command
     except Exception as exc:
         payload = default_codex_account_capacity()
         payload.update(
@@ -16206,6 +16978,20 @@ def _run_codex_account_capacity_probe() -> None:
             "auth_mode": payload.get("auth_mode"),
         },
     )
+    if payload.get("source") == "interactive_usage":
+        try:
+            maybe_start_subscription_capacity_self_improvement(
+                codex_account_capacity_snapshot(auth_mode=auth_mode)
+            )
+        except Exception as exc:
+            append_audit_event(
+                event_type="chat.subscription-self-improvement-skipped",
+                summary="Could not evaluate subscription self-improvement work.",
+                detail=type(exc).__name__,
+                severity="warn",
+                actor_type="system",
+                thread_id=read_text(THREAD_ID_PATH),
+            )
 
 
 def maybe_schedule_codex_account_capacity_probe(
@@ -16219,7 +17005,13 @@ def maybe_schedule_codex_account_capacity_probe(
         return False
     capacity = codex_account_capacity_snapshot(auth_mode=configured_auth_mode)
     interval_seconds = CODEX_ACCOUNT_CAPACITY_POLL_INTERVAL_SECONDS
-    if str(capacity.get("source") or "").strip().lower() == "unsupported_command":
+    probe_command = _safe_codex_account_capacity_probe_command(
+        CODEX_ACCOUNT_CAPACITY_COMMAND
+    )
+    if (
+        str(capacity.get("source") or "").strip().lower() == "unsupported_command"
+        and str(capacity.get("observed_command") or "").strip().lower() == probe_command
+    ):
         interval_seconds = CODEX_ACCOUNT_CAPACITY_UNSUPPORTED_BACKOFF_SECONDS
     if (
         capacity["last_probe_at"]
@@ -16247,6 +17039,9 @@ def codex_subscription_capacity_route_decision(
     runtime: Any,
     model: Any,
     service_tier: Any,
+    prompt: Any = "",
+    job_budget: Any = "",
+    detail: Any = 2,
     route_lock: bool = False,
     service_tier_recovery: dict[str, Any] | None = None,
     capacity: dict[str, Any] | None = None,
@@ -16258,6 +17053,12 @@ def codex_subscription_capacity_route_decision(
         codex_account_capacity_snapshot()
         if capacity is None
         else normalize_codex_account_capacity(capacity)
+    )
+    route_forecast = codex_subscription_capacity_route_forecast(
+        snapshot,
+        prompt=prompt,
+        job_budget=job_budget,
+        detail=detail,
     )
     decision = {
         "enabled": CODEX_SUBSCRIPTION_ROUTE_PREFERENCE_ENABLED,
@@ -16272,6 +17073,7 @@ def codex_subscription_capacity_route_decision(
             "observed_at": _coerce_int(snapshot.get("observed_at")),
             "minimum_window_percent_left": snapshot.get("minimum_window_percent_left"),
             "reset_hint": snapshot.get("reset_hint"),
+            "forecast": route_forecast,
         },
     }
     if not CODEX_SUBSCRIPTION_ROUTE_PREFERENCE_ENABLED:
@@ -16282,8 +17084,8 @@ def codex_subscription_capacity_route_decision(
         decision["reason"] = "recent direct-tier limit recovery keeps Bedrock route"
     elif normalized_runtime != "codex":
         decision["reason"] = "non-Codex runtime selected"
-    elif not codex_subscription_capacity_personal_lane():
-        decision["reason"] = "console is not a personal subscription lane"
+    elif not codex_subscription_capacity_route_lane():
+        decision["reason"] = "console is not an enabled subscription lane"
     elif snapshot.get("auth_mode") != "chatgpt":
         decision["reason"] = "Codex is not signed in with ChatGPT"
     elif stored_codex_auth_mode() != "chatgpt":
@@ -16295,6 +17097,15 @@ def codex_subscription_capacity_route_decision(
         < CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT
     ):
         decision["reason"] = "subscription capacity is below the routing reserve"
+    elif (
+        _coerce_int(route_forecast.get("reset_seconds"))
+        < CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS
+    ):
+        decision["reason"] = "subscription reset window is unavailable or too near"
+    elif not route_forecast.get("turn_fits_reset"):
+        decision["reason"] = str(route_forecast.get("reason") or "")
+    elif not route_forecast.get("fits_policy_envelope"):
+        decision["reason"] = str(route_forecast.get("reason") or "")
     elif service_tier_execution_tier(
         normalized_tier
     ) != "default" or not codex_profile_v2_for_service_tier(normalized_tier):
@@ -16307,7 +17118,10 @@ def codex_subscription_capacity_route_decision(
         decision.update(
             {
                 "selected": True,
-                "reason": "fresh ChatGPT subscription capacity preferred over Bedrock",
+                "reason": (
+                    "fresh ChatGPT subscription capacity fits the reset-aware "
+                    "forecast and is preferred over Bedrock"
+                ),
                 "selected_model": normalize_runtime_model(
                     "codex", codex_model_for_service_tier("flex", normalized_model)
                 ),
@@ -16315,6 +17129,275 @@ def codex_subscription_capacity_route_decision(
             }
         )
     return decision
+
+
+def codex_openai_direct_execution_decision(
+    service_tier: Any,
+    *,
+    auth_mode: Any = "",
+    prompt: Any = "",
+    job_budget: Any = "",
+    detail: Any = 2,
+    estimated_output_tokens: int | None = None,
+) -> dict[str, Any]:
+    normalized_tier = normalize_service_tier(service_tier)
+    provider_surface = (
+        str(usage_provider_tags(normalized_tier).get("provider_surface") or "")
+        .strip()
+        .lower()
+    )
+    observed_auth_mode = str(auth_mode or stored_codex_auth_mode()).strip().lower()
+    decision = {
+        "allowed": True,
+        "provider_surface": provider_surface,
+        "auth_mode": observed_auth_mode,
+        "api_spend_override": CODEX_ALLOW_OPENAI_API_SPEND,
+        "credit_extension_allowed": CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED,
+        "reason_code": "not_applicable",
+        "reason": "selected route does not use OpenAI direct",
+    }
+    if provider_surface != "openai-direct":
+        return decision
+    if observed_auth_mode == "chatgpt":
+        if CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED:
+            decision.update(
+                {
+                    "reason_code": "chatgpt_credit_extension_allowed",
+                    "reason": "verified ChatGPT subscription authentication",
+                }
+            )
+            return decision
+        capacity = codex_account_capacity_snapshot(auth_mode=observed_auth_mode)
+        minimum_percent_left = _coerce_int(capacity.get("minimum_window_percent_left"))
+        reset_seconds = codex_subscription_capacity_reset_seconds(capacity)
+        route_forecast = codex_subscription_capacity_route_forecast(
+            capacity,
+            prompt=prompt,
+            job_budget=job_budget,
+            detail=detail,
+            estimated_output_tokens=estimated_output_tokens,
+        )
+        decision["capacity"] = {
+            "state": capacity.get("state"),
+            "fresh": bool(capacity.get("fresh")),
+            "minimum_window_percent_left": capacity.get("minimum_window_percent_left"),
+            "reset_seconds": reset_seconds,
+            "plan_reserve_percent_left": CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT,
+            "forecast": route_forecast,
+        }
+        if (
+            bool(capacity.get("fresh"))
+            and capacity.get("state") == "available"
+            and minimum_percent_left >= CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT
+            and reset_seconds >= CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS
+            and bool(route_forecast.get("turn_fits_reset"))
+            and bool(route_forecast.get("fits_policy_envelope"))
+        ):
+            decision.update(
+                {
+                    "reason_code": "chatgpt_plan_capacity_verified",
+                    "reason": (
+                        "verified ChatGPT plan capacity is above the no-credit "
+                        "extension reserve"
+                    ),
+                }
+            )
+            return decision
+        decision.update(
+            {
+                "allowed": False,
+                "reason_code": "chatgpt_credit_extension_guard",
+                "reason": (
+                    "paid ChatGPT credit extension is disabled and fresh "
+                    "above-reserve plan capacity or a reset-aware turn forecast "
+                    "was not verified"
+                ),
+            }
+        )
+        return decision
+    if CODEX_ALLOW_OPENAI_API_SPEND:
+        decision.update(
+            {
+                "reason_code": "api_spend_override",
+                "reason": "explicit OpenAI API spend override",
+            }
+        )
+        return decision
+    decision.update(
+        {
+            "allowed": False,
+            "reason_code": "api_spend_disabled",
+            "reason": (
+                "OpenAI direct is blocked because Codex is not authenticated with "
+                "ChatGPT and API spending is disabled."
+            ),
+        }
+    )
+    return decision
+
+
+def codex_openai_direct_execution_block_message(decision: dict[str, Any]) -> str:
+    if decision.get("reason_code") == "chatgpt_credit_extension_guard":
+        return (
+            "OpenAI direct request blocked before launch: paid ChatGPT credit "
+            "extension is disabled and fresh subscription plan capacity above the "
+            "reserve or reset-aware turn forecast was not verified. No OpenAI API "
+            "request was sent. No paid ChatGPT credit extension was sent. Use "
+            "Norllama or Bedrock."
+        )
+    auth_mode = str(decision.get("auth_mode") or "unknown").strip() or "unknown"
+    return (
+        "OpenAI direct request blocked before launch: this console is authenticated "
+        f"as {auth_mode}, not ChatGPT, and API spending is disabled. "
+        "No OpenAI API request was sent. Use Norllama or Bedrock, sign in with "
+        "ChatGPT, or explicitly enable NORMAN_CODEX_ALLOW_OPENAI_API_SPEND."
+    )
+
+
+def is_subscription_capacity_self_improvement_prompt(prompt: Any) -> bool:
+    return SUBSCRIPTION_SELF_IMPROVEMENT_MARKER in str(prompt or "")
+
+
+def subscription_capacity_self_improvement_prompt() -> str:
+    return "\n".join(
+        [
+            SUBSCRIPTION_SELF_IMPROVEMENT_MARKER,
+            "Run one bounded, read-only self-improvement review of this Norman "
+            "workspace.",
+            "Inspect code, tests, and current local state only. Do not edit files, "
+            "run networked commands, use connectors, restart services, deploy, or "
+            "access secrets.",
+            "Return a concise ranked packet: the most valuable verified improvement, "
+            "supporting evidence with file references, a safe next implementation "
+            "step, and the focused verification command.",
+        ]
+    )
+
+
+def codex_subscription_self_improvement_decision(
+    capacity: dict[str, Any] | None = None,
+    *,
+    require_idle: bool = True,
+    now: int | None = None,
+) -> dict[str, Any]:
+    observed_now = _coerce_int(now) or now_ts()
+    snapshot = (
+        codex_account_capacity_snapshot(now=observed_now)
+        if capacity is None
+        else normalize_codex_account_capacity(capacity, now=observed_now)
+    )
+    route_forecast = codex_subscription_capacity_route_forecast(
+        snapshot,
+        prompt=subscription_capacity_self_improvement_prompt(),
+        job_budget="2m",
+        detail=2,
+        estimated_output_tokens=CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ESTIMATED_OUTPUT_TOKENS,
+    )
+    reset_seconds = _coerce_int(route_forecast.get("reset_seconds"))
+    decision = {
+        "eligible": False,
+        "reason": "subscription self-improvement is disabled",
+        "auth_mode": str(snapshot.get("auth_mode") or "").strip().lower(),
+        "capacity_percent_left": snapshot.get("minimum_window_percent_left"),
+        "reset_seconds": reset_seconds,
+        "reset_window_id": (
+            str((observed_now + reset_seconds) // 300) if reset_seconds else ""
+        ),
+        "forecast": route_forecast,
+    }
+    if not CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ENABLED:
+        return decision
+    if not codex_subscription_capacity_personal_lane():
+        decision["reason"] = "console is not a personal subscription lane"
+        return decision
+    if decision["auth_mode"] != "chatgpt" or stored_codex_auth_mode() != "chatgpt":
+        decision["reason"] = "ChatGPT authentication is not currently verified"
+        return decision
+    if not snapshot.get("fresh") or snapshot.get("state") != "available":
+        decision["reason"] = "subscription capacity is unavailable or stale"
+        return decision
+    if (
+        _coerce_int(snapshot.get("minimum_window_percent_left"))
+        < CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_PERCENT_LEFT
+    ):
+        decision["reason"] = (
+            "subscription capacity is below the self-improvement reserve"
+        )
+        return decision
+    if not (
+        CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_RESET_SECONDS
+        <= reset_seconds
+        <= CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MAX_RESET_SECONDS
+    ):
+        decision["reason"] = "subscription reset is outside the opportunistic window"
+        return decision
+    if not route_forecast.get("turn_fits_reset") or not route_forecast.get(
+        "fits_policy_envelope"
+    ):
+        decision["reason"] = str(route_forecast.get("reason") or "")
+        return decision
+    if require_idle:
+        meta = load_status_meta()
+        if (
+            bool(meta.get("pending"))
+            or bool(normalize_queue(meta.get("queued_prompts")))
+            or prompt_runtime_alive()
+            or prompt_thread_alive()
+        ):
+            decision["reason"] = "console is not idle"
+            return decision
+    decision.update(
+        {
+            "eligible": True,
+            "reason": "fresh subscription capacity is available near reset",
+        }
+    )
+    return decision
+
+
+def maybe_start_subscription_capacity_self_improvement(
+    capacity: dict[str, Any] | None = None,
+) -> bool:
+    decision = codex_subscription_self_improvement_decision(capacity)
+    if not decision["eligible"]:
+        return False
+    state = read_json(CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_STATE_PATH, {})
+    reset_window_id = str(decision["reset_window_id"])
+    if str(state.get("last_reset_window_id") or "") == reset_window_id:
+        return False
+    accepted, _snapshot = start_web_prompt(
+        subscription_capacity_self_improvement_prompt(),
+        "balanced",
+        2,
+        "2m",
+        runtime="codex",
+        service_tier="flex",
+        route_lock=True,
+        optimization_mode="raw",
+        source="system",
+    )
+    if not accepted:
+        return False
+    payload = {
+        "last_reset_window_id": reset_window_id,
+        "last_started_at": now_ts(),
+        "capacity_percent_left": decision["capacity_percent_left"],
+        "reset_seconds": decision["reset_seconds"],
+    }
+    write_json(CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_STATE_PATH, payload)
+    append_audit_event(
+        event_type="chat.subscription-self-improvement-started",
+        summary="Started a read-only self-improvement review before subscription reset.",
+        detail=(
+            f"{decision['capacity_percent_left']}% capacity remained with "
+            f"{decision['reset_seconds']} seconds to reset."
+        ),
+        severity="info",
+        actor_type="system",
+        thread_id=read_text(THREAD_ID_PATH),
+        payload=payload,
+    )
+    return True
 
 
 def usage_snapshot(
@@ -19246,6 +20329,7 @@ def save_status_meta(meta: dict[str, Any]) -> dict[str, Any]:
         )
     payload["live_turn"] = normalize_live_turn(payload.get("live_turn"))
     payload["turn_plan"] = normalize_turn_plan_estimate(payload.get("turn_plan"))
+    payload["working_recap"] = normalize_working_recap(payload.get("working_recap"))
     payload["updated_at"] = now_ts()
     write_json(STATUS_PATH, payload)
     return payload
@@ -19439,6 +20523,7 @@ def queue_prompt(
     service_tier: str = "",
     interlace_mode: str = "",
     optimization_mode: str = "",
+    source: str = "",
 ) -> dict[str, Any]:
     duplicate_queue_position = 0
     duplicate_queue_state = ""
@@ -19446,7 +20531,7 @@ def queue_prompt(
         meta = load_status_meta()
         queue = normalize_queue(meta.get("queued_prompts"))
         normalized_relay = normalize_relay_callback(relay_callback)
-        source = normalize_queue_source("", normalized_relay, prompt)
+        source = normalize_queue_source(source, normalized_relay, prompt)
         position = len(queue) + 1
         normalized_attachments = normalize_attachments(attachments)
         normalized_service_tier = normalize_service_tier(service_tier)
@@ -19976,6 +21061,27 @@ def send_text(text: str) -> None:
     finally:
         run(tmux_cmd("delete-buffer", "-b", buffer_name))
     record_action("tmux-send", f"Sent raw text to tmux: {summarize_text(text, 140)}")
+
+
+def send_codex_status_probe() -> None:
+    """Submit /status after its paste has settled in older Codex TUI builds."""
+    if not ensure_session():
+        raise RuntimeError("Codex session could not be started.")
+    buffer_name = f"{SESSION}-status-{int(time.time() * 1000)}"
+    try:
+        run(
+            tmux_cmd("load-buffer", "-b", buffer_name, "-"),
+            input_text="/status",
+            check=True,
+        )
+        run(
+            tmux_cmd("paste-buffer", "-d", "-b", buffer_name, "-t", f"{SESSION}:0.0"),
+            check=True,
+        )
+        time.sleep(CODEX_ACCOUNT_CAPACITY_STATUS_SUBMIT_SETTLE_SECONDS)
+        run(tmux_cmd("send-keys", "-t", f"{SESSION}:0.0", "Enter"), check=True)
+    finally:
+        run(tmux_cmd("delete-buffer", "-b", buffer_name))
 
 
 def send_keys(*keys: str) -> None:
@@ -21649,7 +22755,62 @@ def _execute_codex_prompt(
     normalized_optimization_mode = normalize_optimization_mode(optimization_mode)
     normalized_budget = normalize_job_budget(job_budget)
     normalized_timeout = normalize_job_timeout_seconds(timeout_seconds, job_budget)
+    direct_execution = codex_openai_direct_execution_decision(
+        normalized_service_tier,
+        prompt=prompt,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+    )
+    if not direct_execution["allowed"]:
+        blocked_message = codex_openai_direct_execution_block_message(direct_execution)
+        return (
+            "",
+            blocked_message,
+            read_text(THREAD_ID_PATH),
+            normalize_usage_entry(
+                {
+                    "runtime": "codex",
+                    "model": model,
+                    "service_tier": normalized_service_tier,
+                    "provider_error_kind": "openai_api_spend_blocked",
+                    "provider_error_text": blocked_message,
+                }
+            ),
+        )
+    if is_subscription_capacity_self_improvement_prompt(prompt):
+        self_improvement = codex_subscription_self_improvement_decision(
+            require_idle=False
+        )
+        if not self_improvement["eligible"]:
+            blocked_message = (
+                "Subscription self-improvement review skipped before launch: "
+                f"{self_improvement['reason']}."
+            )
+            return (
+                "",
+                blocked_message,
+                read_text(THREAD_ID_PATH),
+                normalize_usage_entry(
+                    {
+                        "runtime": "codex",
+                        "model": model,
+                        "service_tier": normalized_service_tier,
+                        "provider_error_kind": "subscription_capacity_unavailable",
+                        "provider_error_text": blocked_message,
+                    }
+                ),
+            )
     target_timeout = job_budget_timeout_seconds(normalized_budget)
+    token_capacity_plan = provider_token_budget_plan(
+        prompt=prompt,
+        runtime="codex",
+        model=model,
+        service_tier=normalized_service_tier,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+        attachments=attachments,
+        enforcement="advisory",
+    )
     warning_checkpoints = deadline_warning_checkpoints(
         target_timeout, normalized_timeout
     )
@@ -21675,11 +22836,19 @@ def _execute_codex_prompt(
         if normalized_optimization_mode != "raw"
         else {"should_pack": False, "mode": "raw"}
     )
+    read_only_self_improvement = is_subscription_capacity_self_improvement_prompt(
+        prompt
+    )
+    sandbox_args = (
+        ["--sandbox", "read-only", "--ask-for-approval", "never"]
+        if read_only_self_improvement
+        else ["--dangerously-bypass-approvals-and-sandbox"]
+    )
     cmd = [
         CODEX_BIN,
         "exec",
         "--json",
-        "--dangerously-bypass-approvals-and-sandbox",
+        *sandbox_args,
         *codex_profile_v2_config_args(normalized_service_tier),
         "-m",
         normalized_model,
@@ -21778,12 +22947,39 @@ def _execute_codex_prompt(
 
     env = dict(os.environ)
     env["CODEX_HOME"] = CODEX_HOME
+    launch_direct_execution = codex_openai_direct_execution_decision(
+        normalized_service_tier,
+        prompt=prompt,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+    )
+    if not launch_direct_execution["allowed"]:
+        blocked_message = codex_openai_direct_execution_block_message(
+            launch_direct_execution
+        )
+        return (
+            "",
+            blocked_message,
+            read_text(THREAD_ID_PATH),
+            normalize_usage_entry(
+                {
+                    "runtime": "codex",
+                    "model": normalized_model,
+                    "service_tier": normalized_service_tier,
+                    "provider_error_kind": "openai_api_spend_blocked",
+                    "provider_error_text": blocked_message,
+                    "token_capacity_plan": token_capacity_plan,
+                }
+            ),
+        )
     if (
-        execution_service_tier in DIRECT_SERVICE_TIERS
-        and stored_codex_auth_mode() == "chatgpt"
+        not CODEX_ALLOW_OPENAI_API_SPEND
+        or launch_direct_execution["auth_mode"] == "chatgpt"
     ):
-        # A subscription-preferred launch must not inherit an ambient API key.
+        # Never let an inherited API key turn a Bedrock or plan-authenticated
+        # process into an OpenAI Platform charge.
         env.pop("OPENAI_API_KEY", None)
+        env.pop("CODEX_API_KEY", None)
     apply_codex_provider_environment(env, normalized_service_tier)
     checkpoint_interrupted = False
     deadline_checkpoint_interrupted = False
@@ -21940,6 +23136,7 @@ def _execute_codex_prompt(
     usage = normalize_usage_entry(
         {
             **usage,
+            "token_capacity_plan": token_capacity_plan,
             **codex_provider_diagnostics(
                 proc=proc,
                 events=codex_events,
@@ -22768,6 +23965,18 @@ def _execute_bedrock_converse_prompt(
     normalized_budget = normalize_job_budget(job_budget)
     normalized_timeout = normalize_job_timeout_seconds(timeout_seconds, job_budget)
     normalized_model = normalize_runtime_model("claude", model)
+    token_capacity_plan = provider_token_budget_plan(
+        prompt=prompt,
+        runtime="claude",
+        model=normalized_model,
+        service_tier=service_tier,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+        attachments=attachments,
+        cloud_authorized=True,
+        enforcement="request_hard",
+    )
+    execution_output_cap = token_capacity_plan["execution_output_cap"]
     thread_id = read_text(THREAD_ID_PATH) or f"bedrock-converse-{started_at}"
     tuned_prompt = build_prompt_with_attachments(
         prompt,
@@ -22820,7 +24029,7 @@ def _execute_bedrock_converse_prompt(
         {"role": "user", "content": [{"text": execution_prompt}]}
     ]
     tool_config = {"tools": bedrock_converse_tool_specs()}
-    inference_config = {"maxTokens": BEDROCK_CONVERSE_MAX_OUTPUT_TOKENS}
+    inference_config = {"maxTokens": execution_output_cap}
     response_text = ""
     error_text = ""
     usage = normalize_usage_entry(
@@ -22831,6 +24040,8 @@ def _execute_bedrock_converse_prompt(
             "service_tier": service_tier,
             "started_at": started_at,
             "thread_id": thread_id,
+            "provider_max_output_tokens": execution_output_cap,
+            "token_capacity_plan": token_capacity_plan,
         }
     )
     total_input = 0
@@ -22840,8 +24051,21 @@ def _execute_bedrock_converse_prompt(
     tool_rounds = 0
     model_calls = 0
     tool_budget_exhausted = False
+    output_budget_exhausted = False
     try:
         for _ in range(max(1, tool_budget + 1)):
+            remaining_output_tokens = execution_output_cap - total_output
+            if remaining_output_tokens <= 0:
+                output_budget_exhausted = True
+                response_text = (
+                    "BLOCKED — output-token capacity budget reached before the "
+                    "brokered runtime completed. Continue with the recorded "
+                    "evidence in a new turn or choose a longer job budget."
+                )
+                break
+            inference_config = {
+                "maxTokens": min(execution_output_cap, remaining_output_tokens)
+            }
             model_calls += 1
             response = call_bedrock_converse(
                 model_id=normalized_model,
@@ -22987,11 +24211,19 @@ def _execute_bedrock_converse_prompt(
             "broker_tool_rounds": tool_rounds,
             "broker_model_calls": model_calls,
             "broker_tool_budget_exhausted": tool_budget_exhausted,
+            "broker_output_token_budget": execution_output_cap,
+            "broker_output_budget_exhausted": output_budget_exhausted,
+            "provider_max_output_tokens": execution_output_cap,
+            "token_capacity_plan": token_capacity_plan,
             "provider_yield_kind": "broker_tool_budget_checkpoint"
             if tool_budget_exhausted
+            else "broker_output_budget_checkpoint"
+            if output_budget_exhausted
             else "",
             "provider_yield_reasons": [f"broker tool budget reached: {tool_budget}"]
             if tool_budget_exhausted
+            else [f"broker output-token budget reached: {execution_output_cap}"]
+            if output_budget_exhausted
             else [],
         }
     )
@@ -23171,6 +24403,7 @@ def _prompt_worker(
                 requested_model=requested_model,
                 requested_service_tier=normalized_service_tier,
             )
+            turn_envelope["token_capacity_plan"] = turn_plan["token_capacity_plan"]
             # A worker can wait here behind an older run; reassert ownership once
             # it actually has the prompt lock so stale completions cannot leave
             # the UI showing the wrong prompt or attachment state.
@@ -24766,6 +25999,7 @@ def start_web_prompt(
     interlace_mode: str = "",
     route_lock: bool = False,
     optimization_mode: str = "",
+    source: str = "",
 ) -> tuple[bool, dict[str, Any]]:
     clean = prompt.strip()
     if not clean:
@@ -24857,6 +26091,9 @@ def start_web_prompt(
         runtime=normalized_runtime,
         model=normalized_model,
         service_tier=normalized_service_tier,
+        prompt=clean,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
         route_lock=route_lock,
         service_tier_recovery=service_tier_recovery,
     )
@@ -24873,10 +26110,10 @@ def start_web_prompt(
         )
         append_audit_event(
             event_type="chat.subscription-capacity-preferred",
-            summary="Fresh ChatGPT subscription capacity preferred over Bedrock.",
+            summary="Reset-aware ChatGPT subscription capacity preferred over Bedrock.",
             detail=(
                 "A default Bedrock Codex turn was moved to direct Flex after an "
-                "idle interactive capacity observation."
+                "idle capacity observation and reset-window forecast."
             ),
             severity="info",
             actor_type="system",
@@ -24889,6 +26126,89 @@ def start_web_prompt(
                 "prompt_preview": summarize_text(clean, 240),
             },
         )
+    if normalized_runtime == "codex":
+        direct_execution = codex_openai_direct_execution_decision(
+            normalized_service_tier,
+            prompt=clean,
+            job_budget=normalized_budget,
+            detail=normalized_detail,
+        )
+        if not direct_execution["allowed"]:
+            if direct_execution.get(
+                "reason_code"
+            ) == "chatgpt_credit_extension_guard" and codex_profile_v2_for_service_tier(
+                "default"
+            ):
+                fallback_reason = str(direct_execution.get("reason") or "")
+                normalized_service_tier = "default"
+                normalized_model = normalize_runtime_model(
+                    "codex",
+                    codex_model_for_service_tier(
+                        normalized_service_tier, normalized_model
+                    ),
+                )
+                cost_route_decision.update(
+                    {
+                        "selected_runtime": normalized_runtime,
+                        "selected_model": normalized_model,
+                        "selected_service_tier": normalized_service_tier,
+                        "route_source": "chatgpt-credit-extension-bedrock-fallback",
+                        "reason": fallback_reason,
+                        "charge_basis": usage_route_charge_basis(
+                            {
+                                "runtime": normalized_runtime,
+                                "model": normalized_model,
+                                "service_tier": normalized_service_tier,
+                            }
+                        ),
+                    }
+                )
+                append_audit_event(
+                    event_type="chat.chatgpt-credit-extension-bedrock-fallback",
+                    summary="Protected ChatGPT credits by keeping the turn on Bedrock.",
+                    detail=fallback_reason,
+                    severity="info",
+                    actor_type="system",
+                    thread_id=read_text(THREAD_ID_PATH),
+                    payload={
+                        "runtime": normalized_runtime,
+                        "model": normalized_model,
+                        "service_tier": normalized_service_tier,
+                        "decision": direct_execution,
+                    },
+                )
+            else:
+                blocked_message = codex_openai_direct_execution_block_message(
+                    direct_execution
+                )
+                append_audit_event(
+                    event_type="chat.openai-api-spend-blocked",
+                    summary="Blocked a direct OpenAI request before queueing.",
+                    detail=blocked_message,
+                    severity="warn",
+                    actor_type="system",
+                    thread_id=read_text(THREAD_ID_PATH),
+                    payload={
+                        "runtime": normalized_runtime,
+                        "model": normalized_model,
+                        "service_tier": normalized_service_tier,
+                        "decision": direct_execution,
+                    },
+                )
+                snapshot = current_snapshot()
+                snapshot["openai_api_spend_blocked"] = True
+                snapshot["openai_api_spend_error"] = blocked_message
+                return False, snapshot
+    token_capacity_plan = provider_token_budget_plan(
+        prompt=clean,
+        runtime=normalized_runtime,
+        model=normalized_model,
+        service_tier=normalized_service_tier,
+        job_budget=normalized_budget,
+        detail=normalized_detail,
+        attachments=normalized_attachments,
+        enforcement=("request_hard" if normalized_runtime == "claude" else "advisory"),
+    )
     turn_envelope = build_turn_control_envelope(
         prompt=clean,
         attachments=normalized_attachments,
@@ -24903,8 +26223,9 @@ def start_web_prompt(
         requested_model=requested_model,
         requested_service_tier=requested_service_tier,
     )
+    turn_envelope["token_capacity_plan"] = token_capacity_plan
     normalized_interlace_mode = normalize_queue_interlace_mode(interlace_mode)
-    normalized_source = normalize_queue_source("", normalized_relay_callback, clean)
+    normalized_source = normalize_queue_source(source, normalized_relay_callback, clean)
     recover_stale_prompt_state()
     should_queue = True
     deduplicated_existing = False
@@ -25112,6 +26433,7 @@ def start_web_prompt(
         service_tier=normalized_service_tier,
         interlace_mode=normalized_interlace_mode,
         optimization_mode=normalized_optimization_mode,
+        source=normalized_source,
     )
     if normalized_relay_callback and not queued_snapshot.get("deduplicated_prompt"):
         relay_queue_position = max(1, int(queued_snapshot.get("queue_depth") or 1))
@@ -25383,6 +26705,11 @@ def current_snapshot() -> dict[str, Any]:
             meta["status_message"] = snapshot_status
         save_status_meta(meta)
     running_prompt = str(meta.get("running_prompt") or "")
+    working_recap = ensure_working_recap(
+        meta,
+        pending=pending,
+        queue_depth=queue_depth,
+    )
     raw_resource_meter = load_resource_meter_file() or meta.get("resource_meter")
     resource_meter = normalize_resource_meter(
         raw_resource_meter,
@@ -25574,6 +26901,7 @@ def current_snapshot() -> dict[str, Any]:
             meta.get("live_turn"), pending=pending, observed_at=snapshot_at
         ),
         "turn_plan": normalize_turn_plan_estimate(meta.get("turn_plan")),
+        "working_recap": working_recap,
         "resource_meter": resource_meter,
         "bbs": current_bbs_summary(),
         "permissions_mode": "danger-full-access",
@@ -25700,6 +27028,7 @@ def snapshot_marker(snapshot: dict[str, Any]) -> tuple[Any, ...]:
         json.dumps(snapshot.get("resource_meter") or {}, sort_keys=True),
         json.dumps(snapshot.get("bedrock_health") or {}, sort_keys=True),
         json.dumps(snapshot.get("live_turn") or {}, sort_keys=True),
+        json.dumps(snapshot.get("working_recap") or {}, sort_keys=True),
         json.dumps(snapshot.get("sentinel") or {}, sort_keys=True),
         json.dumps(snapshot.get("kpis") or {}, sort_keys=True),
         json.dumps(snapshot.get("bbs") or {}, sort_keys=True),
@@ -27197,6 +28526,592 @@ SENSITIVE_BEARER_RE = re.compile(
     r"(?P<prefix>\bBearer\s+)(?P<value>[A-Za-z0-9._~+/=-]+)",
     re.IGNORECASE,
 )
+
+
+def _working_recap_sanitize_text(value: Any, limit: int = 240) -> str:
+    text = " ".join(str(value or "").replace("\r", "\n").split())
+    if not text:
+        return ""
+
+    def redact(match: re.Match[str]) -> str:
+        return f"{match.group('prefix')}[redacted]"
+
+    for pattern in (SENSITIVE_ASSIGNMENT_RE, SENSITIVE_QUERY_RE, SENSITIVE_BEARER_RE):
+        text = pattern.sub(redact, text)
+    return summarize_text(text, max(24, int(limit or 240)))
+
+
+def default_working_recap() -> dict[str, Any]:
+    return {
+        "schema": "norman.tui.working-recap.v1",
+        "turn_key": "",
+        "status": "idle",
+        "headline": "",
+        "now": "",
+        "milestones": [],
+        "next": "",
+        "updated_at": 0,
+        "last_attempt_at": 0,
+        "last_llm_at": 0,
+        "refreshing": False,
+        "source": "waiting",
+        "model": "",
+        "history": [],
+    }
+
+
+def _working_recap_history_entry(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "at": _coerce_int(value.get("updated_at")) or now_ts(),
+        "headline": _working_recap_sanitize_text(value.get("headline"), 180),
+        "now": _working_recap_sanitize_text(value.get("now"), 280),
+        "milestones": [
+            _working_recap_sanitize_text(item, 180)
+            for item in value.get("milestones") or []
+            if _working_recap_sanitize_text(item, 180)
+        ][:3],
+        "next": _working_recap_sanitize_text(value.get("next"), 220),
+        "source": str(value.get("source") or "deterministic").strip().lower()
+        or "deterministic",
+    }
+
+
+def _working_recap_history_signature(value: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        str(value.get("headline") or ""),
+        str(value.get("now") or ""),
+        tuple(str(item) for item in value.get("milestones") or []),
+        str(value.get("next") or ""),
+    )
+
+
+def normalize_working_recap(value: Any) -> dict[str, Any]:
+    payload = dict(default_working_recap())
+    if isinstance(value, dict):
+        payload.update(value)
+    payload["turn_key"] = str(payload.get("turn_key") or "").strip()[:96]
+    payload["status"] = str(payload.get("status") or "idle").strip().lower() or "idle"
+    if payload["status"] not in {"idle", "running", "complete"}:
+        payload["status"] = "running" if payload["turn_key"] else "idle"
+    payload["headline"] = _working_recap_sanitize_text(payload.get("headline"), 240)
+    payload["now"] = _working_recap_sanitize_text(payload.get("now"), 360)
+    payload["milestones"] = [
+        _working_recap_sanitize_text(item, 200)
+        for item in payload.get("milestones") or []
+        if _working_recap_sanitize_text(item, 200)
+    ][:3]
+    payload["next"] = _working_recap_sanitize_text(payload.get("next"), 260)
+    for key in ("updated_at", "last_attempt_at", "last_llm_at"):
+        payload[key] = _coerce_int(payload.get(key))
+    payload["refreshing"] = bool(payload.get("refreshing"))
+    payload["source"] = str(payload.get("source") or "waiting").strip().lower()
+    if payload["source"] not in {"waiting", "deterministic", "local_llm"}:
+        payload["source"] = "deterministic"
+    payload["model"] = _working_recap_sanitize_text(payload.get("model"), 96)
+    history: list[dict[str, Any]] = []
+    for item in payload.get("history") or []:
+        if not isinstance(item, dict):
+            continue
+        entry = _working_recap_history_entry(item)
+        if not entry["now"] and not entry["milestones"] and not entry["next"]:
+            continue
+        if history and _working_recap_history_signature(history[-1]) == (
+            _working_recap_history_signature(entry)
+        ):
+            history[-1]["at"] = max(history[-1]["at"], entry["at"])
+            continue
+        history.append(entry)
+    payload["history"] = history[-WORKING_RECAP_HISTORY_ITEMS:]
+    return payload
+
+
+def working_recap_turn_key(meta: dict[str, Any]) -> str:
+    started_at = _coerce_int(meta.get("last_started_at"))
+    prompt = str(meta.get("running_prompt") or "").strip()
+    if not started_at or not prompt:
+        return ""
+    digest = hashlib.sha256(prompt.encode("utf-8", errors="replace")).hexdigest()[:12]
+    return f"{started_at}-{digest}"
+
+
+def working_recap_task_category(plan: dict[str, Any]) -> str:
+    labels = {
+        str(item or "").strip().lower()
+        for item in plan.get("skill_labels") or []
+        if str(item or "").strip()
+    }
+    if "approval boundary check" in labels:
+        return "deployment or approval-boundary work"
+    if "code edit" in labels and "verification" in labels:
+        return "targeted implementation and verification"
+    if "code edit" in labels:
+        return "targeted implementation work"
+    if "verification" in labels:
+        return "system verification"
+    if "attachment review" in labels:
+        return "attached-material review"
+    if "cost accounting" in labels:
+        return "routing and cost review"
+    return "the active request"
+
+
+def working_recap_headline(plan: dict[str, Any]) -> str:
+    understood = _working_recap_sanitize_text(plan.get("understood_task"), 220)
+    if understood:
+        return understood
+    return f"Working through {working_recap_task_category(plan)}."
+
+
+def working_recap_live_activity(live: dict[str, Any]) -> tuple[str, list[str]]:
+    event_count = _coerce_int(live.get("event_count"))
+    tool_started = _coerce_int(live.get("tool_started_count"))
+    tool_finished = _coerce_int(live.get("tool_finished_count"))
+    decision_count = _coerce_int(live.get("decision_count"))
+    file_count = _coerce_int(live.get("file_interaction_count"))
+    status = str(live.get("last_tool_status") or "").strip().lower()
+    milestones: list[str] = []
+    if event_count:
+        milestones.append(
+            f"Observed {event_count} live event{'s' if event_count != 1 else ''}."
+        )
+    if tool_started:
+        if status in {"tool-finished", "finished", "complete", "completed"}:
+            milestones.append(
+                f"Completed {tool_finished or 1} tool checkpoint"
+                f"{'s' if (tool_finished or 1) != 1 else ''}."
+            )
+        else:
+            milestones.append(
+                f"Tool activity is in progress ({tool_finished}/{tool_started} complete)."
+            )
+    if file_count:
+        milestones.append(
+            f"Reviewed {file_count} workspace file{'s' if file_count != 1 else ''}."
+        )
+    elif decision_count:
+        milestones.append(
+            f"Recorded {decision_count} planning checkpoint"
+            f"{'s' if decision_count != 1 else ''}."
+        )
+    if status in {"tool-started", "started", "running"}:
+        now = "A live tool step is running; the next recap will fold in its result."
+    elif tool_finished:
+        now = "A tool checkpoint finished; the worker is evaluating what it found."
+    elif event_count:
+        now = "The worker is moving through live planning and execution signals."
+    else:
+        now = "The worker is preparing the first concrete step."
+    return now, milestones[:3]
+
+
+def deterministic_working_recap(
+    meta: dict[str, Any],
+    *,
+    queue_depth: int = 0,
+    observed_at: int = 0,
+) -> dict[str, Any]:
+    now = observed_at or now_ts()
+    plan = normalize_turn_plan_estimate(meta.get("turn_plan"))
+    live = normalize_live_turn(meta.get("live_turn"))
+    task_category = working_recap_task_category(plan)
+    activity_now, activity_milestones = working_recap_live_activity(live)
+    rate_limited = (
+        bool(meta.get("rate_limit_active"))
+        or str(meta.get("state") or "").lower() == "rate_limited"
+    )
+    handoff_running = str(meta.get("queue_handoff_state") or "").lower() == "running"
+    milestones = [
+        (
+            "Plan ready: "
+            + ", ".join(
+                _working_recap_sanitize_text(label, 56)
+                for label in plan.get("skill_labels") or []
+                if _working_recap_sanitize_text(label, 56)
+            )[:3]
+            + "."
+        )
+        if plan.get("skill_labels")
+        else f"Scope classified as {task_category}."
+    ]
+    milestones.extend(activity_milestones)
+    if queue_depth:
+        milestones.append(
+            f"{queue_depth} follow-up{'s' if queue_depth != 1 else ''} remain queued."
+        )
+    if rate_limited:
+        now_text = "Provider backoff is active; the worker will retry automatically."
+        next_text = "Wait for the retry window, then continue from the preserved turn."
+    elif handoff_running:
+        now_text = (
+            "A safe-checkpoint handoff is active; the earlier reply remains preserved."
+        )
+        next_text = "Finish the active handoff, then return the new reply."
+    else:
+        now_text = activity_now
+        plan_steps = [
+            _working_recap_sanitize_text(step, 180)
+            for step in plan.get("plan_steps") or []
+            if _working_recap_sanitize_text(step, 180)
+        ]
+        if _coerce_int(live.get("tool_started_count")) > _coerce_int(
+            live.get("tool_finished_count")
+        ):
+            next_text = "Use the current tool result to decide the next safe action."
+        elif len(plan_steps) > 1:
+            next_text = plan_steps[1]
+        elif plan_steps:
+            next_text = plan_steps[0]
+        else:
+            next_text = "Turn the current evidence into a concise reply."
+    return normalize_working_recap(
+        {
+            "turn_key": working_recap_turn_key(meta),
+            "status": "running",
+            "headline": working_recap_headline(plan),
+            "now": now_text,
+            "milestones": milestones[:3],
+            "next": next_text,
+            "updated_at": now,
+            "source": "deterministic",
+        }
+    )
+
+
+def working_recap_with_history(
+    recap: dict[str, Any], previous: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    normalized = normalize_working_recap(recap)
+    prior = normalize_working_recap(previous or {})
+    history = list(prior.get("history") or [])
+    entry = _working_recap_history_entry(normalized)
+    if entry["now"] or entry["milestones"] or entry["next"]:
+        if history and _working_recap_history_signature(history[-1]) == (
+            _working_recap_history_signature(entry)
+        ):
+            history[-1]["at"] = entry["at"]
+            history[-1]["source"] = entry["source"]
+        else:
+            history.append(entry)
+    normalized["history"] = history[-WORKING_RECAP_HISTORY_ITEMS:]
+    return normalize_working_recap(normalized)
+
+
+def working_recap_llm_packet(
+    meta: dict[str, Any], recap: dict[str, Any], *, queue_depth: int = 0
+) -> dict[str, Any]:
+    plan = normalize_turn_plan_estimate(meta.get("turn_plan"))
+    live = normalize_live_turn(meta.get("live_turn"))
+    started_at = _coerce_int(meta.get("last_started_at"))
+    return {
+        "task_class": working_recap_task_category(plan),
+        "route": {
+            "runtime": normalize_runtime(meta.get("running_runtime")),
+            "model": _working_recap_sanitize_text(meta.get("running_model"), 96),
+        },
+        "elapsed_seconds": max(0, now_ts() - started_at) if started_at else 0,
+        "queue_depth": max(0, int(queue_depth or 0)),
+        "live": {
+            "event_count": _coerce_int(live.get("event_count")),
+            "tool_started": _coerce_int(live.get("tool_started_count")),
+            "tool_finished": _coerce_int(live.get("tool_finished_count")),
+            "decision_count": _coerce_int(live.get("decision_count")),
+            "file_count": _coerce_int(live.get("file_interaction_count")),
+            "tool_state": (
+                "running"
+                if str(live.get("last_tool_status") or "").lower()
+                in {"tool-started", "started", "running"}
+                else "completed"
+                if _coerce_int(live.get("tool_finished_count"))
+                else "waiting"
+            ),
+        },
+        "deterministic_recap": {
+            "now": recap.get("now"),
+            "milestones": recap.get("milestones"),
+            "next": recap.get("next"),
+        },
+    }
+
+
+def working_recap_local_url(endpoint: str, path: str) -> str:
+    base = str(endpoint or "").strip().rstrip("/")
+    clean_path = "/" + str(path or "").strip().lstrip("/")
+    if not base:
+        return clean_path
+    if base.endswith(clean_path):
+        return base
+    parsed = urlparse(base)
+    base_path = str(parsed.path or "").rstrip("/")
+    if base_path and clean_path.startswith(f"{base_path}/"):
+        return f"{base}{clean_path.removeprefix(base_path)}"
+    if (
+        parsed.scheme
+        and parsed.netloc
+        and base_path in {"/api", "/v1"}
+        and clean_path.startswith(("/api/", "/v1/"))
+    ):
+        return f"{parsed.scheme}://{parsed.netloc}{clean_path}"
+    return f"{base}{clean_path}"
+
+
+def working_recap_local_response_text(payload: dict[str, Any]) -> str:
+    text = str(payload.get("response") or payload.get("text") or "").strip()
+    if text:
+        return text
+    message = payload.get("message")
+    if isinstance(message, dict):
+        text = str(message.get("content") or "").strip()
+        if text:
+            return text
+    choices = payload.get("choices")
+    if isinstance(choices, list) and choices:
+        first = choices[0]
+        if isinstance(first, dict):
+            message = first.get("message")
+            if isinstance(message, dict):
+                text = str(message.get("content") or "").strip()
+                if text:
+                    return text
+            text = str(first.get("text") or "").strip()
+            if text:
+                return text
+    return ""
+
+
+def working_recap_local_generate(
+    endpoint: str, model: str, prompt: str
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "keep_alive": "20m",
+        "think": False,
+        "options": {"num_predict": WORKING_RECAP_LLM_MAX_OUTPUT_TOKENS},
+    }
+    request = urllib_request.Request(
+        working_recap_local_url(endpoint, "/api/chat"),
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "norman-tui-working-recap/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib_request.urlopen(
+            request, timeout=WORKING_RECAP_LLM_TIMEOUT_SECONDS
+        ) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+    except urllib_error.HTTPError as exc:
+        if exc.code != HTTPStatus.NOT_FOUND:
+            raise
+        generate_payload = {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "keep_alive": "20m",
+            "options": {"num_predict": WORKING_RECAP_LLM_MAX_OUTPUT_TOKENS},
+        }
+        fallback = urllib_request.Request(
+            working_recap_local_url(endpoint, "/api/generate"),
+            data=json.dumps(generate_payload).encode("utf-8"),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "User-Agent": "norman-tui-working-recap/1.0",
+            },
+            method="POST",
+        )
+        with urllib_request.urlopen(
+            fallback, timeout=WORKING_RECAP_LLM_TIMEOUT_SECONDS
+        ) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+    parsed = json.loads(raw or "{}")
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def working_recap_local_llm(
+    meta: dict[str, Any], recap: dict[str, Any], *, queue_depth: int = 0
+) -> tuple[dict[str, Any], str]:
+    model = WORKING_RECAP_LOCAL_MODEL
+    if not WORKING_RECAP_ENABLED or not model or not WORKING_RECAP_LOCAL_ENDPOINTS:
+        return {}, ""
+    packet = working_recap_llm_packet(meta, recap, queue_depth=queue_depth)
+    prompt = "\n".join(
+        [
+            "You write a short, factual progress recap for Norman's running TUI.",
+            "Use only this sanitized status packet. It deliberately contains no user prompt, terminal output, or secrets.",
+            "Do not invent completed work, access, commands, findings, or future outcomes.",
+            "Return JSON only with this exact shape:",
+            '{"now":"one short sentence","milestones":["up to three factual short sentences"],"next":"one short sentence"}',
+            "Keep each string readable in a compact operator panel.",
+            "STATUS_PACKET:",
+            json.dumps(packet, sort_keys=True),
+        ]
+    )
+    for endpoint in WORKING_RECAP_LOCAL_ENDPOINTS:
+        try:
+            payload = working_recap_local_generate(endpoint, model, prompt)
+        except Exception:
+            continue
+        response = re.sub(
+            r"(?is)<think>.*?</think>",
+            "",
+            working_recap_local_response_text(payload),
+        ).strip()
+        match = re.search(r"\{.*\}", response, flags=re.DOTALL)
+        if not match:
+            continue
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        candidate = normalize_working_recap(
+            {
+                "turn_key": recap.get("turn_key"),
+                "status": "running",
+                "headline": recap.get("headline"),
+                "now": parsed.get("now"),
+                "milestones": parsed.get("milestones"),
+                "next": parsed.get("next"),
+                "updated_at": now_ts(),
+                "source": "local_llm",
+                "model": model,
+            }
+        )
+        if candidate["now"] or candidate["milestones"] or candidate["next"]:
+            return candidate, model
+    return {}, ""
+
+
+def _working_recap_refresh_worker(turn_key: str) -> None:
+    try:
+        with STATUS_LOCK:
+            meta = load_status_meta()
+            if (
+                not bool(meta.get("pending"))
+                or working_recap_turn_key(meta) != turn_key
+            ):
+                return
+            previous = normalize_working_recap(meta.get("working_recap"))
+            deterministic = deterministic_working_recap(
+                meta,
+                queue_depth=len(normalize_queue(meta.get("queued_prompts"))),
+            )
+        generated, model = working_recap_local_llm(
+            meta,
+            deterministic,
+            queue_depth=len(normalize_queue(meta.get("queued_prompts"))),
+        )
+        refreshed_at = now_ts()
+        with STATUS_LOCK:
+            current = load_status_meta()
+            if (
+                not bool(current.get("pending"))
+                or working_recap_turn_key(current) != turn_key
+            ):
+                return
+            current_recap = normalize_working_recap(current.get("working_recap"))
+            base = deterministic_working_recap(
+                current,
+                queue_depth=len(normalize_queue(current.get("queued_prompts"))),
+                observed_at=refreshed_at,
+            )
+            base.update(
+                {
+                    "last_attempt_at": current_recap.get("last_attempt_at"),
+                    "last_llm_at": current_recap.get("last_llm_at"),
+                    "refreshing": False,
+                    "history": current_recap.get("history") or previous.get("history"),
+                }
+            )
+            if generated:
+                base.update(
+                    {
+                        "now": generated.get("now") or base["now"],
+                        "milestones": generated.get("milestones") or base["milestones"],
+                        "next": generated.get("next") or base["next"],
+                        "source": "local_llm",
+                        "model": model,
+                        "last_llm_at": refreshed_at,
+                    }
+                )
+            current["working_recap"] = working_recap_with_history(base, current_recap)
+            save_status_meta(current)
+    finally:
+        with WORKING_RECAP_LOCK:
+            WORKING_RECAP_ACTIVE_TURNS.discard(turn_key)
+
+
+def ensure_working_recap(
+    meta: dict[str, Any], *, pending: bool, queue_depth: int
+) -> dict[str, Any]:
+    current = normalize_working_recap(meta.get("working_recap"))
+    turn_key = working_recap_turn_key(meta)
+    if not pending or not turn_key:
+        if current["status"] == "running":
+            current["status"] = "complete"
+            current["refreshing"] = False
+        return normalize_working_recap(current)
+
+    deterministic = deterministic_working_recap(
+        meta, queue_depth=queue_depth, observed_at=now_ts()
+    )
+    needs_seed = current.get("turn_key") != turn_key
+    needs_early_refresh = (
+        current.get("source") == "deterministic"
+        and not _coerce_int(current.get("last_llm_at"))
+        and _working_recap_history_signature(current)
+        != _working_recap_history_signature(deterministic)
+    )
+    if needs_seed or needs_early_refresh:
+        deterministic.update(
+            {
+                "last_attempt_at": 0 if needs_seed else current.get("last_attempt_at"),
+                "last_llm_at": 0 if needs_seed else current.get("last_llm_at"),
+                "refreshing": False,
+                "history": [] if needs_seed else current.get("history"),
+            }
+        )
+        current = working_recap_with_history(deterministic, current)
+        with STATUS_LOCK:
+            latest = load_status_meta()
+            if working_recap_turn_key(latest) == turn_key:
+                latest["working_recap"] = current
+                save_status_meta(latest)
+
+    now = now_ts()
+    refreshing_stale = current.get("refreshing") and now - _coerce_int(
+        current.get("last_attempt_at")
+    ) > max(WORKING_RECAP_LLM_TIMEOUT_SECONDS * 2, 60)
+    due = WORKING_RECAP_ENABLED and (
+        not _coerce_int(current.get("last_attempt_at"))
+        or now - _coerce_int(current.get("last_attempt_at"))
+        >= WORKING_RECAP_REFRESH_SECONDS
+        or refreshing_stale
+    )
+    if due:
+        with WORKING_RECAP_LOCK:
+            if turn_key not in WORKING_RECAP_ACTIVE_TURNS:
+                WORKING_RECAP_ACTIVE_TURNS.add(turn_key)
+                current["refreshing"] = True
+                current["last_attempt_at"] = now
+                with STATUS_LOCK:
+                    latest = load_status_meta()
+                    if working_recap_turn_key(latest) == turn_key:
+                        latest["working_recap"] = current
+                        save_status_meta(latest)
+                threading.Thread(
+                    target=_working_recap_refresh_worker,
+                    args=(turn_key,),
+                    daemon=True,
+                    name=f"working-recap-{turn_key[-6:]}",
+                ).start()
+    return normalize_working_recap(current)
 
 
 def _secret_token_suffix(index: int) -> str:
@@ -34116,6 +36031,15 @@ class Handler(BaseHTTPRequestHandler):
         linear-gradient(90deg, color-mix(in srgb, var(--warn) 6%, transparent), transparent 54%),
         color-mix(in srgb, var(--surface-2) 52%, transparent);
     }}
+    .message.pending.live-status.working-on-message {{
+      max-width: min(88%, 780px);
+      padding: 10px 12px 11px;
+      border-color: color-mix(in srgb, var(--warn) 24%, var(--border));
+      background:
+        linear-gradient(180deg, color-mix(in srgb, var(--surface) 38%, transparent), transparent 76%),
+        linear-gradient(90deg, color-mix(in srgb, var(--warn) 7%, transparent), transparent 58%),
+        color-mix(in srgb, var(--surface-2) 54%, transparent);
+    }}
     .message.queued {{
       border-style: dashed;
       background: var(--surface-2);
@@ -34213,6 +36137,7 @@ class Handler(BaseHTTPRequestHandler):
       opacity: 0.8;
     }}
     .message-cost-chip,
+    .message-value-chip,
     .message-estimate-chip {{
       display: inline-flex;
       align-items: center;
@@ -34238,6 +36163,26 @@ class Handler(BaseHTTPRequestHandler):
       border-color: color-mix(in srgb, #38bdf8 30%, var(--border));
       color: color-mix(in srgb, #38bdf8 62%, var(--text));
       background: color-mix(in srgb, #38bdf8 9%, var(--surface-2));
+    }}
+    .message-value-chip[data-value-tone="good"] {{
+      border-color: color-mix(in srgb, #22c55e 34%, var(--border));
+      color: color-mix(in srgb, #22c55e 66%, var(--text));
+      background: color-mix(in srgb, #22c55e 10%, var(--surface-2));
+    }}
+    .message-value-chip[data-value-tone="plan"] {{
+      border-color: color-mix(in srgb, #38bdf8 32%, var(--border));
+      color: color-mix(in srgb, #38bdf8 64%, var(--text));
+      background: color-mix(in srgb, #38bdf8 9%, var(--surface-2));
+    }}
+    .message-value-chip[data-value-tone="watch"] {{
+      border-color: color-mix(in srgb, var(--warn) 48%, var(--border));
+      color: color-mix(in srgb, var(--warn) 74%, var(--text));
+      background: color-mix(in srgb, var(--warn) 12%, var(--surface-2));
+    }}
+    .message-value-chip[data-value-tone="heavy"] {{
+      border-color: color-mix(in srgb, var(--danger) 48%, var(--border));
+      color: color-mix(in srgb, var(--danger) 74%, var(--text));
+      background: color-mix(in srgb, var(--danger) 12%, var(--surface-2));
     }}
     .message-estimate-chip[data-estimate-tone="quiet"] {{
       border-color: color-mix(in srgb, #22c55e 22%, var(--border));
@@ -34509,6 +36454,179 @@ class Handler(BaseHTTPRequestHandler):
       letter-spacing: 0.18em;
       font-size: 0.72rem;
       line-height: 1;
+    }}
+    .message.pending.live-status .message-body.working-on-body::before,
+    .message.pending.live-status .message-body.working-on-body::after {{
+      content: none;
+      display: none;
+    }}
+    .working-on-panel {{
+      display: grid;
+      gap: 8px;
+      max-width: min(100%, 82ch);
+      color: color-mix(in srgb, var(--text) 90%, var(--muted));
+    }}
+    .working-on-panel-head {{
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      min-width: 0;
+    }}
+    .working-on-kicker {{
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: color-mix(in srgb, var(--warn) 68%, var(--text));
+      font-family: var(--font-ui-wide);
+      font-size: 0.62rem;
+      font-weight: 760;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }}
+    .working-on-kicker::before {{
+      content: "";
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: color-mix(in srgb, var(--warn) 78%, white 8%);
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--warn) 10%, transparent);
+      animation: working-recap-pulse 1.8s ease-in-out infinite;
+    }}
+    .working-on-source {{
+      min-width: 0;
+      color: color-mix(in srgb, var(--muted) 74%, var(--text));
+      font-family: var(--font-label);
+      font-size: 0.62rem;
+      font-variant-numeric: tabular-nums;
+      text-align: right;
+      white-space: nowrap;
+    }}
+    .working-on-headline {{
+      color: color-mix(in srgb, var(--text) 94%, var(--agent-accent));
+      font-family: var(--font-reading);
+      font-size: 0.98rem;
+      font-weight: 680;
+      line-height: 1.3;
+    }}
+    .working-on-now {{
+      margin: 0;
+      color: color-mix(in srgb, var(--text) 82%, var(--muted));
+      font-size: 0.84rem;
+      line-height: 1.45;
+    }}
+    .working-on-milestones {{
+      display: grid;
+      gap: 4px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }}
+    .working-on-milestones li {{
+      position: relative;
+      padding-left: 13px;
+      color: color-mix(in srgb, var(--muted) 46%, var(--text));
+      font-size: 0.76rem;
+      line-height: 1.34;
+    }}
+    .working-on-milestones li::before {{
+      content: "";
+      position: absolute;
+      top: 0.48rem;
+      left: 1px;
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background: color-mix(in srgb, var(--agent-accent) 70%, var(--warn));
+    }}
+    .working-on-footer {{
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 5px 10px;
+      padding-top: 7px;
+      border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+      color: var(--muted);
+      font-family: var(--font-label);
+      font-size: 0.7rem;
+      line-height: 1.35;
+    }}
+    .working-on-next {{
+      flex: 1 1 280px;
+      min-width: 0;
+      color: color-mix(in srgb, var(--text) 78%, var(--muted));
+    }}
+    .working-on-elapsed {{
+      color: color-mix(in srgb, var(--muted) 74%, var(--text));
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }}
+    .working-on-timeline {{
+      margin-top: 1px;
+      color: var(--muted);
+      font-family: var(--font-body);
+      font-size: 0.72rem;
+    }}
+    .working-on-timeline summary {{
+      display: inline-flex;
+      align-items: center;
+      min-height: 24px;
+      cursor: pointer;
+      color: color-mix(in srgb, var(--text) 72%, var(--muted));
+      font-family: var(--font-label);
+      font-size: 0.68rem;
+      user-select: none;
+    }}
+    .working-on-timeline summary:hover,
+    .working-on-timeline summary:focus-visible {{
+      color: color-mix(in srgb, var(--text) 94%, var(--agent-accent));
+    }}
+    .working-on-timeline ol {{
+      display: grid;
+      gap: 7px;
+      margin: 5px 0 0;
+      padding: 7px 0 0 11px;
+      border-left: 1px solid color-mix(in srgb, var(--border) 64%, transparent);
+      list-style: none;
+    }}
+    .working-on-timeline li {{
+      display: grid;
+      gap: 2px;
+      min-width: 0;
+    }}
+    .working-on-timeline-stamp {{
+      color: color-mix(in srgb, var(--muted) 80%, var(--text));
+      font-family: var(--font-label);
+      font-size: 0.64rem;
+      font-variant-numeric: tabular-nums;
+    }}
+    .working-on-timeline-copy {{
+      color: color-mix(in srgb, var(--text) 74%, var(--muted));
+      line-height: 1.38;
+    }}
+    @keyframes working-recap-pulse {{
+      0%, 100% {{ opacity: 0.72; transform: scale(0.9); }}
+      50% {{ opacity: 1; transform: scale(1.08); }}
+    }}
+    @media (prefers-reduced-motion: reduce) {{
+      .working-on-kicker::before {{
+        animation: none;
+      }}
+    }}
+    @media (max-width: 640px) {{
+      .message.pending.live-status.working-on-message {{
+        max-width: 100%;
+      }}
+      .working-on-panel-head {{
+        align-items: flex-start;
+      }}
+      .working-on-source {{
+        max-width: 44%;
+        white-space: normal;
+      }}
+      .working-on-headline {{
+        font-size: 0.92rem;
+      }}
     }}
     .message-body > :first-child,
     .raw-view > :first-child {{
@@ -41809,6 +43927,7 @@ class Handler(BaseHTTPRequestHandler):
     const INLINE_ENTITY_DEFS = {script_json(build_inline_entity_defs())};
     const WORKDIR = {json.dumps(WORKDIR)};
     const UI_VERSION = {json.dumps(UI_VERSION)};
+    const PLAN_CREDIT_LABEL = {json.dumps(PLAN_CREDIT_LABEL)};
     const ACTIVE_PROFILE = {active_profile_name_json};
     const ACTIVE_PROFILE_LABEL = {active_profile_label_json};
     const ACTIVE_ROUTE = {json.dumps(route_preference)};
@@ -47283,6 +49402,7 @@ class Handler(BaseHTTPRequestHandler):
       const runtime = String(usage?.runtime || "").trim().toLowerCase();
       const owner = String(usage?.billing_owner || tags.billing_owner || "").trim().toLowerCase();
       const group = String(usage?.agent_group || tags.agent_group || "").trim().toLowerCase();
+      const authMode = String(usage?.codex_auth_mode || tags.codex_auth_mode || "").trim().toLowerCase();
       const providerSurface = String(usage?.provider_surface || "").trim().toLowerCase();
       if (providerSurface === "aws-bedrock") {{
         return "provider_invoice_estimate";
@@ -47290,7 +49410,7 @@ class Handler(BaseHTTPRequestHandler):
       if (["claude", "deepseek", "kimi", "qwen"].includes(runtime)) {{
         return "provider_invoice_estimate";
       }}
-      if (runtime === "codex" && owner === "kristopher" && group !== "work") {{
+      if (runtime === "codex" && owner === "kristopher" && group !== "work" && authMode === "chatgpt") {{
         return "chatgpt_codex_credit_estimate";
       }}
       if (providerSurface === "openai-direct") {{
@@ -47425,6 +49545,148 @@ class Handler(BaseHTTPRequestHandler):
             : totalTokens >= USAGE_POOR_YIELD_MIN_TOKENS
               ? "warn"
               : "tokens",
+        usd,
+        highUsd: cost.highUsd,
+        ledgerKind: rawLedgerKind,
+        displayUnit,
+        totalTokens,
+        isCodexCreditEstimate,
+      }};
+    }}
+
+    function turnCostFeedbackDescriptor(usage, snapshot = state.snapshot) {{
+      const cost = usageCostDescriptor(usage, snapshot);
+      if (!cost) {{
+        return null;
+      }}
+      const runtime = String(usage?.runtime || "").trim().toLowerCase();
+      const providerSurface = String(usage?.provider_surface || "").trim().toLowerCase();
+      const localRoute = ["localllm", "codexspark"].includes(runtime)
+        || runtime.includes("norllama")
+        || runtime.includes("ollama")
+        || runtime.includes("spark")
+        || ["local", "norllama", "ollama"].includes(providerSurface);
+      const avoidedTokens = Math.max(
+        0,
+        Number(
+          usage?.cloud_tokens_avoided_estimate
+          || usage?.cloud_tokens_avoided_floor
+          || 0
+        )
+      );
+      const contextSavedTokens = Math.max(
+        0,
+        Number(usage?.context_pack_saved_tokens || 0)
+      );
+      const savingsTokens = Math.max(avoidedTokens, contextSavedTokens);
+      const netAvoidedTokens = Number(
+        usage?.cloud_preflight_net_token_delta_estimate || 0
+      );
+      const savingsTitle = [
+        "Estimated cloud input tokens avoided through local preflight, local tools, or context packing.",
+        savingsTokens ? `${{formatCount(savingsTokens)}} cloud tokens avoided` : "",
+        contextSavedTokens
+          ? `${{formatCount(contextSavedTokens)}} context tokens compacted`
+          : "",
+        netAvoidedTokens
+          ? `${{formatCount(netAvoidedTokens)}} net avoided after local preflight`
+          : "",
+        "This is a token-avoidance estimate, not an invoice saving.",
+      ].filter(Boolean).join(" · ");
+      if (savingsTokens >= 20_000) {{
+        return {{
+          label: `Big save · ${{formatCompactMetric(savingsTokens)}} tok`,
+          meta: "cloud avoided",
+          tone: "good",
+          title: [savingsTitle, cost.title].filter(Boolean).join(" · "),
+        }};
+      }}
+      if (savingsTokens >= 2_000) {{
+        return {{
+          label: `Saved · ${{formatCompactMetric(savingsTokens)}} tok`,
+          meta: "cloud avoided",
+          tone: "good",
+          title: [savingsTitle, cost.title].filter(Boolean).join(" · "),
+        }};
+      }}
+      if (localRoute) {{
+        return {{
+          label: "Good · local",
+          meta: "no cloud bill",
+          tone: "good",
+          title: [
+            "Completed on a local/Norllama route. No metered cloud-provider charge was recorded for this turn.",
+            "This does not include local hardware, electricity, or depreciation.",
+            cost.title,
+          ].filter(Boolean).join(" · "),
+        }};
+      }}
+      if (cost.isCodexCreditEstimate) {{
+        return {{
+          label: "Plan credits",
+          meta: cost.label || "usage estimated",
+          tone: "plan",
+          title: [
+            "Completed on the personal ChatGPT/Codex subscription lane.",
+            "This is an estimated plan-credit use, not a credit-card charge or a known balance deduction.",
+            cost.title,
+          ].filter(Boolean).join(" · "),
+        }};
+      }}
+      const estimatedUsd = Math.max(0, Number(cost.highUsd || cost.usd || 0));
+      if (estimatedUsd > 0) {{
+        if (estimatedUsd >= 0.75) {{
+          return {{
+            label: "Heavy",
+            meta: `~${{formatCompactUsd(estimatedUsd)}} cloud est`,
+            tone: "heavy",
+            title: [
+              "Large estimated cloud-provider turn. This is a local rate-card estimate, not an invoice.",
+              cost.title,
+            ].filter(Boolean).join(" · "),
+          }};
+        }}
+        if (estimatedUsd >= 0.15) {{
+          return {{
+            label: "High",
+            meta: `~${{formatCompactUsd(estimatedUsd)}} cloud est`,
+            tone: "watch",
+            title: [
+              "Higher estimated cloud-provider turn. This is a local rate-card estimate, not an invoice.",
+              cost.title,
+            ].filter(Boolean).join(" · "),
+          }};
+        }}
+        if (estimatedUsd >= 0.03) {{
+          return {{
+            label: "Watch",
+            meta: `~${{formatCompactUsd(estimatedUsd)}} cloud est`,
+            tone: "watch",
+            title: [
+              "Moderate estimated cloud-provider turn. This is a local rate-card estimate, not an invoice.",
+              cost.title,
+            ].filter(Boolean).join(" · "),
+          }};
+        }}
+        return {{
+          label: "Good",
+          meta: `~${{formatCompactUsd(estimatedUsd)}} cloud est`,
+          tone: "good",
+          title: [
+            "Low estimated cloud-provider turn. This is a local rate-card estimate, not an invoice.",
+            cost.title,
+          ].filter(Boolean).join(" · "),
+        }};
+      }}
+      const heavyTokens = cost.totalTokens >= 50_000;
+      return {{
+        label: heavyTokens ? "Token heavy" : "Tracked",
+        meta: `${{formatCompactMetric(cost.totalTokens)}} tok`,
+        tone: heavyTokens ? "watch" : "quiet",
+        title: [
+          "Token use is tracked, but no provider-price estimate is configured for this turn.",
+          cost.title,
+        ].filter(Boolean).join(" · "),
       }};
     }}
 
@@ -49875,6 +52137,33 @@ class Handler(BaseHTTPRequestHandler):
           ? `${{formatCompactUsd(lowUsd)}}-${{formatCompactUsd(highUsd)}}`
           : formatCompactUsd(highUsd)
         : `${{formatCompactMetric(inputTokens + outputTokens)}} tok`;
+      const billingTags = billing.tags && typeof billing.tags === "object"
+        ? billing.tags
+        : {{}};
+      const plannedOwner = String(
+        billingTags.billing_owner || snapshot?.accounting?.billing_owner || ""
+      ).trim().toLowerCase();
+      const plannedGroup = String(
+        billingTags.agent_group || snapshot?.accounting?.agent_group || ""
+      ).trim().toLowerCase();
+      const plannedAuthMode = String(
+        billingTags.codex_auth_mode || snapshot?.accounting?.codex_auth_mode || ""
+      ).trim().toLowerCase();
+      const plannedLocalRoute = ["localllm", "codexspark"].includes(selectedRuntime)
+        || selectedRuntime.includes("norllama")
+        || selectedRuntime.includes("ollama")
+        || selectedRuntime.includes("spark");
+      const plannedSubscriptionRoute = selectedRuntime === "codex"
+        && plannedOwner === "kristopher"
+        && plannedGroup !== "work"
+        && plannedAuthMode === "chatgpt";
+      const plannedSpendLabel = plannedLocalRoute
+        ? "Planned local · no cloud bill"
+        : plannedSubscriptionRoute
+          ? `Planned ${{PLAN_CREDIT_LABEL}} · ~${{formatCompactMetric(creditEstimate.credits)}} cr`
+          : hasUsd
+            ? `Planned cloud · ~${{nextCostLabel}}`
+            : "Planned token target";
       const resolvedLabel = selectedTier === effectiveTier
         ? serviceTierOption(selectedTier).short_label || selectedTier
         : `${{serviceTierOption(selectedTier).short_label || selectedTier}}→${{serviceTierOption(effectiveTier).short_label || effectiveTier}}`;
@@ -49897,16 +52186,20 @@ class Handler(BaseHTTPRequestHandler):
         ? "1 model call"
         : `~${{turns.toFixed(1).replace(/\\.0$/, "")}} model calls`;
       const label = [
+        plannedSpendLabel,
         `Target ${{jobBudgetLabel(preferences.jobBudget)}}`,
         turnLabel,
-        `next ~${{nextCostLabel}}`,
-        `${{optimizationModeOption(optimizationMode).short_label || optimizationMode}}`,
-        resolvedLabel,
-        hourlyLabel,
-        perTurnLabel,
+        `${{optimizationModeOption(optimizationMode).short_label || optimizationMode}} / ${{resolvedLabel}}`,
       ].filter(Boolean).join(" · ");
       const title = [
         "Projected next prompt target and cost; local estimate, not invoice.",
+        plannedLocalRoute
+          ? "Planned local/Norllama route has no metered cloud-provider charge. Local hardware and electricity are not included."
+          : plannedSubscriptionRoute
+            ? `Planned personal ${{PLAN_CREDIT_LABEL}} estimate. It is not a credit-card charge or a known balance deduction.`
+            : hasUsd
+              ? `Planned cloud rate-card estimate ~${{nextCostLabel}}.`
+              : "No provider price card is available for this planned route.",
         "Work window is the primary control; depth affects answer effort; spend path is an emergency override.",
         `Window ${{jobBudgetLabel(preferences.jobBudget)}} estimates ~${{turns.toFixed(1).replace(/\\.0$/, "")}} turn-equivalent model calls.`,
         `Input estimate ${{formatCount(inputTokens)}} tokens, cached ${{formatCount(cachedTokens)}}, output ${{formatCount(outputTokens)}}.`,
@@ -49914,9 +52207,9 @@ class Handler(BaseHTTPRequestHandler):
         `Spend path ${{serviceTierLabel(selectedTier)}} resolves to ${{serviceTierLabel(effectiveTier)}} for estimation.`,
         `Optimization ${{optimizationModeLabel(optimizationMode)}}; cache factor ${{Math.round(cacheFraction * 100)}}%.`,
         hasUsd ? `Projected USD equivalent ${{nextCostLabel}}.` : "USD rates unavailable; showing token estimate.",
-        creditRates.configured ? `Codex credit comparison ~${{formatCompactMetric(creditEstimate.credits)}} credits.` : "",
+        creditRates.configured ? `${{PLAN_CREDIT_LABEL}} comparison ~${{formatCompactMetric(creditEstimate.credits)}} credits.` : "",
         recentUsd > 0 ? `Recent ledger ${{formatCompactUsd(recentUsd)}} last 24h; ${{hourlyLabel}}; ${{perTurnLabel || "no per-turn average"}}.` : "",
-        recentCredits > 0 ? `Recent Codex credit estimate ~${{formatCompactMetric(recentCredits)}} credits last 24h.` : "",
+        recentCredits > 0 ? `Recent ${{PLAN_CREDIT_LABEL}} estimate ~${{formatCompactMetric(recentCredits)}} credits last 24h.` : "",
         !recentUsd && recentTokens > 0 ? `Recent ledger ${{formatCompactMetric(recentTokens)}} tokens across ${{formatCount(recentTurns)}} turns last 24h.` : "",
         rates.source ? `Rate source: ${{rates.source}}.` : "",
         usd.longContext ? "Long-context uplift may apply at provider thresholds." : "",
@@ -50351,6 +52644,32 @@ class Handler(BaseHTTPRequestHandler):
         tone,
         title,
         sparkline,
+        action: "system",
+      }};
+    }}
+
+    function spendFeedbackCapsuleState(snapshot) {{
+      const usage = snapshot && typeof snapshot === "object" ? snapshot.usage || {{}} : {{}};
+      const lastTurn = usage && typeof usage === "object" && usage.last_turn && typeof usage.last_turn === "object"
+        ? usage.last_turn
+        : null;
+      const feedback = turnCostFeedbackDescriptor(lastTurn, snapshot);
+      if (!feedback) {{
+        return null;
+      }}
+      return {{
+        id: "turn-spend",
+        label: "Spend",
+        value: feedback.label,
+        meta: feedback.meta,
+        tone: feedback.tone === "good"
+          ? "ok"
+          : feedback.tone === "heavy"
+            ? "alert"
+            : feedback.tone === "watch"
+              ? "warn"
+              : "active",
+        title: feedback.title,
         action: "system",
       }};
     }}
@@ -51574,6 +53893,10 @@ class Handler(BaseHTTPRequestHandler):
       const timeCapsule = timeTargetCapsuleState(snapshot);
       if (timeCapsule) {{
         capsules.push(timeCapsule);
+      }}
+      const spendFeedbackCapsule = spendFeedbackCapsuleState(snapshot);
+      if (spendFeedbackCapsule) {{
+        capsules.push(spendFeedbackCapsule);
       }}
       const humanCapsule = humanInterventionCapsuleState(snapshot);
       if (humanCapsule) {{
@@ -54825,6 +57148,9 @@ class Handler(BaseHTTPRequestHandler):
       if (cleanRole.includes("pending")) {{
         article.classList.add("live-status");
       }}
+      if (options.workingRecap) {{
+        article.classList.add("working-on-message");
+      }}
       if (options.liveStatusStage) {{
         article.dataset.liveStatusStage = String(options.liveStatusStage || "");
       }}
@@ -54861,6 +57187,21 @@ class Handler(BaseHTTPRequestHandler):
         costNode.title = cost.title;
         costNode.setAttribute("aria-label", cost.title);
         metaWrap.appendChild(costNode);
+      }}
+      const costFeedback = turnCostFeedbackDescriptor(
+        options.usage,
+        options.usageSnapshot || state.snapshot
+      );
+      if (costFeedback && (cleanRole.includes("assistant") || cleanRole.includes("error"))) {{
+        const feedbackNode = document.createElement("span");
+        feedbackNode.className = "message-value-chip";
+        feedbackNode.dataset.valueTone = costFeedback.tone || "quiet";
+        feedbackNode.textContent = [costFeedback.label, costFeedback.meta]
+          .filter(Boolean)
+          .join(" · ");
+        feedbackNode.title = costFeedback.title;
+        feedbackNode.setAttribute("aria-label", costFeedback.title);
+        metaWrap.appendChild(feedbackNode);
       }}
       const effort = turnEffortLedgerDescriptor(options.historyItem || null, options.usage || null);
       if (effort && (cleanRole.includes("assistant") || cleanRole.includes("error"))) {{
@@ -54968,8 +57309,12 @@ class Handler(BaseHTTPRequestHandler):
 
       const text = document.createElement("div");
       text.className = "message-body";
-      const collapsedPrompt = collapsedPromptDescriptor(cleanRole, body, options);
-      if (collapsedPrompt) {{
+      if (cleanRole.includes("pending") && options.workingRecap) {{
+        text.classList.add("working-on-body");
+        text.replaceChildren(buildWorkingOnPanel(options.workingRecap, options.usageSnapshot || state.snapshot, body));
+      }} else {{
+        const collapsedPrompt = collapsedPromptDescriptor(cleanRole, body, options);
+        if (collapsedPrompt) {{
         text.innerHTML = `
           <button type="button" class="collapsed-prompt-toggle" aria-expanded="false">
             <span class="collapsed-prompt-badge">${{escapeHtml(collapsedPrompt.badge || "Text")}}</span>
@@ -55001,10 +57346,11 @@ class Handler(BaseHTTPRequestHandler):
             toggle.setAttribute("aria-expanded", opening ? "true" : "false");
           }});
         }}
-      }} else {{
-        text.innerHTML = cleanRole.includes("error")
-          ? renderErrorMarkup(body)
-          : renderRichText(body);
+        }} else {{
+          text.innerHTML = cleanRole.includes("error")
+            ? renderErrorMarkup(body)
+            : renderRichText(body);
+        }}
       }}
 
       article.appendChild(head);
@@ -55236,7 +57582,9 @@ class Handler(BaseHTTPRequestHandler):
         const elapsed = activityElapsed(snapshot);
         const modelState = snapshot.model_process_alive ? "model process alive" : "waiting for model process";
         const usageCopy = usageSummaryForActiveWork(snapshot);
-        const liveExpanded = liveStatusExpanded(snapshot, elapsed);
+        const workingRecap = workingRecapForSnapshot(snapshot);
+        const liveExpanded = liveStatusExpanded(snapshot, elapsed)
+          || Boolean(workingRecap.now || workingRecap.milestones.length || workingRecap.history.length > 1);
         const liveStatusBody = liveStatusBodyForSnapshot(snapshot, elapsed, usageCopy, modelState, liveExpanded);
         if (!runningPromptAlreadyVisible) {{
           appendMessage(
@@ -55264,6 +57612,8 @@ class Handler(BaseHTTPRequestHandler):
             sourcePrompt: snapshot.running_prompt || "",
             inlinePreviews: false,
             liveStatusStage: liveExpanded ? "expanded" : "initial",
+            workingRecap,
+            usageSnapshot: snapshot,
           }}
         );
       }}
@@ -55425,6 +57775,11 @@ class Handler(BaseHTTPRequestHandler):
       const tokens = Math.max(0, Number(plan.estimated_total_tokens || 0));
       const usd = Math.max(0, Number(plan.estimated_cost_usd || 0));
       const confidence = String(plan.estimate_confidence || "").trim();
+      const capacity = plan.token_capacity_plan && typeof plan.token_capacity_plan === "object"
+        ? plan.token_capacity_plan
+        : {{}};
+      const outputCap = Math.max(0, Number(capacity.execution_output_cap || 0));
+      const capacityProvider = String(capacity.provider_class || "").trim().replace(/_/g, " ");
       const parts = [];
       if (skillCount) {{
         parts.push(`${{formatCount(skillCount)}} skill${{skillCount === 1 ? "" : "s"}}`);
@@ -55439,6 +57794,9 @@ class Handler(BaseHTTPRequestHandler):
       }}
       if (usd && Boolean(plan.cost_configured)) {{
         parts.push(`~${{formatCompactUsd(usd)}} equiv`);
+      }}
+      if (outputCap) {{
+        parts.push(`${{capacityProvider || "provider"}} cap ${{formatCompactMetric(outputCap)}} out`);
       }}
       if (confidence && confidence !== "none") {{
         parts.push(`${{confidence}} confidence`);
@@ -55539,6 +57897,138 @@ class Handler(BaseHTTPRequestHandler):
         usageCopy ? `${{usageCopy}}.` : "",
         `${{modelState}}.`,
       ].filter(Boolean).join(" ");
+    }}
+
+    function workingRecapForSnapshot(snapshot = state.snapshot) {{
+      const recap = snapshot && typeof snapshot.working_recap === "object"
+        ? snapshot.working_recap
+        : {{}};
+      const milestones = Array.isArray(recap.milestones)
+        ? recap.milestones.map((item) => String(item || "").trim()).filter(Boolean).slice(0, 3)
+        : [];
+      const history = Array.isArray(recap.history)
+        ? recap.history
+          .filter((item) => item && typeof item === "object")
+          .map((item) => ({{
+            at: Number(item.at || 0),
+            now: String(item.now || "").trim(),
+            milestones: Array.isArray(item.milestones)
+              ? item.milestones.map((value) => String(value || "").trim()).filter(Boolean).slice(0, 3)
+              : [],
+            next: String(item.next || "").trim(),
+            source: String(item.source || "").trim().toLowerCase(),
+          }}))
+          .filter((item) => item.now || item.milestones.length || item.next)
+          .slice(-6)
+        : [];
+      return {{
+        status: String(recap.status || "").trim().toLowerCase(),
+        headline: String(recap.headline || "").trim(),
+        now: String(recap.now || "").trim(),
+        milestones,
+        next: String(recap.next || "").trim(),
+        updatedAt: Number(recap.updated_at || 0),
+        refreshing: Boolean(recap.refreshing),
+        source: String(recap.source || "").trim().toLowerCase(),
+        model: String(recap.model || "").trim(),
+        history,
+      }};
+    }}
+
+    function workingRecapSourceLabel(recap) {{
+      if (recap.refreshing) return "Refreshing local recap";
+      if (recap.source === "local_llm") return "Local recap";
+      return "Live recap";
+    }}
+
+    function buildWorkingOnPanel(recap, snapshot, fallbackBody = "") {{
+      const panel = document.createElement("section");
+      panel.className = "working-on-panel";
+      panel.setAttribute("aria-label", "Working on");
+
+      const top = document.createElement("div");
+      top.className = "working-on-panel-head";
+      const label = document.createElement("span");
+      label.className = "working-on-kicker";
+      label.textContent = "Working on";
+      top.appendChild(label);
+      const source = document.createElement("span");
+      source.className = "working-on-source";
+      source.textContent = workingRecapSourceLabel(recap);
+      if (recap.updatedAt) {{
+        source.title = `Last recap ${{formatTs(recap.updatedAt)}}${{recap.model ? ` via ${{recap.model}}` : ""}}`;
+      }}
+      top.appendChild(source);
+      panel.appendChild(top);
+
+      const headline = document.createElement("strong");
+      headline.className = "working-on-headline";
+      headline.textContent = recap.headline || "Preparing the active request.";
+      panel.appendChild(headline);
+
+      const now = document.createElement("p");
+      now.className = "working-on-now";
+      now.textContent = recap.now || fallbackBody || "The worker is preparing the first concrete step.";
+      panel.appendChild(now);
+
+      if (recap.milestones.length) {{
+        const milestones = document.createElement("ul");
+        milestones.className = "working-on-milestones";
+        for (const item of recap.milestones) {{
+          const milestone = document.createElement("li");
+          milestone.textContent = item;
+          milestones.appendChild(milestone);
+        }}
+        panel.appendChild(milestones);
+      }}
+
+      const footer = document.createElement("div");
+      footer.className = "working-on-footer";
+      if (recap.next) {{
+        const next = document.createElement("span");
+        next.className = "working-on-next";
+        next.textContent = `Next: ${{recap.next}}`;
+        footer.appendChild(next);
+      }}
+      const elapsed = activityElapsed(snapshot);
+      if (elapsed > 0) {{
+        const elapsedNode = document.createElement("span");
+        elapsedNode.className = "working-on-elapsed";
+        elapsedNode.textContent = `${{formatElapsedCompact(elapsed)}} elapsed`;
+        footer.appendChild(elapsedNode);
+      }}
+      if (footer.childElementCount) {{
+        panel.appendChild(footer);
+      }}
+
+      if (recap.history.length > 1) {{
+        const timeline = document.createElement("details");
+        timeline.className = "working-on-timeline";
+        const summary = document.createElement("summary");
+        const count = recap.history.length;
+        summary.textContent = `${{count}} recap update${{count === 1 ? "" : "s"}}`;
+        timeline.appendChild(summary);
+        const entries = document.createElement("ol");
+        for (const entry of recap.history.slice().reverse()) {{
+          const item = document.createElement("li");
+          const stamp = document.createElement("span");
+          stamp.className = "working-on-timeline-stamp";
+          stamp.textContent = entry.at ? formatTs(entry.at) : "Earlier";
+          item.appendChild(stamp);
+          const copy = document.createElement("span");
+          copy.className = "working-on-timeline-copy";
+          copy.textContent = [
+            entry.now,
+            ...(entry.milestones || []),
+            entry.next ? `Next: ${{entry.next}}` : "",
+          ].filter(Boolean).join(" ");
+          item.appendChild(copy);
+          entries.appendChild(item);
+        }}
+        timeline.appendChild(entries);
+        panel.appendChild(timeline);
+      }}
+      return panel;
     }}
 
     function responseFrameRouteCopy(snapshot = state.snapshot, live = null) {{
@@ -55933,6 +58423,7 @@ class Handler(BaseHTTPRequestHandler):
       const queued = queuedEntries(snapshot);
       if (snapshot.pending) {{
         const stage = inferWorkingStage(snapshot);
+        const workingRecap = workingRecapForSnapshot(snapshot);
         const elapsed = activityElapsed(snapshot);
         const handoffActive = String(snapshot.queue_handoff_state || "").toLowerCase() === "running";
         const startedParts = [];
@@ -55990,6 +58481,7 @@ class Handler(BaseHTTPRequestHandler):
           mode: "working",
           stripTitle: handoffActive ? "Interrupt handoff" : stage.line,
           stripDetail: [
+            workingRecap.now ? summarizePrompt(workingRecap.now, 112) : "",
             promptProfileText(snapshot.running_speed, snapshot.running_detail, snapshot.running_job_budget, snapshot.running_service_tier, snapshot.running_optimization_mode),
             startedParts.find((item) => item.includes("in flight")) || "",
             handoffActive ? "previous work preserved" : "",
@@ -55999,7 +58491,7 @@ class Handler(BaseHTTPRequestHandler):
             !elapsed && snapshot.last_started_at ? `started ${{formatTs(snapshot.last_started_at)}}` : "",
           ].filter(Boolean).join(" · "),
           peekTitle: handoffActive ? "Interrupt" : "Background",
-          simLine: `${{handoffActive ? "Interrupt handoff" : "Running"}}: ${{summarizePrompt(snapshot.running_prompt || "", 120)}}`,
+          simLine: `${{handoffActive ? "Interrupt handoff" : "Running"}}: ${{workingRecap.headline || summarizePrompt(snapshot.running_prompt || "", 120)}}`,
           simMeta: handoffActive
             ? [snapshot.queue_handoff_detail || "The queued prompt is running after a safe-checkpoint handoff.", ...startedParts, ...queuePreview]
             : [...startedParts, ...queuePreview],
@@ -56504,6 +58996,7 @@ class Handler(BaseHTTPRequestHandler):
       let statusText = snapshot.status_message || "Ready.";
       if (snapshot.pending && snapshot.running_prompt) {{
         const elapsed = activityElapsed(snapshot);
+        const workingRecap = workingRecapForSnapshot(snapshot);
         const handoffActive = String(snapshot.queue_handoff_state || "").toLowerCase() === "running";
         if (snapshot.rate_limit_active || snapshot.state === "rate_limited") {{
           statusText = [
@@ -56521,7 +59014,8 @@ class Handler(BaseHTTPRequestHandler):
           ].filter(Boolean).join(" · ");
         }} else {{
           statusText = [
-            `Running: ${{summarizePrompt(snapshot.running_prompt, 88)}}`,
+            `Running: ${{workingRecap.headline || summarizePrompt(snapshot.running_prompt, 88)}}`,
+            workingRecap.now ? summarizePrompt(workingRecap.now, 104) : "",
             elapsed > 0 ? `${{formatElapsedCompact(elapsed)}} elapsed` : "",
             promptProfileText(snapshot.running_speed, snapshot.running_detail, snapshot.running_job_budget, snapshot.running_service_tier, snapshot.running_optimization_mode),
             usageSummaryForActiveWork(snapshot),

--- a/scripts/sync_agent_console_template.py
+++ b/scripts/sync_agent_console_template.py
@@ -306,6 +306,13 @@ RUNTIME_BRIDGE_RECENT_ITEMS = "12"
 RUNTIME_BRIDGE_LOCAL_FIRST_PROOF_LIMIT = "250"
 RUNTIME_BRIDGE_LOCAL_FIRST_SESSION_LIMIT = "20"
 LOCAL_LLM_DISABLED_MODEL_PATTERNS = "llama3.2,llama3.2:*"
+LOCAL_ROUTE_INTENT_CLASSIFIER_MODEL = (
+    os.environ.get(
+        "NORMAN_SYNC_LOCAL_ROUTE_INTENT_CLASSIFIER_MODEL",
+        "qwen3.6:35b-a3b-q4_K_M",
+    ).strip()
+    or "qwen3.6:35b-a3b-q4_K_M"
+)
 WORK_BEDROCK_DEFAULT_INSTANCES: tuple[str, ...] = (
     "compere",
     "control-plane",
@@ -1298,8 +1305,6 @@ def instance_uses_non_work_bedrock(
         return False
     if instance_uses_work_config(host, instance):
         return False
-    if host.name in {"norman", "networking-host", "work-special"}:
-        return False
     return non_work_bedrock_profile_source_ready()
 
 
@@ -1448,6 +1453,32 @@ def _origin_model_updates(
                 "NORMAN_CODEX_STANDARD_AWS_PROFILE": NON_WORK_BEDROCK_AWS_PROFILE,
                 "NORMAN_CODEX_STANDARD_AWS_REGION": NON_WORK_BEDROCK_AWS_REGION,
                 "NORMAN_CODEX_STANDARD_MODEL": PERSONAL_DEFAULT_MODEL,
+                "NORMAN_CODEX_MODEL": PERSONAL_DEFAULT_MODEL,
+                "NORMAN_CODEX_MODEL_FLOOR": PERSONAL_DEFAULT_MODEL,
+                "NORMAN_CODEX_DIRECT_MODEL": PERSONAL_DEFAULT_MODEL,
+                "NORMAN_CODEX_FLEX_MODEL": PERSONAL_DEFAULT_MODEL,
+                "NORMAN_CODEX_PRIORITY_MODEL": PERSONAL_DEFAULT_MODEL,
+                "NORMAN_CODEX_SWITCHABLE_MODELS": PERSONAL_SWITCHABLE_MODELS,
+                "NORMAN_CODEX_AVAILABLE_MODELS": PERSONAL_SWITCHABLE_MODELS,
+                "NORMAN_CODEX_ZERO_TOKEN_PROVIDER_MAX_RETRIES": "1",
+            },
+            [],
+        )
+
+    non_work_bedrock_enabled = (
+        os.environ.get("NORMAN_SYNC_NON_WORK_BEDROCK_DEFAULT_ENABLED", "1") != "0"
+    )
+    if not use_work and non_work_bedrock_enabled:
+        # The non-secret profile source is unavailable in this invocation. Do not
+        # erase an already-deployed Bedrock profile and fall back to direct Flex.
+        # A missing profile then fails closed to the default tier rather than
+        # silently spending through a direct route.
+        return (
+            {
+                **role_policy_env,
+                "NORMAN_CODEX_BILLING_SCOPE": host.name,
+                "NORMAN_CODEX_BILLING_OWNER": "kristopher",
+                "NORMAN_CODEX_SERVICE_TIER": "default",
                 "NORMAN_CODEX_MODEL": PERSONAL_DEFAULT_MODEL,
                 "NORMAN_CODEX_MODEL_FLOOR": PERSONAL_DEFAULT_MODEL,
                 "NORMAN_CODEX_DIRECT_MODEL": PERSONAL_DEFAULT_MODEL,
@@ -1940,6 +1971,33 @@ def sync_instance_local_llm_foreground_settings(
         "NORMAN_LOCAL_LLM_SHORT_NUM_CTX": "4096",
         "NORMAN_LOCAL_LLM_FALLBACK_MODELS": "",
         "NORMAN_LOCAL_LLM_ALLOW_TINY_FOREGROUND_FALLBACK": "0",
+        "NORMAN_TUI_TOKEN_CAPACITY_PLAN_ENABLED": "1",
+        "NORMAN_TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS": "3600",
+        "NORMAN_TUI_NORLLAMA_OUTPUT_TOKENS_PER_HOUR": "48000",
+        "NORMAN_TUI_BEDROCK_OUTPUT_TOKENS_PER_HOUR": "72000",
+        "NORMAN_TUI_CODEX_OUTPUT_TOKENS_PER_HOUR": "60000",
+        "NORMAN_TUI_OPENAI_OUTPUT_TOKENS_PER_HOUR": "60000",
+        "NORMAN_CODEX_ACCOUNT_CAPACITY_COMMAND": "/status",
+        "NORMAN_CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND": "",
+        "NORMAN_CODEX_SUBSCRIPTION_ROUTE_PREFERENCE_ENABLED": "1",
+        "NORMAN_CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED": (
+            "1" if instance_uses_work_config(host, instance) else "0"
+        ),
+        "NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT": "25",
+        "NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS": "300",
+        "NORMAN_CODEX_SUBSCRIPTION_ROUTE_FORECAST_CAP_FRACTION": "0.5",
+        "NORMAN_CODEX_ALLOW_OPENAI_API_SPEND": "0",
+        "NORMAN_CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED": "0",
+        "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ENABLED": (
+            "1" if instance.name == "norman" else "0"
+        ),
+        "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_PERCENT_LEFT": "70",
+        "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MIN_RESET_SECONDS": "240",
+        "NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_MAX_RESET_SECONDS": "1200",
+        "NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_MODEL": (
+            LOCAL_ROUTE_INTENT_CLASSIFIER_MODEL
+        ),
+        "NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_MAX_OUTPUT_TOKENS": "192",
     }
     remove_keys = [
         "NORMAN_LOCAL_PLANNER_PREFLIGHT_MODELS",

--- a/scripts/systemd/norman-agent-console-sync-local.service
+++ b/scripts/systemd/norman-agent-console-sync-local.service
@@ -5,4 +5,5 @@ Description=Sync local Norman agent console template writes
 Type=oneshot
 WorkingDirectory=/home/kristopher/code/norman
 Environment=PYTHONPATH=/home/kristopher/code/norman
+Environment=NORMAN_SYNC_NON_WORK_BEDROCK_PROFILE_SOURCE=/home/kristopher/.codex-nonwork/personal-bedrock.config.toml
 ExecStart=/usr/bin/flock -n /run/norman-agent-console-sync-local.lock /home/kristopher/code/norman/.venv/bin/python /home/kristopher/code/norman/scripts/sync_agent_console_template.py --targets hal

--- a/scripts/systemd/norman-agent-console-sync-personal-bedrock.conf
+++ b/scripts/systemd/norman-agent-console-sync-personal-bedrock.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=NORMAN_SYNC_NON_WORK_BEDROCK_PROFILE_SOURCE=/home/kristopher/.codex-nonwork/personal-bedrock.config.toml

--- a/scripts/systemd/norman-agent-console-sync.service
+++ b/scripts/systemd/norman-agent-console-sync.service
@@ -4,4 +4,5 @@ Description=Sync Norman agent console template
 [Service]
 Type=oneshot
 WorkingDirectory=%h/code/norman
+Environment=NORMAN_SYNC_NON_WORK_BEDROCK_PROFILE_SOURCE=%h/.codex-nonwork/personal-bedrock.config.toml
 ExecStart=/usr/bin/flock -n %t/norman-agent-console-sync.lock /usr/bin/python3 %h/code/norman/scripts/sync_agent_console_template.py

--- a/scripts/tui_bedrock_region_smoke.py
+++ b/scripts/tui_bedrock_region_smoke.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import tempfile
 import sqlite3
@@ -314,6 +315,44 @@ def _event_types(stdout_text: str) -> list[str]:
     return event_types
 
 
+def resolve_codex_profile_config_flag(codex_bin: str) -> str:
+    try:
+        completed = subprocess.run(
+            [codex_bin, "exec", "--help"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "--profile"
+    help_text = f"{completed.stdout}\n{completed.stderr}"
+    has_profile = bool(re.search(r"(?<![\w-])--profile(?![\w-])", help_text))
+    has_profile_v2 = bool(re.search(r"(?<![\w-])--profile-v2(?![\w-])", help_text))
+    if has_profile and has_profile_v2:
+        try:
+            version = subprocess.run(
+                [codex_bin, "--version"],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return "--profile-v2"
+        match = re.search(r"(\d+)\.(\d+)\.(\d+)", f"{version.stdout} {version.stderr}")
+        if match and tuple(int(part) for part in match.groups()) < (0, 134, 0):
+            return "--profile-v2"
+        return "--profile"
+    if has_profile:
+        return "--profile"
+    if has_profile_v2:
+        return "--profile-v2"
+    return "--profile"
+
+
 def run_live_candidate(
     *,
     codex_bin: str,
@@ -325,6 +364,7 @@ def run_live_candidate(
     timeout_seconds: int,
 ) -> dict[str, Any]:
     started_at = int(time.time())
+    profile_flag = resolve_codex_profile_config_flag(codex_bin)
     sentinel = "BEDROCK_SMOKE_OK_" + "".join(
         ch if ch.isalnum() else "_" for ch in f"{profile_v2}_{aws_region}"
     )
@@ -339,14 +379,14 @@ def run_live_candidate(
             "--ignore-rules",
             "-C",
             workdir,
-            "--profile-v2",
+            profile_flag,
             profile_v2,
             "-m",
             model,
             "-c",
             'service_tier="default"',
             "-c",
-            'model_reasoning_effort="minimal"',
+            'model_reasoning_effort="low"',
             "-o",
             str(output_path),
             f"Reply exactly: {sentinel}",

--- a/scripts/tui_fleet_scorecard.py
+++ b/scripts/tui_fleet_scorecard.py
@@ -7,6 +7,7 @@ import os
 import re
 import sqlite3
 import subprocess
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass, field
@@ -871,6 +872,49 @@ def render_markdown(rows: list[ScoreRow]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def render_inventory_unavailable(
+    *,
+    db_path: Path,
+    registry_path: Path,
+    json_output: bool,
+) -> str:
+    detail = (
+        "No TUI inventory was found from the configured database or registry. "
+        "This is not a healthy empty fleet; refresh the runtime inventory or "
+        "supply --db/--registry with populated sources."
+    )
+    if json_output:
+        return json.dumps(
+            {
+                "schema": "norman.tui-fleet-scorecard.v1",
+                "status": "inventory_unavailable",
+                "items": [],
+                "error": detail,
+                "sources": {
+                    "db": str(db_path),
+                    "registry": str(registry_path),
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    return (
+        "\n".join(
+            (
+                "# TUI Fleet Scorecard",
+                "",
+                "Status: `inventory_unavailable`",
+                "",
+                detail,
+                "",
+                f"- Database: `{db_path}`",
+                f"- Registry: `{registry_path}`",
+            )
+        )
+        + "\n"
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Score Norman TUI fleet health.")
     parser.add_argument("--db", type=Path, default=DEFAULT_DB)
@@ -908,6 +952,22 @@ def main() -> int:
         [*load_db_items(args.db), *load_registry_items(args.registry)],
         token_map,
     )
+    if not items:
+        payload = render_inventory_unavailable(
+            db_path=args.db,
+            registry_path=args.registry,
+            json_output=bool(args.json),
+        )
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(payload, encoding="utf-8")
+        print(payload, end="" if payload.endswith("\n") else "\n")
+        print(
+            "TUI fleet scorecard failed: no inventory found; refusing to report "
+            "a healthy empty fleet.",
+            file=sys.stderr,
+        )
+        return 2
     expected_dns = expected_tailnet_dns(items, tailnet_frontdoor)
     with ThreadPoolExecutor(max_workers=max(1, int(args.jobs))) as executor:
         rows = list(

--- a/scripts/tui_kernel_acceptance.py
+++ b/scripts/tui_kernel_acceptance.py
@@ -2182,6 +2182,45 @@ def print_report(results: list[dict[str, Any]]) -> None:
             print("  - %s" % failure)
 
 
+def dry_run_report(
+    matrix: list[tuple[TuiTarget, ScenarioRun]], *, run_id: str
+) -> dict[str, Any]:
+    plans: list[dict[str, Any]] = []
+    for target, run in matrix:
+        plans.append(
+            {
+                "target": target.name,
+                "scenario": run.name,
+                "transport": (
+                    f"ssh:{target.ssh_target}" if target.ssh_target else "local"
+                ),
+                "planned_message": run.message,
+                "expected_response": run.expected_response,
+                "execution_status": "not_executed",
+            }
+        )
+    return {
+        "schema": "norman.tui-kernel-acceptance.v1",
+        "run_id": run_id,
+        "generated_at": int(time.time()),
+        "dry_run_only": True,
+        "model_calls_executed": 0,
+        "execution_status": "not_executed",
+        "passed": None,
+        "total_count": len(plans),
+        "plans": plans,
+    }
+
+
+def write_json_report(path: str, report: dict[str, Any]) -> None:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run Norman TUI kernel local-first acceptance canaries."
@@ -2270,12 +2309,15 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args.live:
         print("Dry run. Add --live to send prompts.")
+        report = dry_run_report(matrix, run_id=run_id)
         for target, run in matrix:
             transport = "ssh:%s" % target.ssh_target if target.ssh_target else "local"
             print(
-                "%-11s %-7s %s %s"
+                "%-11s %-7s %s expected response (not executed): %s"
                 % (target.name, run.name, transport, run.expected_response)
             )
+        if args.output_json:
+            write_json_report(args.output_json, report)
         return 0
 
     results: list[dict[str, Any]] = []
@@ -2329,10 +2371,7 @@ def main(argv: list[str] | None = None) -> int:
         }
         print(report["preflight_failures"][0], file=sys.stderr)
         if args.output_json:
-            Path(args.output_json).write_text(
-                json.dumps(report, indent=2, sort_keys=True) + "\n",
-                encoding="utf-8",
-            )
+            write_json_report(args.output_json, report)
         return 2
     for index, (target, run) in enumerate(matrix, start=1):
         print(
@@ -2440,10 +2479,7 @@ def main(argv: list[str] | None = None) -> int:
     }
     print_report(results)
     if args.output_json:
-        Path(args.output_json).write_text(
-            json.dumps(report, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
+        write_json_report(args.output_json, report)
     return 0 if report["passed"] else 1
 
 

--- a/scripts/tui_vllm_sense.py
+++ b/scripts/tui_vllm_sense.py
@@ -20,10 +20,10 @@ from urllib import error, request
 SCHEMA = "norman.tui.vllm-sense.v1"
 DEFAULT_VLLM_PORT = 8000
 DEFAULT_ENDPOINTS = (
-    "http://127.0.0.1:8000",
-    "http://localhost:8000",
     "https://llm.home.arpa",
     "http://llm.home.arpa",
+    "http://127.0.0.1:8000",
+    "http://localhost:8000",
 )
 DEFAULT_LAN_SUFFIXES = ("home.arpa", "local")
 urlopen = request.urlopen
@@ -223,7 +223,7 @@ def configured_endpoints(
         if should_autosense
         else []
     )
-    return _dedupe([*default_items, *env_items, *lan_items, *(extra or [])])
+    return _dedupe([*(extra or []), *env_items, *default_items, *lan_items])
 
 
 def _model_names(payload: dict[str, Any]) -> list[str]:
@@ -385,12 +385,23 @@ def probe_endpoint(
 
 
 def build_report(
-    endpoints: list[str], *, timeout: float, preferred_model: str = ""
+    endpoints: list[str],
+    *,
+    timeout: float,
+    preferred_model: str = "",
+    stop_after_usable: bool = False,
 ) -> dict[str, Any]:
-    results = [
-        probe_endpoint(endpoint, timeout=timeout, preferred_model=preferred_model)
-        for endpoint in _dedupe(endpoints)
-    ]
+    candidate_endpoints = _dedupe(endpoints)
+    results: list[ProbeResult] = []
+    for endpoint in candidate_endpoints:
+        result = probe_endpoint(
+            endpoint,
+            timeout=timeout,
+            preferred_model=preferred_model,
+        )
+        results.append(result)
+        if stop_after_usable and result.usable:
+            break
     usable = [result for result in results if result.usable]
     online = [result for result in results if result.ok]
     reachable = [result for result in results if result.ok or result.health_ok]
@@ -398,6 +409,7 @@ def build_report(
         "schema": SCHEMA,
         "generated_at": int(time.time()),
         "summary": {
+            "candidate_endpoint_count": len(candidate_endpoints),
             "total_endpoints": len(results),
             "reachable_endpoints": len(reachable),
             "online_endpoints": len(online),
@@ -499,6 +511,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Exit non-zero when no usable endpoint is found.",
     )
+    parser.add_argument(
+        "--probe-all",
+        action="store_true",
+        help="Probe every candidate even after a usable endpoint is found.",
+    )
     return parser.parse_args(argv)
 
 
@@ -513,6 +530,7 @@ def main(argv: list[str] | None = None) -> int:
         ),
         timeout=max(0.1, args.timeout),
         preferred_model=args.preferred_model.strip(),
+        stop_after_usable=not args.probe_all,
     )
     output = json.dumps(report, indent=2, sort_keys=True) + "\n"
     if args.output:

--- a/tests/test_agent_console_runtime_bridge.py
+++ b/tests/test_agent_console_runtime_bridge.py
@@ -102,6 +102,187 @@ def test_response_owner_meta_ignores_stale_response_hash(monkeypatch, tmp_path):
     assert module.last_response_meta_for("second answer") == {}
 
 
+def test_working_recap_redacts_sensitive_text_and_uses_bounded_history(
+    monkeypatch, tmp_path
+):
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+    recap = module.normalize_working_recap(
+        {
+            "turn_key": "turn-1",
+            "status": "running",
+            "headline": "Inspect api_key=super-secret",
+            "now": "Using Bearer top-secret-token to check progress.",
+            "milestones": [
+                "Found token=another-secret.",
+                "First safe milestone.",
+                "Second safe milestone.",
+                "This item is beyond the panel limit.",
+            ],
+            "next": "Do not expose password: no-thanks.",
+            "history": [
+                {
+                    "at": 10,
+                    "now": "First api_key=old-secret update.",
+                    "milestones": [],
+                    "next": "Continue.",
+                }
+                for _ in range(module.WORKING_RECAP_HISTORY_ITEMS + 2)
+            ],
+        }
+    )
+
+    visible_text = " ".join(
+        [
+            recap["headline"],
+            recap["now"],
+            *recap["milestones"],
+            recap["next"],
+            *[
+                " ".join(
+                    [
+                        item["now"],
+                        *item["milestones"],
+                        item["next"],
+                    ]
+                )
+                for item in recap["history"]
+            ],
+        ]
+    )
+
+    assert "super-secret" not in visible_text
+    assert "top-secret-token" not in visible_text
+    assert "another-secret" not in visible_text
+    assert "no-thanks" not in visible_text
+    assert "[redacted]" in visible_text
+    assert len(recap["milestones"]) == 3
+    assert len(recap["history"]) <= module.WORKING_RECAP_HISTORY_ITEMS
+
+
+def test_working_recap_local_llm_uses_sanitized_packet_and_normalizes_json(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("NORMAN_LOCAL_LLM_EXECUTION_ENABLED", "1")
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+    module.WORKING_RECAP_ENABLED = True
+    module.LOCAL_LLM_EXECUTION_ENABLED = True
+    captured: dict[str, object] = {}
+
+    def fake_generate(endpoint, model, prompt, **kwargs):
+        captured.update(
+            {
+                "endpoint": endpoint,
+                "model": model,
+                "prompt": prompt,
+                "kwargs": kwargs,
+            }
+        )
+        return (
+            {
+                "response": (
+                    '{"now":"A tool result is being reviewed.",'
+                    '"milestones":["One checkpoint completed.",'
+                    '"api_key=must-not-leak"],'
+                    '"next":"Choose the next safe action."}'
+                )
+            },
+            "http://norllama.invalid/api/chat",
+            "norllama-chat",
+        )
+
+    monkeypatch.setattr(
+        module, "local_llm_candidate_endpoints", lambda _model, foreground: ["local"]
+    )
+    monkeypatch.setattr(module, "local_llm_generate_once", fake_generate)
+    meta = {
+        "last_started_at": 1712878300,
+        "running_prompt": "Deploy with api_key=prompt-secret and Bearer prompt-token",
+        "running_runtime": "localllm",
+        "running_model": "norllama",
+        "turn_plan": {
+            "understood_task": "Deploy api_key=plan-secret",
+            "skill_labels": ["code edit", "verification"],
+            "plan_steps": ["Check the running worker.", "Report the result."],
+        },
+        "live_turn": {
+            "event_count": 3,
+            "tool_started_count": 2,
+            "tool_finished_count": 1,
+            "last_tool_status": "tool-finished",
+        },
+    }
+    deterministic = module.deterministic_working_recap(meta, observed_at=1712878350)
+
+    recap, model = module.working_recap_local_llm(meta, deterministic, queue_depth=1)
+
+    prompt = str(captured["prompt"])
+    assert "prompt-secret" not in prompt
+    assert "prompt-token" not in prompt
+    assert "plan-secret" not in prompt
+    assert captured["endpoint"] == "local"
+    assert (
+        captured["kwargs"]["timeout_seconds"]
+        == module.WORKING_RECAP_LLM_TIMEOUT_SECONDS
+    )
+    assert captured["kwargs"]["max_output_tokens"] == (
+        module.WORKING_RECAP_LLM_MAX_OUTPUT_TOKENS
+    )
+    assert model == module.normalize_runtime_model(
+        "localllm", module.LOCAL_LLM_ROUTE_DEFAULT_MODEL
+    )
+    assert recap["source"] == "local_llm"
+    assert recap["now"] == "A tool result is being reviewed."
+    assert recap["milestones"] == ["One checkpoint completed.", "api_key=[redacted]"]
+
+
+def test_status_snapshot_exposes_working_recap(monkeypatch, tmp_path):
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+    expected = module.normalize_working_recap(
+        {
+            "turn_key": "turn-1",
+            "status": "running",
+            "headline": "Review the active change.",
+            "now": "A local recap is available.",
+            "milestones": ["One checkpoint is complete."],
+            "next": "Verify the result.",
+            "source": "local_llm",
+            "model": "norllama",
+        }
+    )
+    module.update_status_meta(
+        pending=False,
+        state="ok",
+        status_message="Ready.",
+        working_recap=expected,
+    )
+
+    monkeypatch.setattr(module, "recover_stale_prompt_state", lambda: None)
+    monkeypatch.setattr(module, "capture_pane", lambda: "")
+    monkeypatch.setattr(module, "service_status", lambda names: [])
+    monkeypatch.setattr(module, "usage_snapshot", lambda thread_id="": {"totals": {}})
+    monkeypatch.setattr(module, "load_draft_attachments", lambda: [])
+    monkeypatch.setattr(module, "prompt_thread_alive", lambda: False)
+    monkeypatch.setattr(module, "active_codex_process_alive", lambda: False)
+    monkeypatch.setattr(module, "console_runtime_activity_snapshot", lambda: {})
+    monkeypatch.setattr(module, "console_runtime_capabilities_snapshot", lambda: {})
+    monkeypatch.setattr(
+        module, "console_runtime_local_first_proof_snapshot", lambda: {}
+    )
+    monkeypatch.setattr(module, "local_llm_health_snapshot", lambda _model: {})
+    monkeypatch.setattr(module, "local_llm_route_outcome_summary", lambda: {})
+    monkeypatch.setattr(module, "bedrock_health_snapshot", lambda snapshot_at=0: {})
+    monkeypatch.setattr(
+        module, "host_pressure_guard_snapshot", lambda snapshot_at=0: {}
+    )
+    monkeypatch.setattr(module, "usage_accounting_tags", lambda: {})
+
+    snapshot = module.current_snapshot()
+
+    assert snapshot["working_recap"]["headline"] == "Review the active change."
+    assert snapshot["working_recap"]["source"] == "local_llm"
+    assert snapshot["working_recap"]["next"] == "Verify the result."
+
+
 def test_console_runtime_bridge_posts_audit_events(monkeypatch, tmp_path):
     monkeypatch.setenv("NORMAN_CONSOLE_RUNTIME_API_BASE", "http://norman.local/api/v1")
     monkeypatch.setenv("NORMAN_CONSOLE_RUNTIME_TOKEN", "runtime-token")
@@ -839,7 +1020,7 @@ def test_kernel_primary_runtime_can_return_visible_response(monkeypatch, tmp_pat
     monkeypatch.setattr(module, "append_audit_event", lambda **_kwargs: {})
 
     response, error, _thread_id, usage = module._execute_prompt_runtime(
-        "Summarize these notes locally.",
+        "Summarize the following notes locally: alpha beta gamma.",
         "balanced",
         2,
         [],
@@ -860,7 +1041,15 @@ def test_kernel_primary_runtime_can_return_visible_response(monkeypatch, tmp_pat
     assert requests[0][2]["dry_run"] is False
     assert requests[0][2]["continuous"] is True
     assert requests[0][2]["max_steps"] == 5
+    assert requests[0][2]["local_token_budget"] > 0
     assert requests[0][2]["cloud_token_budget"] == 0
+    assert (
+        requests[0][2]["route_policy"]["token_capacity_plan"]["provider_class"]
+        == "norllama"
+    )
+    assert requests[0][2]["metadata"]["token_capacity_plan"]["enforcement"] == (
+        "kernel_hard"
+    )
     assert requests[0][2]["model"] == "qwen3.5:32b-q4_K_M"
     assert requests[0][2]["route_policy"]["verifier_can_stop"] is True
     assert requests[0][2]["route_policy"]["model_timeout_seconds"] == 595.0
@@ -1124,7 +1313,7 @@ def test_kernel_primary_runtime_falls_back_to_codex(monkeypatch, tmp_path):
     monkeypatch.setattr(module, "append_audit_event", lambda **_kwargs: {})
 
     response, error, thread_id, usage = module._execute_prompt_runtime(
-        "Summarize these notes locally.",
+        "Summarize the following notes locally: alpha beta gamma.",
         "balanced",
         2,
         [],
@@ -1162,7 +1351,7 @@ def test_kernel_owned_turn_blocks_codex_fallback(monkeypatch, tmp_path):
     monkeypatch.setattr(module, "append_audit_event", lambda **_kwargs: {})
 
     response, error, _thread_id, usage = module._execute_prompt_runtime(
-        "Summarize these notes locally.",
+        "Summarize the following notes locally: alpha beta gamma.",
         "balanced",
         2,
         [],
@@ -1214,7 +1403,7 @@ def test_kernel_owned_turn_can_fall_back_to_codex_when_not_strict(
     )
 
     response, error, thread_id, usage = module._execute_prompt_runtime(
-        "Summarize these notes locally.",
+        "Summarize the following notes locally: alpha beta gamma.",
         "balanced",
         2,
         [],
@@ -1950,6 +2139,7 @@ def test_cost_route_prefers_local_for_safe_self_contained_prompt(monkeypatch, tm
     assert decision["local_candidate_policy"] == "benchmark_lane_guardrail"
     assert decision["route_source"] == "local_first_policy"
     assert decision["charge_basis"] == "local_token_estimate"
+    assert decision["local_final_authority"] is True
     assert decision["local_mesh"]["healthy_worker_count"] == 1
 
 
@@ -2000,7 +2190,7 @@ def test_cost_route_keeps_service_status_matrix_local(monkeypatch, tmp_path):
     assert decision["mutation_risk"] == "none"
 
 
-def test_cost_route_keeps_typo_status_update_prompt_local(monkeypatch, tmp_path):
+def test_cost_route_keeps_typo_status_update_on_cloud_authority(monkeypatch, tmp_path):
     monkeypatch.setenv("NORMAN_LOCAL_LLM_MODEL", "qwen3.6:27b")
     monkeypatch.setenv("NORMAN_LOCAL_LLM_MODELS", "qwen3.6:27b")
     monkeypatch.setenv("NORMAN_LOCAL_LLM_ENDPOINTS", "http://local-llm:11434")
@@ -2039,15 +2229,13 @@ def test_cost_route_keeps_typo_status_update_prompt_local(monkeypatch, tmp_path)
         requested_service_tier="default",
     )
 
-    assert decision["selected_runtime"] == "localllm"
-    assert decision["selected_model"] in {
-        "qwen3.6:27b",
-        "qwen3.6:35b-a3b-q4_K_M",
-    }
+    assert decision["selected_runtime"] == "codex"
+    assert decision["selected_model"] == module.MODEL
     assert decision["requested_action"] == "status"
     assert decision["operator_intent_class"] == "status"
-    assert decision["route_source"] == "local_first_policy"
-    assert decision["charge_basis"] == "local_token_estimate"
+    assert decision["local_final_authority"] is False
+    assert decision["route_source"] == "local_preflight_cloud_authority"
+    assert "selected cloud runtime is final authority" in decision["reason"]
 
 
 def test_deterministic_status_prompt_completes_without_model_call(
@@ -2171,23 +2359,37 @@ def test_cost_route_uses_local_intent_classifier_for_ambiguous_status(
         requested_service_tier="default",
     )
 
-    assert decision["selected_runtime"] == "localllm"
-    assert decision["selected_model"] in {
-        "qwen3.6:27b",
-        "qwen3.6:35b-a3b-q4_K_M",
-    }
+    assert decision["selected_runtime"] == "codex"
+    assert decision["selected_model"] == module.MODEL
     assert decision["requested_action"] == "status"
     assert decision["operator_intent_class"] == "status"
-    assert decision["local_lane"] == "scout"
-    assert decision["route_source"] == "local_first_intent_classifier"
-    assert decision["charge_basis"] == "local_token_estimate"
+    assert decision["local_final_authority"] is False
+    assert decision["route_source"] == "local_preflight_cloud_authority"
     assert decision["local_intent_classifier"]["used"] is True
     assert decision["local_intent_classifier"]["promoted_local"] is True
     assert decision["local_intent_classifier"]["confidence"] == 0.94
     assert decision["local_intent_classifier"]["worker_endpoint"] == "spark151"
 
 
-def test_cost_route_keeps_broad_planning_on_local_planner_lane(monkeypatch, tmp_path):
+def test_local_route_intent_classifier_prompt_enforces_bounded_status_values(
+    monkeypatch, tmp_path
+):
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+
+    prompt = module.local_route_intent_classifier_prompt(
+        "How are things looking?",
+        requested_action="operator_prompt",
+        intent_class="operator_prompt",
+    )
+
+    assert module.LOCAL_ROUTE_INTENT_CLASSIFIER_MAX_OUTPUT_TOKENS == 192
+    assert "do not invent aliases such as status_check" in prompt.lower()
+    assert "requested_action=status" in prompt
+    assert "operator_intent_class=status" in prompt
+    assert "lane=scout" in prompt
+
+
+def test_cost_route_keeps_broad_planning_on_cloud_authority(monkeypatch, tmp_path):
     monkeypatch.setenv("NORMAN_LOCAL_LLM_MODEL", "qwen3.6:27b")
     monkeypatch.setenv("NORMAN_LOCAL_LLM_MODELS", "qwen3.6:27b")
     monkeypatch.setenv("NORMAN_LOCAL_LLM_ENDPOINTS", "http://local-llm:11434")
@@ -2206,6 +2408,7 @@ def test_cost_route_keeps_broad_planning_on_local_planner_lane(monkeypatch, tmp_
     prompt = "what happened with the plan for forking TUIs into multiple sessions?"
     assert module.prompt_is_broad_planning_request(prompt) is True
     assert module.prompt_is_local_first_candidate(prompt) is True
+    assert module.prompt_is_local_final_response_candidate(prompt) is False
 
     decision = module.cost_route_decision_for_prompt(
         prompt=prompt,
@@ -2222,11 +2425,11 @@ def test_cost_route_keeps_broad_planning_on_local_planner_lane(monkeypatch, tmp_
         requested_service_tier="default",
     )
 
-    assert decision["selected_runtime"] == "localllm"
-    assert decision["local_lane"] == "planner"
+    assert decision["selected_runtime"] == "codex"
     assert decision["requested_action"] == "operator_prompt"
     assert decision["operator_intent_class"] == "operator_prompt"
-    assert decision["route_source"] == "local_first_policy"
+    assert decision["local_final_authority"] is False
+    assert decision["route_source"] == "local_preflight_cloud_authority"
 
 
 def test_local_intent_classifier_cannot_downgrade_broad_planning_to_status(
@@ -2328,7 +2531,11 @@ def test_cost_route_keeps_route_diagnostic_local(monkeypatch, tmp_path):
     assert module.turn_control_mutation_risk(prompt) == "none"
     assert module.prompt_requires_cloud_or_tools(prompt) is False
     assert module.prompt_is_local_first_candidate(prompt) is True
-    assert module.console_runtime_kernel_primary_skip_reason(prompt, [], "codex") == ""
+    assert module.prompt_is_local_final_response_candidate(prompt) is False
+    assert (
+        module.console_runtime_kernel_primary_skip_reason(prompt, [], "codex")
+        == "Norllama is advisory preflight; selected cloud runtime is final authority"
+    )
 
     decision = module.cost_route_decision_for_prompt(
         prompt=prompt,
@@ -2345,10 +2552,10 @@ def test_cost_route_keeps_route_diagnostic_local(monkeypatch, tmp_path):
         requested_service_tier="default",
     )
 
-    assert decision["selected_runtime"] == "localllm"
-    assert decision["selected_model"] == "qwen3.6:35b-a3b-q4_K_M"
-    assert decision["local_lane"] == "planner"
-    assert decision["route_source"] == "local_first_policy"
+    assert decision["selected_runtime"] == "codex"
+    assert decision["selected_model"] == module.MODEL
+    assert decision["local_final_authority"] is False
+    assert decision["route_source"] == "local_preflight_cloud_authority"
     assert decision["requested_action"] == "status"
     assert decision["mutation_risk"] == "none"
 
@@ -2360,6 +2567,42 @@ def test_route_diagnostic_does_not_mask_mutating_order(monkeypatch, tmp_path):
     assert module.prompt_is_route_status_diagnostic(prompt) is False
     assert module.prompt_requires_cloud_or_tools(prompt) is True
     assert module.turn_control_mutation_risk(prompt) == "deploy_restart"
+
+
+def test_route_diagnostic_does_not_misclassify_declarative_route_prompt(
+    monkeypatch, tmp_path
+):
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+    prompt = (
+        "Draft a short three-step plan for documenting the differences between a "
+        "local reasoning pass and a final cloud review in a new internal "
+        "engineering guide. The response should be suitable for a release note."
+    )
+
+    assert module.prompt_is_route_status_diagnostic(prompt) is False
+    assert module.deterministic_status_prompt_allowed(prompt, []) is False
+    assert module.route_receipt_requested_action(prompt) == "approval_boundary"
+    assert module.prompt_is_local_first_candidate(prompt) is True
+    assert module.prompt_is_local_final_response_candidate(prompt) is False
+
+    decision = module.cost_route_decision_for_prompt(
+        prompt=prompt,
+        attachments=[],
+        relay_callback=None,
+        runtime="codex",
+        model=module.MODEL,
+        service_tier="default",
+        job_budget="quick",
+        optimization_mode="auto",
+        route_lock=False,
+        requested_runtime="codex",
+        requested_model=module.MODEL,
+        requested_service_tier="default",
+    )
+
+    assert decision["selected_runtime"] == "codex"
+    assert decision["local_final_authority"] is False
+    assert decision["route_source"] == "existing_selection"
 
 
 def test_cost_route_does_not_treat_negated_tools_as_tool_requirement(
@@ -3581,6 +3824,49 @@ def test_agent_template_bedrock_pack_forces_hard_cloud_context_cap(
     assert plan["reason"] == "hard-cloud-context-cap"
 
 
+def test_agent_template_direct_codex_pack_forces_hard_cloud_context_cap(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("NORMAN_CODEX_SERVICE_TIER", "flex")
+    monkeypatch.setenv("NORMAN_CODEX_FLEX_PROFILE_V2", "")
+    monkeypatch.setenv("NORMAN_CODEX_BEDROCK_CONTEXT_PACK_MIN_THREAD_TOKENS", "80000")
+    monkeypatch.setenv("NORMAN_CODEX_BEDROCK_CONTEXT_PACK_HARD_THREAD_TOKENS", "200000")
+    monkeypatch.setenv("NORMAN_CODEX_BEDROCK_CONTEXT_PACK_MIN_SAVED_TOKENS", "4000")
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+    module.ensure_state_dir()
+    old_thread_id = "template-direct-million-token-thread"
+    old_scope = "direct:default:model:gpt-5.4"
+    module.append_usage_entry(
+        started_at=100,
+        finished_at=212,
+        thread_id=old_thread_id,
+        speed="careful",
+        detail=5,
+        service_tier="flex",
+        success=True,
+        runtime="codex",
+        model="gpt-5.4",
+        usage={
+            "input_tokens": 1_161_817,
+            "cached_input_tokens": 954_558,
+            "output_tokens": 6_365,
+        },
+    )
+
+    plan = module.bedrock_context_pack_plan(
+        service_tier="flex",
+        model="gpt-5.4",
+        session_id=old_thread_id,
+        thread_scope=old_scope,
+    )
+
+    assert plan["profile_v2"] == ""
+    assert plan["hard_cap_exceeded"] is True
+    assert plan["should_pack"] is True
+    assert plan["reason"] == "hard-cloud-context-cap"
+    assert "fresh Codex thread" in module.bedrock_context_pack_prompt_context(plan)
+
+
 def test_agent_template_personal_bedrock_usage_displays_usd_not_plan_credits(
     monkeypatch, tmp_path
 ):
@@ -3914,7 +4200,7 @@ def test_localllm_execution_adapter_records_local_usage(monkeypatch, tmp_path):
     assert payload["keep_alive"] == module.LOCAL_LLM_KEEP_ALIVE
     assert payload["think"] is False
     assert payload["options"]["num_ctx"] == 8192
-    assert payload["options"]["num_predict"] == module.LOCAL_LLM_SHORT_MAX_OUTPUT_TOKENS
+    assert payload["options"]["num_predict"] == 1200
     assert usage["provider_surface"] == "norllama"
     assert usage["route_class"] == "local"
     assert usage["route_execution"] == "local_worker"
@@ -3966,8 +4252,8 @@ def test_localllm_foreground_timeout_is_budget_capped(monkeypatch, tmp_path):
     assert module.local_llm_foreground_timeout_seconds(4800, "normal") == 240
     assert module.local_llm_num_ctx_for_budget("quick") == 4096
     assert module.local_llm_num_ctx_for_budget("short") == 8192
-    assert module.local_llm_max_output_tokens_for_budget("quick") == 384
-    assert module.local_llm_max_output_tokens_for_budget("short") == 800
+    assert module.local_llm_max_output_tokens_for_budget("quick") == 1200
+    assert module.local_llm_max_output_tokens_for_budget("short") == 1200
     assert module.console_runtime_kernel_primary_timeout(4800, "quick") == 120
     assert module.console_runtime_kernel_primary_timeout(4800, "short") == 600
     assert module.console_runtime_kernel_model_timeout(4800, "short") == 595
@@ -3987,11 +4273,142 @@ def test_localllm_foreground_timeout_is_budget_capped(monkeypatch, tmp_path):
     assert error == ""
     payload = json.loads(requests[0][0].data.decode())
     assert payload["options"]["num_ctx"] == 8192
-    assert payload["options"]["num_predict"] == 800
+    assert payload["options"]["num_predict"] == 96
     assert requests[0][1] == 180
     assert usage["provider_timeout_seconds"] == 180
     assert usage["provider_num_ctx"] == 8192
-    assert usage["provider_max_output_tokens"] == 800
+    assert usage["provider_max_output_tokens"] == 96
+    assert usage["token_capacity_plan"]["provider_class"] == "norllama"
+    assert usage["token_capacity_plan"]["execution_output_cap"] == 96
+
+
+def test_provider_token_budget_plan_scales_two_minute_norllama_execution(
+    monkeypatch, tmp_path
+):
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+
+    plan = module.provider_token_budget_plan(
+        prompt="Implement the focused routing fix and verify it.",
+        runtime="localllm",
+        model="qwen3.6:35b-a3b-q4_K_M",
+        job_budget="2m",
+        detail=2,
+        entries=[],
+        now=1_700_000_000,
+    )
+
+    assert plan["provider_class"] == "norllama"
+    assert plan["target_seconds"] == 120
+    assert plan["soft_output_tokens_per_hour"] == 48_000
+    assert plan["time_window_output_cap"] == 1600
+    assert plan["estimated_output_tokens"] > 1600
+    assert plan["execution_output_cap"] == 1600
+    assert plan["local_token_budget"] == 3200
+    assert plan["cloud_token_budget"] == 0
+    assert plan["enforcement"] == "request_hard"
+    assert plan["recent_window_seconds"] == 3600
+
+
+def test_provider_token_budget_uses_observed_rate_as_advisory_not_quota(
+    monkeypatch, tmp_path
+):
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+    now = 1_700_000_000
+    entries = [
+        {
+            **module.local_llm_provider_tags(),
+            "runtime": "localllm",
+            "model": "qwen3.6:35b-a3b-q4_K_M",
+            "finished_at": now - 1,
+            "success": True,
+            "output_tokens": 750,
+            "total_tokens": 800,
+        }
+    ]
+
+    plan = module.provider_token_budget_plan(
+        prompt="Implement the focused routing fix and verify it.",
+        runtime="localllm",
+        job_budget="2m",
+        detail=2,
+        entries=entries,
+        now=now,
+    )
+
+    assert plan["recent_observed_output_tokens_per_hour"] == 9000
+    assert plan["capacity_source"] == "configured_policy+observed_ledger"
+    assert plan["soft_output_tokens_per_hour"] == 48_000
+    assert plan["execution_output_cap"] == 1600
+
+
+def test_provider_token_budget_uses_rolling_hour_not_usage_report_window(
+    monkeypatch, tmp_path
+):
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+    now = 1_700_000_000
+    entries = [
+        {
+            **module.local_llm_provider_tags(),
+            "runtime": "localllm",
+            "finished_at": now - 3601,
+            "success": True,
+            "output_tokens": 48_000,
+            "total_tokens": 48_100,
+        },
+        {
+            **module.local_llm_provider_tags(),
+            "runtime": "localllm",
+            "finished_at": now - 60,
+            "success": True,
+            "output_tokens": 47_600,
+            "total_tokens": 47_700,
+        },
+    ]
+
+    plan = module.provider_token_budget_plan(
+        prompt="Implement the focused routing fix and verify it.",
+        runtime="localllm",
+        job_budget="2m",
+        detail=2,
+        entries=entries,
+        now=now,
+    )
+
+    assert plan["recent_window_seconds"] == 300
+    assert plan["recent_sample_count"] == 1
+    assert plan["recent_output_tokens"] == 47_600
+    assert plan["remaining_soft_output_tokens"] == 400
+    assert plan["time_window_output_cap"] == 400
+    assert plan["execution_output_cap"] == 400
+
+
+def test_provider_token_budget_bounds_cloud_only_when_cloud_is_authorized(
+    monkeypatch, tmp_path
+):
+    module = _load_agent_console_web(monkeypatch, tmp_path)
+
+    authorized = module.provider_token_budget_plan(
+        prompt="Verify the Bedrock fallback route.",
+        runtime="claude",
+        job_budget="2m",
+        detail=2,
+        entries=[],
+        cloud_authorized=True,
+    )
+    blocked = module.provider_token_budget_plan(
+        prompt="Verify the Bedrock fallback route.",
+        runtime="claude",
+        job_budget="2m",
+        detail=2,
+        entries=[],
+        cloud_authorized=False,
+    )
+
+    assert authorized["provider_class"] == "bedrock"
+    assert authorized["cloud_token_budget"] > 0
+    assert authorized["local_token_budget"] == 0
+    assert blocked["execution_output_cap"] == authorized["execution_output_cap"]
+    assert blocked["cloud_token_budget"] == 0
 
 
 def test_localllm_execution_preserves_cancel_request(monkeypatch, tmp_path):

--- a/tests/test_agent_console_template_masking.py
+++ b/tests/test_agent_console_template_masking.py
@@ -49,12 +49,17 @@ def _load_agent_console_web():
     env_snapshot = {
         key: value for key, value in os.environ.items() if key.startswith(env_prefixes)
     }
-    if "NORMAN_CODEX_WEB_STATE_DIR" not in os.environ:
-        os.environ["NORMAN_CODEX_WEB_STATE_DIR"] = tempfile.mkdtemp(
-            prefix="norman-agent-console-test-"
-        )
+    os.environ["NORMAN_CODEX_WEB_STATE_DIR"] = tempfile.mkdtemp(
+        prefix="norman-agent-console-test-"
+    )
+    if "NORMAN_CODEX_ALLOW_OPENAI_API_SPEND" not in env_snapshot:
+        # This integration fixture does not create an auth.json file for the
+        # synthetic Codex process exercised by legacy executor tests.
+        os.environ["NORMAN_CODEX_ALLOW_OPENAI_API_SPEND"] = "1"
     for key, value in list(os.environ.items()):
         if key.startswith("HOUSEBOT_CODEX_"):
+            if key == "HOUSEBOT_CODEX_WEB_STATE_DIR":
+                continue
             suffix = key.removeprefix("HOUSEBOT_CODEX_")
             os.environ[f"NORMAN_CODEX_{suffix}"] = value
     spec = importlib.util.spec_from_file_location("agent_console_web", script_path)
@@ -2886,6 +2891,35 @@ def test_template_exposes_status_capsule_strip() -> None:
     assert "const backgroundItems = background && !background.intervention" in source
 
 
+def test_template_surfaces_turn_spend_feedback() -> None:
+    source = _agent_console_web_source()
+
+    assert (
+        "function turnCostFeedbackDescriptor(usage, snapshot = state.snapshot)"
+        in source
+    )
+    assert "function spendFeedbackCapsuleState(snapshot)" in source
+    assert 'className = "message-value-chip"' in source
+    assert "Big save" in source
+    assert "no cloud bill" in source
+    assert "Plan credits" in source
+
+
+def test_template_exposes_dynamic_working_on_recap_panel() -> None:
+    source = _agent_console_web_source()
+
+    assert "NORMAN_CODEX_WORKING_RECAP_REFRESH_SECONDS" in source
+    assert "def working_recap_local_llm(" in source
+    assert "Use only this sanitized status packet." in source
+    assert '"working_recap": working_recap' in source
+    assert "function workingRecapForSnapshot(" in source
+    assert "function buildWorkingOnPanel(" in source
+    assert 'panel.setAttribute("aria-label", "Working on");' in source
+    assert "working-on-timeline" in source
+    assert "Local recap" in source
+    assert "working-recap-pulse" in source
+
+
 def test_template_exposes_lightweight_version_endpoint() -> None:
     source = _agent_console_web_source()
 
@@ -4656,6 +4690,9 @@ def test_sync_template_rolls_kernel_primary_to_canary_instances() -> None:
     assert '"NORMAN_LOCAL_LLM_SHORT_NUM_CTX": "4096"' in source
     assert '"NORMAN_LOCAL_LLM_FALLBACK_MODELS": ""' in source
     assert '"NORMAN_LOCAL_LLM_ALLOW_TINY_FOREGROUND_FALLBACK": "0"' in source
+    assert "LOCAL_ROUTE_INTENT_CLASSIFIER_MODEL = (" in source
+    assert '"NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_MODEL": (' in source
+    assert '"NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_MAX_OUTPUT_TOKENS": "192"' in source
 
     housebot = module.ConsoleInstance(
         name="housebot",
@@ -4888,10 +4925,23 @@ def test_kernel_rollout_sync_writes_backend_env(monkeypatch) -> None:
 
 def test_local_sync_systemd_units_target_hal() -> None:
     service = _systemd_unit_source("norman-agent-console-sync-local.service")
+    user_service = _systemd_unit_source("norman-agent-console-sync.service")
+    bedrock_dropin = _systemd_unit_source(
+        "norman-agent-console-sync-personal-bedrock.conf"
+    )
     path = _systemd_unit_source("norman-agent-console-sync-local.path")
     timer = _systemd_unit_source("norman-agent-console-sync-local.timer")
 
     assert "sync_agent_console_template.py --targets hal" in service
+    profile_source = (
+        "NORMAN_SYNC_NON_WORK_BEDROCK_PROFILE_SOURCE="
+        "/home/kristopher/.codex-nonwork/personal-bedrock.config.toml"
+    )
+    assert profile_source in service
+    assert profile_source in bedrock_dropin
+    assert "NORMAN_SYNC_NON_WORK_BEDROCK_PROFILE_SOURCE=%h/.codex-nonwork/" in (
+        user_service
+    )
     assert (
         "/home/kristopher/code/norman/scripts/agent_console_template/agent_console_web.py"
         in path
@@ -5200,6 +5250,33 @@ def test_codex_account_capacity_parser_and_forecast_are_aggregate_only() -> None
     assert "limit:" not in json.dumps(parsed)
 
 
+def test_codex_status_capacity_parser_records_credit_metadata_without_resetting() -> (
+    None
+):
+    module = _load_agent_console_web()
+    observed_at = int(time.mktime((2026, 7, 16, 12, 0, 0, 0, 0, -1)))
+
+    parsed = module.parse_codex_account_capacity_pane(
+        """
+        You have 4 usage limit resets available. Run /usage to use one.
+        Weekly limit: 100% left
+        (resets 12:12 on 23 Jul)
+        Context window: 92% left
+        Credits: 6,907 credits
+        """,
+        observed_at=observed_at,
+        auth_mode="chatgpt",
+    )
+
+    assert parsed["state"] == "available"
+    assert parsed["minimum_window_percent_left"] == 100
+    assert [window["label"] for window in parsed["windows"]] == ["Weekly"]
+    assert parsed["windows"][0]["reset_seconds"] > 6 * 24 * 60 * 60
+    assert parsed["credits_available"] == 6907
+    assert parsed["usage_limit_resets_available"] == 4
+    assert "/usage" not in json.dumps(parsed)
+
+
 def test_codex_account_capacity_forecast_excludes_api_and_bedrock_usage() -> None:
     module = _load_agent_console_web()
     observed_at = 1_789_000_000
@@ -5335,16 +5412,18 @@ def test_codex_account_capacity_probe_requires_changed_pane(
     )
     sent: list[str] = []
     monkeypatch.setattr(module, "capture_pane", lambda: next(panes))
-    monkeypatch.setattr(module, "send_text", lambda value: sent.append(value))
+    monkeypatch.setattr(
+        module, "send_codex_status_probe", lambda: sent.append("/status")
+    )
 
     payload = module._capture_codex_account_capacity_command(
-        "/usage",
+        "/status",
         observed_at=1_789_000_000,
         auth_mode="chatgpt",
         baseline_pane=prompt_pane,
     )
 
-    assert sent == ["/usage"]
+    assert sent == ["/status"]
     assert payload["state"] == "available"
     assert payload["minimum_window_percent_left"] == 84
 
@@ -5424,6 +5503,105 @@ def test_codex_subscription_capacity_prefers_flex_only_for_fresh_personal_bedroc
     )
 
 
+def test_codex_subscription_route_stays_on_bedrock_without_a_reset_forecast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NORMAN_CODEX_STANDARD_PROFILE_V2", "personal-bedrock")
+    monkeypatch.setenv("NORMAN_CODEX_STANDARD_AWS_PROFILE", "norman-bedrock")
+    monkeypatch.setenv("NORMAN_CODEX_AGENT_GROUP", "personal")
+    monkeypatch.setenv("NORMAN_CODEX_BILLING_OWNER", "kristopher")
+    module = _load_agent_console_web()
+    monkeypatch.setattr(module, "stored_codex_auth_mode", lambda: "chatgpt")
+    observed_at = module.now_ts()
+    capacity = {
+        **module.default_codex_account_capacity(),
+        "source": "interactive_usage",
+        "observed_at": observed_at,
+        "last_probe_at": observed_at,
+        "auth_mode": "chatgpt",
+        "state": "available",
+        "credits_available": 6907,
+        "windows": [
+            {
+                "label": "Weekly",
+                "percent_left": 84,
+                "reset_hint": "",
+                "reset_seconds": 0,
+            }
+        ],
+    }
+
+    decision = module.codex_subscription_capacity_route_decision(
+        runtime="codex",
+        model=module.MODEL,
+        service_tier="default",
+        prompt="Implement the focused fix and verify it.",
+        job_budget="normal",
+        detail=2,
+        capacity=capacity,
+    )
+
+    assert decision["selected"] is False
+    assert "reset window" in decision["reason"]
+    assert decision["capacity"]["forecast"]["credits_available_informational"] == 6907
+
+
+def test_chatgpt_direct_credit_extension_guard_requires_fresh_plan_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_agent_console_web()
+    monkeypatch.setattr(module, "stored_codex_auth_mode", lambda: "chatgpt")
+
+    guarded = module.codex_openai_direct_execution_decision("flex")
+
+    assert guarded["allowed"] is False
+    assert guarded["reason_code"] == "chatgpt_credit_extension_guard"
+
+    monkeypatch.setattr(
+        module,
+        "codex_account_capacity_snapshot",
+        lambda **_kwargs: {
+            "fresh": True,
+            "state": "available",
+            "minimum_window_percent_left": 25,
+            "windows": [{"reset_seconds": 7200}],
+        },
+    )
+
+    allowed = module.codex_openai_direct_execution_decision("flex")
+
+    assert allowed["allowed"] is True
+    assert allowed["reason_code"] == "chatgpt_plan_capacity_verified"
+
+
+def test_template_direct_chatgpt_launch_requires_turn_to_fit_reset_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_agent_console_web()
+    monkeypatch.setattr(module, "stored_codex_auth_mode", lambda: "chatgpt")
+    monkeypatch.setattr(
+        module,
+        "codex_account_capacity_snapshot",
+        lambda **_kwargs: {
+            "fresh": True,
+            "state": "available",
+            "minimum_window_percent_left": 75,
+            "windows": [{"reset_seconds": 300}],
+        },
+    )
+
+    decision = module.codex_openai_direct_execution_decision(
+        "flex",
+        prompt="Implement the focused fix and verify it.",
+        job_budget="normal",
+        detail=3,
+    )
+
+    assert decision["allowed"] is False
+    assert decision["reason_code"] == "chatgpt_credit_extension_guard"
+    assert decision["capacity"]["forecast"]["turn_fits_reset"] is False
+
+
 def test_codex_account_capacity_probe_only_runs_at_idle_prompt(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -5445,7 +5623,9 @@ def test_codex_account_capacity_probe_only_runs_at_idle_prompt(
     sent: list[str] = []
     keys: list[tuple[str, ...]] = []
     monkeypatch.setattr(module, "capture_pane", lambda: next(panes))
-    monkeypatch.setattr(module, "send_text", lambda value: sent.append(value))
+    monkeypatch.setattr(
+        module, "send_codex_status_probe", lambda: sent.append("/status")
+    )
     monkeypatch.setattr(module, "send_keys", lambda *value: keys.append(value))
 
     assert (
@@ -5463,7 +5643,7 @@ def test_codex_account_capacity_probe_only_runs_at_idle_prompt(
     history_text = module.CODEX_ACCOUNT_CAPACITY_HISTORY_PATH.read_text(
         encoding="utf-8"
     )
-    assert sent == ["/usage"]
+    assert sent == ["/status"]
     assert keys == [("Escape",), ("C-u",), ("C-a", "C-k"), ("C-l",)]
     assert persisted["state"] == "available"
     assert persisted["minimum_window_percent_left"] == 84
@@ -5489,7 +5669,7 @@ def test_codex_account_capacity_probe_only_runs_at_idle_prompt(
     )
 
 
-def test_codex_account_capacity_probe_uses_configured_fallback_without_pane_persistence(
+def test_codex_account_capacity_probe_rejects_unsafe_configured_command(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     module = _load_agent_console_web()
@@ -5499,23 +5679,17 @@ def test_codex_account_capacity_probe_uses_configured_fallback_without_pane_pers
     module.CODEX_ACCOUNT_CAPACITY_PROBE_POLL_SECONDS = 0.01
     module.CODEX_ACCOUNT_CAPACITY_PROBE_THREAD = None
     module.CODEX_ACCOUNT_CAPACITY_COMMAND = "/usage"
-    module.CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND = "/plan-limits"
+    module.CODEX_ACCOUNT_CAPACITY_FALLBACK_COMMAND = "/status"
     monkeypatch.setattr(module, "stored_codex_auth_mode", lambda: "chatgpt")
     monkeypatch.setattr(module, "prompt_runtime_alive", lambda: False)
     monkeypatch.setattr(module, "prompt_thread_alive", lambda: False)
     prompt_pane = "OpenAI Codex (v0.118.0)\n\n› "
-    panes = iter(
-        [
-            prompt_pane,
-            "Account token usage is available for this account.\n\n› ",
-            "No aggregate capacity was returned.\n\n› ",
-            "5h limit: 72% remaining · resets in 1h\n\n› ",
-        ]
-    )
     sent: list[str] = []
     keys: list[tuple[str, ...]] = []
-    monkeypatch.setattr(module, "capture_pane", lambda: next(panes))
-    monkeypatch.setattr(module, "send_text", lambda value: sent.append(value))
+    monkeypatch.setattr(module, "capture_pane", lambda: prompt_pane)
+    monkeypatch.setattr(
+        module, "send_codex_status_probe", lambda: sent.append("/status")
+    )
     monkeypatch.setattr(module, "send_keys", lambda *value: keys.append(value))
 
     assert (
@@ -5533,23 +5707,14 @@ def test_codex_account_capacity_probe_uses_configured_fallback_without_pane_pers
     history_text = module.CODEX_ACCOUNT_CAPACITY_HISTORY_PATH.read_text(
         encoding="utf-8"
     )
-    assert sent == ["/usage", "/plan-limits"]
-    assert keys == [
-        ("Escape",),
-        ("C-u",),
-        ("C-a", "C-k"),
-        ("C-l",),
-        ("Escape",),
-        ("C-u",),
-        ("C-a", "C-k"),
-        ("C-l",),
-    ]
-    assert persisted["minimum_window_percent_left"] == 72
-    assert "Account token usage" not in history_text
-    assert "5h limit" not in history_text
+    assert sent == []
+    assert keys == []
+    assert persisted["source"] == "probe_command_rejected"
+    assert persisted["state"] == "unknown"
+    assert "/usage can consume an account limit reset" in history_text
 
 
-def test_codex_account_capacity_unsupported_usage_command_is_sanitized_and_backed_off(
+def test_codex_account_capacity_probe_never_sends_usage_command(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     module = _load_agent_console_web()
@@ -5564,12 +5729,12 @@ def test_codex_account_capacity_unsupported_usage_command_is_sanitized_and_backe
     monkeypatch.setattr(module, "prompt_runtime_alive", lambda: False)
     monkeypatch.setattr(module, "prompt_thread_alive", lambda: False)
     prompt_pane = "OpenAI Codex (v0.144.4)\n\n› "
-    unsupported_pane = "Unrecognized command '/usage'. Type \"/\" for a list of supported commands.\n\n› "
-    panes = iter([prompt_pane, unsupported_pane, unsupported_pane])
     sent: list[str] = []
     keys: list[tuple[str, ...]] = []
-    monkeypatch.setattr(module, "capture_pane", lambda: next(panes))
-    monkeypatch.setattr(module, "send_text", lambda value: sent.append(value))
+    monkeypatch.setattr(module, "capture_pane", lambda: prompt_pane)
+    monkeypatch.setattr(
+        module, "send_codex_status_probe", lambda: sent.append("/status")
+    )
     monkeypatch.setattr(module, "send_keys", lambda *value: keys.append(value))
 
     assert (
@@ -5587,13 +5752,12 @@ def test_codex_account_capacity_unsupported_usage_command_is_sanitized_and_backe
     history_text = module.CODEX_ACCOUNT_CAPACITY_HISTORY_PATH.read_text(
         encoding="utf-8"
     )
-    assert sent == ["/usage"]
-    assert keys == [("Escape",), ("C-u",), ("C-a", "C-k"), ("C-l",)]
-    assert persisted["source"] == "unsupported_command"
+    assert sent == []
+    assert keys == []
+    assert persisted["source"] == "probe_command_rejected"
     assert persisted["state"] == "unknown"
     assert persisted["eligible_for_subscription_route"] is False
     assert "Unrecognized command" not in history_text
-    assert "/usage" not in history_text
     assert (
         module.maybe_schedule_codex_account_capacity_probe(
             pane=prompt_pane,

--- a/tests/test_local_runtime_health.py
+++ b/tests/test_local_runtime_health.py
@@ -52,3 +52,42 @@ def test_ollama_sense_fallback_marks_lan_endpoint_routeable(monkeypatch) -> None
     assert ollama["endpoint_scope"] == "lan"
     assert report["summary"]["healthy_runtime_count"] == 1
     assert report["summary"]["routeable_runtime_classes"] == ["ollama"]
+
+
+def test_vllm_sense_is_used_without_duplicate_direct_probe(monkeypatch) -> None:
+    module = load_module()
+    requested_urls: list[str] = []
+
+    def fake_read_json_url(url: str, *, timeout_seconds: float = 1.5):
+        requested_urls.append(url)
+        return False, {}, "connection refused"
+
+    monkeypatch.setattr(module, "_read_json_url", fake_read_json_url)
+    report = module.build_report(
+        vllm_endpoint="http://127.0.0.1:8000",
+        vllm_sense_report={
+            "schema": "norman.tui.vllm-sense.v1",
+            "summary": {"best_endpoint": "https://llm.home.arpa"},
+            "endpoints": [
+                {
+                    "endpoint": "https://llm.home.arpa",
+                    "scope": "lan",
+                    "usable": True,
+                    "models": ["qwen3.6:35b-a3b-q4_K_M"],
+                    "latency_ms": 68,
+                }
+            ],
+        },
+    )
+
+    vllm = report["runtimes"][1]
+    assert vllm["runtime_class"] == "spark_vllm"
+    assert vllm["status"] == "healthy"
+    assert vllm["routeable"] is True
+    assert vllm["endpoint"] == "https://llm.home.arpa"
+    assert vllm["model_count"] == 1
+    assert vllm["health_source"] == "vllm_sense"
+    assert vllm["endpoint_scope"] == "lan"
+    assert "http://127.0.0.1:8000/v1/models" not in requested_urls
+    assert report["summary"]["healthy_runtime_count"] == 1
+    assert report["summary"]["routeable_runtime_classes"] == ["spark_vllm"]

--- a/tests/test_norman_codex_model_settings.py
+++ b/tests/test_norman_codex_model_settings.py
@@ -19,6 +19,9 @@ LAUNCH_SCRIPT_PATH = REPO_ROOT / "scripts" / "norman_codex_launch.sh"
 def _load_norman_codex_web(monkeypatch, tmp_path, **overrides):
     codex_home = tmp_path / "codex-home"
     state_dir = tmp_path / "state"
+    existing_legacy_keys = {
+        key for key in os.environ if key.startswith("HOUSEBOT_CODEX_")
+    }
     for key in tuple(os.environ):
         if (
             key.startswith(("NORMAN_CODEX_", "HOUSEBOT_CODEX_"))
@@ -28,10 +31,15 @@ def _load_norman_codex_web(monkeypatch, tmp_path, **overrides):
     monkeypatch.setenv("NORMAN_CODEX_HOME", str(codex_home))
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
     monkeypatch.setenv("NORMAN_CODEX_WEB_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("NORMAN_CODEX_PROFILE_CONFIG_FLAG", "--profile-v2")
     monkeypatch.setenv("NORMAN_CODEX_MODEL", "gpt-5.4")
     monkeypatch.setenv("NORMAN_CODEX_LATEST_MODEL", "gpt-5.5")
     monkeypatch.setenv("NORMAN_CODEX_AVAILABLE_MODELS", "gpt-5.5")
     monkeypatch.setenv("NORMAN_CODEX_BBS_SUMMARY_ENABLED", "0")
+    if "NORMAN_CODEX_ALLOW_OPENAI_API_SPEND" not in overrides:
+        # Legacy executor tests use a synthetic direct Codex runtime without
+        # creating either a ChatGPT or API-key auth fixture.
+        monkeypatch.setenv("NORMAN_CODEX_ALLOW_OPENAI_API_SPEND", "1")
     for key in (
         "NORMAN_CODEX_BILLING_SCOPE",
         "NORMAN_CODEX_BILLING_UNIT",
@@ -52,6 +60,11 @@ def _load_norman_codex_web(monkeypatch, tmp_path, **overrides):
         spec.loader.exec_module(module)
     finally:
         sys.modules.pop(module_name, None)
+        # The module bridges canonical settings to legacy aliases with direct
+        # os.environ writes. Keep those aliases from leaking into later tests.
+        for key in tuple(os.environ):
+            if key.startswith("HOUSEBOT_CODEX_") and key not in existing_legacy_keys:
+                os.environ.pop(key, None)
     return module
 
 
@@ -80,6 +93,25 @@ def test_runtime_model_enforces_gpt55_floor(monkeypatch, tmp_path) -> None:
     assert module.chat_model_update_available() is False
 
 
+def test_profile_flag_uses_modern_cli_option_when_available(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_PROFILE_CONFIG_FLAG="",
+    )
+
+    def fake_run(args, **_kwargs):
+        if args == [module.CODEX_BIN, "exec", "--help"]:
+            return SimpleNamespace(stdout="--profile", stderr="")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    assert module.resolve_codex_profile_config_flag() == "--profile"
+
+
 def test_switchboard_exposes_lightweight_version_endpoint() -> None:
     source = WEB_SCRIPT_PATH.read_text(encoding="utf-8")
 
@@ -87,6 +119,487 @@ def test_switchboard_exposes_lightweight_version_endpoint() -> None:
     assert '"ui_version": UI_VERSION' in source
     assert '"agent_name": AGENT_NAME' in source
     assert '"session_name": SESSION' in source
+
+
+def test_switchboard_exposes_dynamic_working_on_recap_panel() -> None:
+    source = WEB_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "NORMAN_CODEX_WORKING_RECAP_REFRESH_SECONDS" in source
+    assert "https://llm.home.arpa" in source
+    assert "def working_recap_local_llm(" in source
+    assert "Use only this sanitized status packet." in source
+    assert '"working_recap": working_recap' in source
+    assert "function workingRecapForSnapshot(" in source
+    assert "function buildWorkingOnPanel(" in source
+    assert "working-on-timeline" in source
+    assert "working-recap-pulse" in source
+
+
+def test_switchboard_token_capacity_plan_tracks_duration_and_provider(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_norman_codex_web(monkeypatch, tmp_path)
+
+    bedrock = module.provider_token_budget_plan(
+        prompt="Implement the focused fix and verify it.",
+        runtime="claude",
+        job_budget="2m",
+        detail=2,
+        entries=[],
+        cloud_authorized=True,
+    )
+    codex = module.provider_token_budget_plan(
+        prompt="Implement the focused fix and verify it.",
+        runtime="codex",
+        service_tier="flex",
+        job_budget="2m",
+        detail=2,
+        entries=[],
+    )
+
+    assert bedrock["provider_class"] == "bedrock"
+    assert bedrock["time_window_output_cap"] == 2400
+    assert bedrock["execution_output_cap"] == 2100
+    assert bedrock["cloud_token_budget"] == 4200
+    assert bedrock["enforcement"] == "request_hard"
+    assert codex["provider_class"] in {"codex_subscription", "openai_direct"}
+    assert codex["execution_output_cap"] == 2000
+    assert codex["enforcement"] == "advisory"
+
+
+def test_subscription_route_requires_a_reset_aware_forecast(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_STANDARD_PROFILE_V2="personal-bedrock",
+        NORMAN_CODEX_STANDARD_AWS_PROFILE="norman-bedrock",
+        NORMAN_CODEX_AGENT_GROUP="personal",
+        NORMAN_CODEX_BILLING_OWNER="kristopher",
+    )
+    monkeypatch.setattr(module, "stored_codex_auth_mode", lambda: "chatgpt")
+    observed_at = module.now_ts()
+    capacity = {
+        **module.default_codex_account_capacity(),
+        "source": "interactive_usage",
+        "observed_at": observed_at,
+        "last_probe_at": observed_at,
+        "auth_mode": "chatgpt",
+        "state": "available",
+        "credits_available": 6907,
+        "windows": [
+            {
+                "label": "Short window",
+                "percent_left": 84,
+                "reset_hint": "2h",
+                "reset_seconds": 7200,
+            }
+        ],
+    }
+
+    selected = module.codex_subscription_capacity_route_decision(
+        runtime="codex",
+        model=module.MODEL,
+        service_tier="default",
+        prompt="Implement the focused fix and verify it.",
+        job_budget="normal",
+        detail=2,
+        capacity=capacity,
+    )
+
+    assert selected["selected"] is True
+    forecast = selected["capacity"]["forecast"]
+    assert forecast["reset_seconds"] == 7200
+    assert forecast["fits_policy_envelope"] is True
+    assert forecast["credits_available_informational"] == 6907
+
+    too_near = module.codex_subscription_capacity_route_decision(
+        runtime="codex",
+        model=module.MODEL,
+        service_tier="default",
+        prompt="Implement the focused fix and verify it.",
+        job_budget="normal",
+        detail=2,
+        capacity={
+            **capacity,
+            "windows": [
+                {
+                    "label": "Short window",
+                    "percent_left": 84,
+                    "reset_hint": "2m",
+                    "reset_seconds": 120,
+                }
+            ],
+        },
+    )
+
+    assert too_near["selected"] is False
+    assert "reset window" in too_near["reason"]
+
+
+def test_work_subscription_route_requires_explicit_scope_enablement(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_AGENT_GROUP="work",
+        NORMAN_CODEX_BILLING_OWNER="openbrand",
+        NORMAN_CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED="0",
+    )
+
+    assert module.codex_subscription_capacity_personal_lane() is False
+    assert module.codex_subscription_capacity_route_lane() is False
+
+    module.CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED = True
+
+    assert module.codex_subscription_capacity_route_lane() is True
+
+
+def test_switchboard_working_recap_uses_sanitized_norllama_packet(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_WORKING_RECAP_MODEL="norllama-test",
+        NORMAN_CODEX_WORKING_RECAP_ENDPOINTS="http://norllama.invalid",
+    )
+    captured: list[object] = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {
+                    "message": {
+                        "content": (
+                            '{"now":"Reviewing the completed checkpoint.",'
+                            '"milestones":["One tool checkpoint completed.",'
+                            '"Bearer output-token"],'
+                            '"next":"Choose the next safe action."}'
+                        )
+                    }
+                }
+            ).encode()
+
+    def fake_urlopen(request, timeout):
+        captured.extend((request, timeout))
+        return Response()
+
+    monkeypatch.setattr(module.urllib_request, "urlopen", fake_urlopen)
+    meta = {
+        "last_started_at": 1712878300,
+        "running_prompt": "Deploy api_key=prompt-secret with Bearer prompt-token",
+        "running_runtime": "codex",
+        "running_model": "gpt-5.5",
+        "turn_plan": {
+            "understood_task": "Deploy api_key=plan-secret",
+            "skill_labels": ["code edit", "verification"],
+            "plan_steps": ["Check the running worker.", "Report the result."],
+        },
+        "live_turn": {
+            "event_count": 3,
+            "tool_started_count": 2,
+            "tool_finished_count": 1,
+            "last_tool_status": "tool-finished",
+        },
+    }
+    deterministic = module.deterministic_working_recap(meta, observed_at=1712878350)
+
+    recap, model = module.working_recap_local_llm(meta, deterministic, queue_depth=1)
+
+    request, timeout = captured
+    request_payload = json.loads(request.data.decode())
+    prompt = request_payload["messages"][0]["content"]
+    assert request.full_url == "http://norllama.invalid/api/chat"
+    assert timeout == module.WORKING_RECAP_LLM_TIMEOUT_SECONDS
+    assert "prompt-secret" not in prompt
+    assert "prompt-token" not in prompt
+    assert "plan-secret" not in prompt
+    assert model == "norllama-test"
+    assert recap["source"] == "local_llm"
+    assert recap["now"] == "Reviewing the completed checkpoint."
+    assert recap["milestones"] == [
+        "One tool checkpoint completed.",
+        "Bearer [redacted]",
+    ]
+
+
+def test_direct_openai_execution_requires_plan_capacity_or_explicit_override(
+    monkeypatch, tmp_path
+) -> None:
+    blocked = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_ALLOW_OPENAI_API_SPEND="0",
+    )
+    monkeypatch.setattr(blocked, "stored_codex_auth_mode", lambda: "api_key")
+
+    blocked_decision = blocked.codex_openai_direct_execution_decision("flex")
+
+    assert blocked_decision["allowed"] is False
+    assert blocked_decision["auth_mode"] == "api_key"
+    assert "API spending is disabled" in blocked_decision["reason"]
+
+    guarded_subscription = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_ALLOW_OPENAI_API_SPEND="0",
+    )
+    monkeypatch.setattr(
+        guarded_subscription, "stored_codex_auth_mode", lambda: "chatgpt"
+    )
+
+    guarded_decision = guarded_subscription.codex_openai_direct_execution_decision(
+        "flex"
+    )
+
+    assert guarded_decision["allowed"] is False
+    assert guarded_decision["reason_code"] == "chatgpt_credit_extension_guard"
+    assert "paid ChatGPT credit extension is disabled" in guarded_decision["reason"]
+
+    subscription = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_ALLOW_OPENAI_API_SPEND="0",
+    )
+    monkeypatch.setattr(subscription, "stored_codex_auth_mode", lambda: "chatgpt")
+    monkeypatch.setattr(
+        subscription,
+        "codex_account_capacity_snapshot",
+        lambda **_kwargs: {
+            "fresh": True,
+            "state": "available",
+            "minimum_window_percent_left": 75,
+            "windows": [{"reset_seconds": 7200}],
+        },
+    )
+
+    subscription_decision = subscription.codex_openai_direct_execution_decision("flex")
+
+    assert subscription_decision["allowed"] is True
+    assert subscription_decision["api_spend_override"] is False
+    assert (
+        subscription_decision["reason"]
+        == "verified ChatGPT plan capacity is above the no-credit extension reserve"
+    )
+
+    override = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_ALLOW_OPENAI_API_SPEND="1",
+    )
+    monkeypatch.setattr(override, "stored_codex_auth_mode", lambda: "")
+
+    override_decision = override.codex_openai_direct_execution_decision("flex")
+
+    assert override_decision["allowed"] is True
+    assert override_decision["api_spend_override"] is True
+    assert override_decision["reason"] == "explicit OpenAI API spend override"
+
+
+def test_direct_openai_execution_rechecks_auth_before_process_launch(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_ALLOW_OPENAI_API_SPEND="0",
+    )
+    auth_state = {"calls": 0}
+
+    def auth_mode() -> str:
+        auth_state["calls"] += 1
+        return "chatgpt" if auth_state["calls"] == 1 else "api_key"
+
+    monkeypatch.setattr(module, "stored_codex_auth_mode", auth_mode)
+
+    def fail_popen(*_args, **_kwargs):
+        raise AssertionError("direct Codex process must not launch after auth changes")
+
+    monkeypatch.setattr(module.subprocess, "Popen", fail_popen)
+
+    response, error_text, _thread_id, usage = module._execute_codex_prompt(
+        "Check the current state.", "balanced", 2, [], service_tier="flex"
+    )
+
+    assert response == ""
+    assert "No OpenAI API request was sent." in error_text
+    assert usage["provider_error_kind"] == "openai_api_spend_blocked"
+
+
+def test_direct_chatgpt_launch_requires_turn_to_fit_reset_window(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_ALLOW_OPENAI_API_SPEND="0",
+    )
+    monkeypatch.setattr(module, "stored_codex_auth_mode", lambda: "chatgpt")
+    monkeypatch.setattr(
+        module,
+        "codex_account_capacity_snapshot",
+        lambda **_kwargs: {
+            "fresh": True,
+            "state": "available",
+            "minimum_window_percent_left": 75,
+            "windows": [{"reset_seconds": 300}],
+        },
+    )
+
+    decision = module.codex_openai_direct_execution_decision(
+        "flex",
+        prompt="Implement the focused fix and verify it.",
+        job_budget="normal",
+        detail=3,
+    )
+
+    assert decision["allowed"] is False
+    assert decision["reason_code"] == "chatgpt_credit_extension_guard"
+    assert decision["capacity"]["forecast"]["turn_fits_reset"] is False
+
+
+def test_bedrock_launch_drops_inherited_openai_api_key_when_api_spend_disabled(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-bedrock-child")
+    module = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_ALLOW_OPENAI_API_SPEND="0",
+        NORMAN_CODEX_STANDARD_PROFILE_V2="personal-bedrock",
+        NORMAN_CODEX_STANDARD_MODEL="openai.gpt-5.5",
+        NORMAN_CODEX_STANDARD_AWS_PROFILE="kk-personal",
+        NORMAN_CODEX_STANDARD_AWS_REGION="us-east-2",
+    )
+    captured_env: dict[str, str] = {}
+
+    class FakePopen:
+        pid = 12345
+        returncode = 0
+
+        def __init__(self, cmd, text, stdin, stdout, stderr, env, start_new_session):
+            captured_env.update(env)
+            output_path = pathlib.Path(cmd[cmd.index("-o") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text("ok", encoding="utf-8")
+
+        def communicate(self, timeout=None):
+            return "", ""
+
+    monkeypatch.setattr(module.subprocess, "Popen", FakePopen)
+
+    response, error_text, _thread_id, _usage = module._execute_codex_prompt(
+        "Check the Bedrock route.", "balanced", 2, [], service_tier="default"
+    )
+
+    assert response == "ok"
+    assert error_text == ""
+    assert "OPENAI_API_KEY" not in captured_env
+    assert captured_env["AWS_PROFILE"] == "kk-personal"
+    assert captured_env["AWS_REGION"] == "us-east-2"
+
+
+def test_subscription_self_improvement_runs_once_near_reset_with_read_only_codex(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_norman_codex_web(
+        monkeypatch,
+        tmp_path,
+        NORMAN_CODEX_ALLOW_OPENAI_API_SPEND="0",
+        NORMAN_CODEX_SUBSCRIPTION_SELF_IMPROVEMENT_ENABLED="1",
+        NORMAN_CODEX_BILLING_OWNER="kristopher",
+        NORMAN_CODEX_AGENT_GROUP="personal",
+    )
+    module.ensure_state_dir()
+    now = 1_700_000_000
+    capacity = {
+        **module.default_codex_account_capacity(),
+        "source": "interactive_usage",
+        "observed_at": now,
+        "last_probe_at": now,
+        "auth_mode": "chatgpt",
+        "state": "available",
+        "windows": [
+            {
+                "label": "Short",
+                "percent_left": 75,
+                "reset_hint": "10m",
+                "reset_seconds": 600,
+            }
+        ],
+    }
+    monkeypatch.setattr(module, "stored_codex_auth_mode", lambda: "chatgpt")
+    monkeypatch.setattr(module, "now_ts", lambda: now)
+    monkeypatch.setattr(module, "prompt_runtime_alive", lambda: False)
+    monkeypatch.setattr(module, "prompt_thread_alive", lambda: False)
+    module.update_status_meta(pending=False, queued_prompts=[])
+    module._persist_codex_account_capacity(capacity)
+    launches: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        module,
+        "start_web_prompt",
+        lambda *args, **kwargs: (
+            launches.append((args, kwargs)) is None,
+            {},
+        ),
+    )
+
+    decision = module.codex_subscription_self_improvement_decision(capacity, now=now)
+
+    assert decision["eligible"] is True
+    assert decision["reset_window_id"]
+    assert module.maybe_start_subscription_capacity_self_improvement(capacity) is True
+    assert module.maybe_start_subscription_capacity_self_improvement(capacity) is False
+    assert len(launches) == 1
+    args, kwargs = launches[0]
+    assert module.SUBSCRIPTION_SELF_IMPROVEMENT_MARKER in str(args[0])
+    assert kwargs["runtime"] == "codex"
+    assert kwargs["service_tier"] == "flex"
+    assert kwargs["route_lock"] is True
+    assert kwargs["source"] == "system"
+
+    command: list[str] = []
+
+    class FakePopen:
+        pid = 12345
+        returncode = 0
+
+        def __init__(self, cmd, text, stdin, stdout, stderr, env, start_new_session):
+            command.extend(cmd)
+            assert "OPENAI_API_KEY" not in env
+            assert "CODEX_API_KEY" not in env
+            output_path = pathlib.Path(cmd[cmd.index("-o") + 1])
+            output_path.write_text("Read-only review complete.", encoding="utf-8")
+
+        def communicate(self, timeout=None):
+            return "", ""
+
+    monkeypatch.setattr(module.subprocess, "Popen", FakePopen)
+
+    response, error_text, _thread_id, _usage = module._execute_codex_prompt(
+        module.subscription_capacity_self_improvement_prompt(),
+        "balanced",
+        2,
+        [],
+        service_tier="flex",
+        job_budget="2m",
+        optimization_mode="raw",
+    )
+
+    assert response == "Read-only review complete."
+    assert error_text == ""
+    assert command[command.index("--sandbox") + 1] == "read-only"
+    assert command[command.index("--ask-for-approval") + 1] == "never"
+    assert "--dangerously-bypass-approvals-and-sandbox" not in command
 
 
 def test_careful_response_speed_uses_xhigh_reasoning(monkeypatch, tmp_path) -> None:
@@ -619,6 +1132,8 @@ def test_bedrock_standard_profile_routes_standard_and_keeps_flex_direct(
     module = _load_norman_codex_web(
         monkeypatch,
         tmp_path,
+        NORMAN_CODEX_ALLOW_OPENAI_API_SPEND="1",
+        NORMAN_CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED="1",
         NORMAN_CODEX_SERVICE_TIER="default",
         NORMAN_CODEX_STANDARD_PROFILE_V2="traqline-bedrock",
         NORMAN_CODEX_STANDARD_MODEL="openai.gpt-5.5",
@@ -1192,7 +1707,7 @@ def test_start_web_prompt_prefers_fresh_chatgpt_capacity_over_bedrock(
     assert events[0]["payload"]["selected_service_tier"] == "flex"
 
 
-def test_switchboard_unsupported_usage_command_is_sanitized_and_backed_off(
+def test_switchboard_capacity_probe_never_sends_usage_command(
     monkeypatch, tmp_path
 ) -> None:
     module = _load_norman_codex_web(monkeypatch, tmp_path)
@@ -1207,12 +1722,12 @@ def test_switchboard_unsupported_usage_command_is_sanitized_and_backed_off(
     monkeypatch.setattr(module, "prompt_runtime_alive", lambda: False)
     monkeypatch.setattr(module, "prompt_thread_alive", lambda: False)
     prompt_pane = "OpenAI Codex (v0.144.4)\n\n› "
-    unsupported_pane = "Unrecognized command '/usage'. Type \"/\" for a list of supported commands.\n\n› "
-    panes = iter([prompt_pane, unsupported_pane, unsupported_pane])
     sent: list[str] = []
     keys: list[tuple[str, ...]] = []
-    monkeypatch.setattr(module, "capture_pane", lambda: next(panes))
-    monkeypatch.setattr(module, "send_text", lambda value: sent.append(value))
+    monkeypatch.setattr(module, "capture_pane", lambda: prompt_pane)
+    monkeypatch.setattr(
+        module, "send_codex_status_probe", lambda: sent.append("/status")
+    )
     monkeypatch.setattr(module, "send_keys", lambda *value: keys.append(value))
 
     assert (
@@ -1227,16 +1742,12 @@ def test_switchboard_unsupported_usage_command_is_sanitized_and_backed_off(
     worker.join(timeout=1)
 
     persisted = module.codex_account_capacity_snapshot(auth_mode="chatgpt")
-    history_text = module.CODEX_ACCOUNT_CAPACITY_HISTORY_PATH.read_text(
-        encoding="utf-8"
-    )
-    assert sent == ["/usage"]
-    assert keys == [("Escape",), ("C-u",), ("C-a", "C-k"), ("C-l",)]
-    assert persisted["source"] == "unsupported_command"
+    assert sent == []
+    assert keys == []
+    assert persisted["source"] == "probe_command_rejected"
     assert persisted["state"] == "unknown"
     assert persisted["eligible_for_subscription_route"] is False
-    assert "Unrecognized command" not in history_text
-    assert "/usage" not in history_text
+    assert "/usage can consume an account limit reset" in persisted["last_error"]
     assert (
         module.maybe_schedule_codex_account_capacity_probe(
             pane=prompt_pane,
@@ -1244,6 +1755,32 @@ def test_switchboard_unsupported_usage_command_is_sanitized_and_backed_off(
         )
         is False
     )
+
+
+def test_norman_status_capacity_parser_records_credit_metadata(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_norman_codex_web(monkeypatch, tmp_path)
+    observed_at = int(time.mktime((2026, 7, 16, 12, 0, 0, 0, 0, -1)))
+
+    parsed = module.parse_codex_account_capacity_pane(
+        """
+        You have 4 usage limit resets available. Run /usage to use one.
+        Weekly limit: 100% left
+        (resets 12:12 on 23 Jul)
+        Context window: 92% left
+        Credits: 6,907 credits
+        """,
+        observed_at=observed_at,
+        auth_mode="chatgpt",
+    )
+
+    assert parsed["state"] == "available"
+    assert parsed["minimum_window_percent_left"] == 100
+    assert [window["label"] for window in parsed["windows"]] == ["Weekly"]
+    assert parsed["windows"][0]["reset_seconds"] > 6 * 24 * 60 * 60
+    assert parsed["credits_available"] == 6907
+    assert parsed["usage_limit_resets_available"] == 4
 
 
 def test_bedrock_standard_can_disable_direct_openai_tiers(

--- a/tests/test_sync_agent_console_template.py
+++ b/tests/test_sync_agent_console_template.py
@@ -895,6 +895,67 @@ def test_uplink_sync_removes_disabled_figma_plugin(monkeypatch, tmp_path) -> Non
     assert 'plugins."github@openai-curated"' in config
 
 
+def test_local_llm_foreground_sync_configures_intent_classifier(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_sync_script(monkeypatch)
+    env_path = tmp_path / "uplink.env"
+    env_path.write_text(
+        "NORMAN_LOCAL_LLM_FILTER_MODELS=qwen3.6:27b\n",
+        encoding="utf-8",
+    )
+    uplink = replace(
+        _instance(module, "uplink", host_name="networking-host"),
+        env_file=str(env_path),
+    )
+    monkeypatch.setattr(
+        module,
+        "ssh_command",
+        lambda host, script: ["bash", "-lc", script],
+    )
+
+    assert module.sync_instance_local_llm_foreground_settings(
+        _named_host(module, "networking-host"),
+        uplink,
+    )
+
+    synced = env_path.read_text(encoding="utf-8")
+    assert "NORMAN_LOCAL_LLM_FILTER_MODELS" not in synced
+    assert (
+        "NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_MODEL=" "qwen3.6:35b-a3b-q4_K_M"
+    ) in synced
+    assert "NORMAN_LOCAL_ROUTE_INTENT_CLASSIFIER_MAX_OUTPUT_TOKENS=192" in synced
+    assert "NORMAN_TUI_TOKEN_CAPACITY_USAGE_WINDOW_SECONDS=3600" in synced
+    assert "NORMAN_CODEX_SUBSCRIPTION_ROUTE_PREFERENCE_ENABLED=1" in synced
+    assert "NORMAN_CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED=0" in synced
+    assert "NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_PERCENT_LEFT=25" in synced
+    assert "NORMAN_CODEX_SUBSCRIPTION_ROUTE_MIN_RESET_SECONDS=300" in synced
+    assert "NORMAN_CODEX_SUBSCRIPTION_ROUTE_FORECAST_CAP_FRACTION=0.5" in synced
+    assert "NORMAN_CODEX_CHATGPT_CREDIT_EXTENSION_ALLOWED=0" in synced
+
+
+def test_local_llm_foreground_sync_enables_work_subscription_scope(
+    monkeypatch, tmp_path
+) -> None:
+    module = _load_sync_script(monkeypatch)
+    env_path = tmp_path / "panelbot.env"
+    env_path.write_text("", encoding="utf-8")
+    panelbot = replace(_instance(module, "panelbot"), env_file=str(env_path))
+    monkeypatch.setattr(
+        module,
+        "ssh_command",
+        lambda host, script: ["bash", "-lc", script],
+    )
+
+    assert module.sync_instance_local_llm_foreground_settings(
+        _named_host(module, "work-special"),
+        panelbot,
+    )
+
+    synced = env_path.read_text(encoding="utf-8")
+    assert "NORMAN_CODEX_SUBSCRIPTION_ROUTE_WORK_ENABLED=1" in synced
+
+
 def test_work_bedrock_secondary_failover_requires_explicit_enablement(
     monkeypatch,
 ) -> None:
@@ -1300,10 +1361,10 @@ def test_work_named_tui_on_norman_stays_personal_without_test_override(
     script = captured["script"]
     assert '"NORMAN_CODEX_BILLING_SCOPE":"norman"' in script
     assert '"NORMAN_CODEX_BILLING_OWNER":"kristopher"' in script
-    assert '"NORMAN_CODEX_SERVICE_TIER":"flex"' in script
-    assert '"NORMAN_CODEX_MODEL":"gpt-5.4"' in script
-    assert '"NORMAN_CODEX_DIRECT_MODEL":"gpt-5.4"' in script
-    assert "NORMAN_CODEX_STANDARD_PROFILE_V2" in script
+    assert '"NORMAN_CODEX_SERVICE_TIER":"default"' in script
+    assert '"NORMAN_CODEX_MODEL":"openai.gpt-5.4"' in script
+    assert '"NORMAN_CODEX_DIRECT_MODEL":"openai.gpt-5.4"' in script
+    assert "NORMAN_CODEX_STANDARD_PROFILE_V2" not in script
     assert "traqline-bedrock" not in script
     assert "ob-traqline-admin" not in script
 
@@ -1362,13 +1423,13 @@ def test_personal_tui_does_not_receive_work_bedrock_defaults(monkeypatch) -> Non
     assert module.sync_instance_origin_settings(toy_box, housebot) is False
 
     script = captured["script"]
-    assert '"NORMAN_CODEX_SERVICE_TIER":"flex"' in script
-    assert "remove_keys" in script
-    assert '"NORMAN_CODEX_MODEL":"gpt-5.4"' in script
-    assert '"NORMAN_CODEX_DIRECT_MODEL":"gpt-5.4"' in script
-    assert "NORMAN_CODEX_STANDARD_PROFILE_V2" in script
+    assert '"NORMAN_CODEX_SERVICE_TIER":"default"' in script
+    assert "remove_keys = json.loads('[]')" in script
+    assert '"NORMAN_CODEX_MODEL":"openai.gpt-5.4"' in script
+    assert '"NORMAN_CODEX_DIRECT_MODEL":"openai.gpt-5.4"' in script
+    assert "NORMAN_CODEX_STANDARD_PROFILE_V2" not in script
     assert "traqline-bedrock" not in script
-    assert "NORMAN_CODEX_DIRECT_TIERS_ENABLED" in script
+    assert "NORMAN_CODEX_DIRECT_TIERS_ENABLED" not in script
     assert "ob-traqline-admin" not in script
 
 
@@ -1564,7 +1625,7 @@ def test_personal_bedrock_source_falls_back_when_sync_runs_as_root(
     assert module.non_work_bedrock_profile_source_ready() is True
 
 
-def test_netops_defaults_to_direct_5_4_and_removes_bedrock(
+def test_netops_preserves_bedrock_when_profile_source_is_unavailable(
     monkeypatch,
 ) -> None:
     module = _load_sync_script(monkeypatch)
@@ -1590,12 +1651,12 @@ def test_netops_defaults_to_direct_5_4_and_removes_bedrock(
     assert module.sync_instance_origin_settings(netops_host, networking) is True
 
     script = captured["script"]
-    assert '"NORMAN_CODEX_SERVICE_TIER":"flex"' in script
-    assert '"NORMAN_CODEX_MODEL":"gpt-5.4"' in script
-    assert '"NORMAN_CODEX_MODEL_FLOOR":"gpt-5.4"' in script
-    assert '"NORMAN_CODEX_DIRECT_MODEL":"gpt-5.4"' in script
-    assert '"NORMAN_CODEX_FLEX_MODEL":"gpt-5.4"' in script
-    assert '"NORMAN_CODEX_PRIORITY_MODEL":"gpt-5.4"' in script
+    assert '"NORMAN_CODEX_SERVICE_TIER":"default"' in script
+    assert '"NORMAN_CODEX_MODEL":"openai.gpt-5.4"' in script
+    assert '"NORMAN_CODEX_MODEL_FLOOR":"openai.gpt-5.4"' in script
+    assert '"NORMAN_CODEX_DIRECT_MODEL":"openai.gpt-5.4"' in script
+    assert '"NORMAN_CODEX_FLEX_MODEL":"openai.gpt-5.4"' in script
+    assert '"NORMAN_CODEX_PRIORITY_MODEL":"openai.gpt-5.4"' in script
     assert (
         '"NORMAN_CODEX_SWITCHABLE_MODELS":"'
         "openai.gpt-5.4,openai.gpt-5.5,"
@@ -1608,8 +1669,49 @@ def test_netops_defaults_to_direct_5_4_and_removes_bedrock(
         "openai.gpt-5.6-luna,openai.gpt-5.6-terra,openai.gpt-5.6-sol,"
         'gpt-5.4,gpt-5.5,gpt-5.6-luna,gpt-5.6-terra,gpt-5.6-sol"'
     ) in script
-    assert "NORMAN_CODEX_STANDARD_PROFILE_V2" in script
+    assert "NORMAN_CODEX_STANDARD_PROFILE_V2" not in script
     assert "traqline-bedrock" not in script
+
+
+def test_shared_and_norman_instances_use_non_work_bedrock(
+    monkeypatch, tmp_path: Path
+) -> None:
+    source = tmp_path / "personal-bedrock.config.toml"
+    source.write_text('model = "openai.gpt-5.4"\n', encoding="utf-8")
+    monkeypatch.setenv("NORMAN_SYNC_NON_WORK_BEDROCK_PROFILE_SOURCE", str(source))
+    module = _load_sync_script(monkeypatch)
+    netops_host = _named_host(module, "networking-host")
+    norman_host = _named_host(module, "norman")
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        module,
+        "ssh_command",
+        lambda host, script: ["ssh", script],
+    )
+
+    def fake_capture(cmd):
+        captured["script"] = cmd[1]
+        return "changed\n"
+
+    monkeypatch.setattr(module, "capture", fake_capture)
+
+    for name in ("cloudagent", "networking", "uplink"):
+        instance = _instance(module, name, host_name="networking-host")
+        assert module.instance_uses_non_work_bedrock(netops_host, instance) is True
+
+    norman = _instance(module, "norman", host_name="norman")
+    assert module.instance_uses_non_work_bedrock(norman_host, norman) is True
+    assert (
+        module.sync_instance_origin_settings(
+            netops_host, _instance(module, "networking", host_name="networking-host")
+        )
+        is True
+    )
+
+    script = captured["script"]
+    assert '"NORMAN_CODEX_SERVICE_TIER":"default"' in script
+    assert '"NORMAN_CODEX_STANDARD_PROFILE_V2":"personal-bedrock"' in script
 
 
 def test_console_files_include_soul_support_scripts(monkeypatch) -> None:
@@ -1648,7 +1750,7 @@ def test_norman_switchboard_uses_its_dedicated_web_source(monkeypatch) -> None:
 def test_web_sources_must_share_ui_version(monkeypatch, tmp_path: Path) -> None:
     module = _load_sync_script(monkeypatch)
 
-    assert module.validate_web_source_versions() == "2026.07.16.07"
+    assert module.validate_web_source_versions() == "2026.07.16.14"
 
     stale_switchboard = tmp_path / "norman_codex_web.py"
     stale_switchboard.write_text(
@@ -1662,7 +1764,7 @@ def test_web_sources_must_share_ui_version(monkeypatch, tmp_path: Path) -> None:
     except RuntimeError as exc:
         assert str(exc) == (
             "Web UI source versions must match: "
-            "norman-switchboard=v2026.07.16.06, web=v2026.07.16.07"
+            "norman-switchboard=v2026.07.16.06, web=v2026.07.16.14"
         )
     else:
         raise AssertionError("expected mismatched web sources to be rejected")

--- a/tests/test_tui_bedrock_region_smoke.py
+++ b/tests/test_tui_bedrock_region_smoke.py
@@ -203,7 +203,11 @@ def test_live_smoke_report_runs_codex_candidate(monkeypatch) -> None:
     module = _load_module()
     calls = []
 
-    def fake_run(cmd, text, stdout, stderr, env, timeout, check):
+    def fake_run(cmd, text, stdout, stderr, timeout, check, env=None):
+        if cmd == ["/usr/local/bin/codex", "exec", "--help"]:
+            return module.subprocess.CompletedProcess(
+                cmd, 0, stdout="--profile", stderr=""
+            )
         calls.append((cmd, env, timeout))
         output_path = Path(cmd[cmd.index("-o") + 1])
         output_path.write_text("BEDROCK_SMOKE_OK_profile_us_east_1", encoding="utf-8")
@@ -230,17 +234,50 @@ def test_live_smoke_report_runs_codex_candidate(monkeypatch) -> None:
     assert profile["status"] == "ok"
     assert profile["event_types"] == ["thread.started", "turn.completed"]
     cmd, env, timeout = calls[0]
-    assert cmd[cmd.index("--profile-v2") + 1] == "profile"
+    assert cmd[cmd.index("--profile") + 1] == "profile"
     assert cmd[cmd.index("-m") + 1] == "openai.gpt-5.5"
+    assert 'model_reasoning_effort="low"' in cmd
     assert env["CODEX_HOME"] == "/tmp/codex-home"
     assert env["AWS_REGION"] == "us-east-1"
     assert timeout == 90
 
 
+def test_live_smoke_uses_legacy_profile_flag_when_required(monkeypatch) -> None:
+    module = _load_module()
+    calls = []
+
+    def fake_run(cmd, text, stdout, stderr, timeout, check, env=None):
+        if cmd == ["codex", "exec", "--help"]:
+            return module.subprocess.CompletedProcess(
+                cmd, 0, stdout="--profile-v2", stderr=""
+            )
+        calls.append((cmd, env, timeout))
+        output_path = Path(cmd[cmd.index("-o") + 1])
+        output_path.write_text("BEDROCK_SMOKE_OK_profile_us_east_1", encoding="utf-8")
+        return module.subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    report = module.build_live_smoke_report(
+        candidates=[("profile", "us-east-1")],
+        model="openai.gpt-5.5",
+        codex_bin="codex",
+        codex_home="",
+        workdir="/tmp",
+        timeout_seconds=90,
+    )
+
+    assert report["profiles"]["profile"]["ok"] is True
+    assert calls[0][0][calls[0][0].index("--profile-v2") + 1] == "profile"
+
+
 def test_live_smoke_report_classifies_stream_disconnect(monkeypatch) -> None:
     module = _load_module()
 
-    def fake_run(cmd, text, stdout, stderr, env, timeout, check):
+    def fake_run(cmd, text, stdout, stderr, timeout, check, env=None):
+        if cmd == ["codex", "exec", "--help"]:
+            return module.subprocess.CompletedProcess(
+                cmd, 0, stdout="--profile", stderr=""
+            )
         return module.subprocess.CompletedProcess(
             cmd,
             1,

--- a/tests/test_tui_fleet_scorecard.py
+++ b/tests/test_tui_fleet_scorecard.py
@@ -189,6 +189,30 @@ def test_console_link_token_paths_use_active_home_and_env_override(
     assert module.console_link_token_paths() == [override_a, override_b]
 
 
+def test_main_fails_explicitly_when_no_inventory(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    module = _load_scorecard(monkeypatch)
+    output = tmp_path / "scorecard.json"
+    monkeypatch.setattr(module, "load_db_items", lambda _path: [])
+    monkeypatch.setattr(module, "load_registry_items", lambda _path: [])
+    monkeypatch.setattr(module, "console_link_token_paths", lambda: [])
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["tui_fleet_scorecard.py", "--json", "--output", str(output)],
+    )
+
+    result = module.main()
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    captured = capsys.readouterr()
+    assert result == 2
+    assert report["status"] == "inventory_unavailable"
+    assert report["items"] == []
+    assert "refusing to report a healthy empty fleet" in captured.err
+
+
 def test_load_tokens_from_console_links_indexes_all_console_url_shapes(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_tui_kernel_acceptance.py
+++ b/tests/test_tui_kernel_acceptance.py
@@ -48,6 +48,34 @@ def test_form_payload_uses_locked_local_llm_route():
     assert run.expected_response == "DONE local visible r1-norman-canary"
 
 
+def test_dry_run_writes_not_executed_plan(tmp_path, capsys):
+    output = tmp_path / "nested" / "acceptance-plan.json"
+
+    result = acceptance.main(
+        [
+            "--targets",
+            "norman",
+            "--scenarios",
+            "canary",
+            "--run-id",
+            "dry-plan",
+            "--output-json",
+            str(output),
+        ]
+    )
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    captured = capsys.readouterr()
+    assert result == 0
+    assert report["dry_run_only"] is True
+    assert report["model_calls_executed"] == 0
+    assert report["execution_status"] == "not_executed"
+    assert report["passed"] is None
+    assert report["plans"][0]["target"] == "norman"
+    assert report["plans"][0]["execution_status"] == "not_executed"
+    assert "expected response (not executed)" in captured.out
+
+
 def test_norman_target_uses_ssh_when_acceptance_runs_off_host(monkeypatch):
     monkeypatch.delenv("NORMAN_TUI_ACCEPTANCE_NORMAN_SSH_TARGET", raising=False)
     monkeypatch.setattr(acceptance.socket, "gethostname", lambda: "hal")

--- a/tests/test_tui_vllm_sense.py
+++ b/tests/test_tui_vllm_sense.py
@@ -92,6 +92,17 @@ class TuiVllmSenseTests(unittest.TestCase):
         self.assertIn("http://192.168.2.50:8000", endpoints)
         self.assertNotIn("http://169.254.1.10:8000", endpoints)
 
+    def test_explicit_endpoint_precedes_defaults_and_frontdoor_is_first_default(self):
+        module = load_module()
+
+        endpoints = module.configured_endpoints(
+            ["http://explicit-spark:8000"],
+            autosense_lan=False,
+        )
+
+        self.assertEqual(endpoints[0], "http://explicit-spark:8000")
+        self.assertEqual(module.DEFAULT_ENDPOINTS[0], "https://llm.home.arpa")
+
     def test_build_report_marks_model_missing(self):
         module = load_module()
 
@@ -170,6 +181,26 @@ class TuiVllmSenseTests(unittest.TestCase):
             result = module.probe_endpoint("spark:8000", timeout=0.5)
 
         self.assertTrue(result.ok)
+
+    def test_build_report_stops_after_first_usable_endpoint(self):
+        module = load_module()
+        requested_urls = []
+
+        def fake_urlopen(req, timeout, context=None):
+            requested_urls.append(req.full_url)
+            return DummyResponse({"data": [{"id": "qwen3.6:35b-a3b-q4_K_M"}]})
+
+        with mock.patch.object(module, "urlopen", fake_urlopen):
+            report = module.build_report(
+                ["http://frontdoor:8000", "http://fallback:8000"],
+                timeout=0.5,
+                stop_after_usable=True,
+            )
+
+        self.assertEqual(report["summary"]["candidate_endpoint_count"], 2)
+        self.assertEqual(report["summary"]["total_endpoints"], 1)
+        self.assertEqual(report["summary"]["best_endpoint"], "http://frontdoor:8000")
+        self.assertEqual(requested_urls, ["http://frontdoor:8000/v1/models"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Make Norllama the safer local-first routing lane and add bounded token-capacity planning.
- Propagate personal Bedrock profiles through the managed console sync path.
- Guard direct Codex use with fresh ChatGPT capacity, reset-aware forecasts, and no paid OpenAI API or credit-extension fallback.
- Improve the console working recap and provider usage feedback.

## Why
This closes routing and capacity blind spots that could otherwise leave local work underused or permit direct OpenAI spend when plan capacity is unknown.

## Validation
- `make format`
- `make lint`
- `make test` (`1955 passed`, `65 warnings`)

No frontend files changed, so `npm test` was not required.