### PR TITLE
Guard cloud runtime requests by token budget

### DIFF
--- a/app/services/console_runtime/worker.py
+++ b/app/services/console_runtime/worker.py
@@ -57,6 +57,7 @@ DEFAULT_WORKSPACE_PREFLIGHT_COMMANDS = [
     "git status --short",
     "git branch --show-current",
 ]
+CLOUD_TOKEN_REQUEST_OVERHEAD = 32
 GOAL_PHASE_TASK_KIND = {
     "chat": "chat",
     "compact": "compact",
@@ -549,6 +550,55 @@ def _completion_requested_for_step(options: "ConsoleRuntimeRunOptions") -> bool:
     return bool(options.complete)
 
 
+def _cloud_input_token_reserve(messages: list[dict[str, Any]]) -> int:
+    """Return a conservative upper bound for text sent to a cloud provider."""
+
+    text = "\n".join(str(message.get("content") or "") for message in messages)
+    return len(text.encode("utf-8")) + CLOUD_TOKEN_REQUEST_OVERHEAD
+
+
+def _cloud_budget_plan(
+    *,
+    route: Any,
+    options: "ConsoleRuntimeRunOptions",
+    messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if options.dry_run or not bool(getattr(route, "cloud_proxy", False)):
+        return {}
+
+    configured_total = max(0, int(options.cloud_token_budget or 0))
+    input_reserve = _cloud_input_token_reserve(messages)
+    remaining_output = configured_total - input_reserve
+    plan = {
+        "configured_total_tokens": configured_total,
+        "input_reserve_tokens": input_reserve,
+        "request_overhead_tokens": CLOUD_TOKEN_REQUEST_OVERHEAD,
+        "reserve_strategy": "utf8_bytes_plus_request_overhead",
+    }
+    if configured_total <= 0:
+        return {
+            **plan,
+            "blocked": True,
+            "reason": "cloud_token_budget_zero",
+        }
+    if remaining_output <= 0:
+        return {
+            **plan,
+            "blocked": True,
+            "reason": "cloud_token_budget_below_input_reserve",
+            "remaining_output_tokens": 0,
+        }
+    return {
+        **plan,
+        "blocked": False,
+        "remaining_output_tokens": remaining_output,
+        "max_output_tokens": min(
+            max(1, int(options.max_output_tokens or 1)),
+            remaining_output,
+        ),
+    }
+
+
 @dataclass
 class ConsoleRuntimeRunOptions:
     worker_id: str = "runtime-api-worker"
@@ -830,28 +880,80 @@ class DbConsoleRuntimeWorker:
             _route_requested_model(route.model, route_policy, opts)
         )
         route_payload = route.as_dict()
+        messages = [
+            {
+                "role": "system",
+                "content": self._system_prompt_for_phase(goal_phase),
+            },
+            {
+                "role": "user",
+                "content": self._phase_user_prompt(
+                    db,
+                    user_id=user_id,
+                    job=job,
+                    phase=goal_phase,
+                ),
+            },
+        ]
+        cloud_budget = _cloud_budget_plan(
+            route=route,
+            options=opts,
+            messages=messages,
+        )
+        if cloud_budget.get("blocked"):
+            reason = (
+                "Cloud token budget blocked provider invocation: "
+                f"{cloud_budget['reason']}"
+            )
+            self.store.record_policy_block(
+                db,
+                user_id=user_id,
+                job_id=job_id,
+                reason=reason,
+                policy_state=policy_state,
+                metadata={
+                    "decision_id": decision.decision_id,
+                    "cloud_budget": cloud_budget,
+                },
+            )
+            self.store.append_event(
+                db,
+                user_id=user_id,
+                job_id=job_id,
+                event_type="policy.cloud_budget_blocked",
+                payload={
+                    "reason": cloud_budget["reason"],
+                    "cloud_budget": cloud_budget,
+                    "route": route_payload,
+                },
+                summary="Cloud token budget blocked provider invocation.",
+                detail=reason,
+            )
+            blocked = self.store.block_job(
+                db, user_id=user_id, job_id=job_id, reason=reason
+            )
+            snapshot = self.store.activity_snapshot(db, user_id=user_id, job_id=job_id)
+            return {
+                "job": blocked.as_dict(),
+                "model_result": None,
+                "snapshot": snapshot,
+                "dry_run": opts.dry_run,
+                "worker_id": opts.worker_id,
+                "route_blocked": True,
+                "blocked_reason": reason,
+                "cloud_budget": cloud_budget,
+            }
+
         request = ModelRequest(
-            messages=[
-                {
-                    "role": "system",
-                    "content": self._system_prompt_for_phase(goal_phase),
-                },
-                {
-                    "role": "user",
-                    "content": self._phase_user_prompt(
-                        db,
-                        user_id=user_id,
-                        job=job,
-                        phase=goal_phase,
-                    ),
-                },
-            ],
+            messages=messages,
             model=requested_model,
             route_key=route.lane,
             budget=ModelBudget(
                 max_runtime_seconds=opts.max_runtime_seconds
                 or job.contract.max_runtime_seconds,
-                max_output_tokens=opts.max_output_tokens,
+                max_output_tokens=cloud_budget.get(
+                    "max_output_tokens", opts.max_output_tokens
+                ),
             ),
             metadata={
                 **opts.metadata,
@@ -888,6 +990,7 @@ class DbConsoleRuntimeWorker:
                 or route_policy.get("provider_timeout_seconds"),
                 "completion_requested": completion_requested,
                 "require_verifier_for_completion": verifier_required,
+                "cloud_budget": cloud_budget,
             },
         )
         self.store.append_event(
@@ -924,6 +1027,7 @@ class DbConsoleRuntimeWorker:
                 "provider": model_adapter.name,
                 "model": request.model,
                 "route_key": request.route_key,
+                "cloud_budget": cloud_budget,
                 "reasoning_plan_id": reasoning_plan.get("plan_id"),
                 "selected_skill_ids": list(
                     reasoning_plan.get("selected_skill_ids") or []
@@ -1298,11 +1402,17 @@ class DbConsoleRuntimeWorker:
                 opts.goal_phase_sequence, step_index, opts.max_steps
             )
             goal_task_kind = _goal_task_kind(goal_phase, opts.planner_kind)
+            remaining_cloud_budget = (
+                max(0, opts.cloud_token_budget - cloud_tokens)
+                if opts.cloud_token_budget
+                else 0
+            )
             step_options = replace(
                 opts,
                 complete=bool(opts.complete and step_index >= opts.max_steps),
                 continuous=False,
                 planner_kind=goal_task_kind,
+                cloud_token_budget=remaining_cloud_budget,
                 metadata={
                     **opts.metadata,
                     "goal_loop": True,

--- a/tests/test_console_runtime_worker.py
+++ b/tests/test_console_runtime_worker.py
@@ -1388,6 +1388,7 @@ def test_db_console_runtime_worker_uses_native_bedrock_for_explicit_cloud_route(
             dry_run=False,
             complete=False,
             live_execution_approved=True,
+            cloud_token_budget=4096,
         ),
     )
 
@@ -1406,6 +1407,156 @@ def test_db_console_runtime_worker_uses_native_bedrock_for_explicit_cloud_route(
     assert model_event.payload["route"]["provider"] == "bedrock"
     assert model_event.payload["route_receipt"]["usage_bucket"] == "bedrock_amazon"
     assert model_event.payload["route_receipt"]["total_tokens"] == 12
+
+
+@pytest.mark.parametrize(
+    ("cloud_token_budget", "reason"),
+    [
+        (0, "cloud_token_budget_zero"),
+        (1, "cloud_token_budget_below_input_reserve"),
+    ],
+)
+def test_db_console_runtime_worker_blocks_cloud_route_without_budget(
+    db, monkeypatch, cloud_token_budget, reason
+):
+    class UnexpectedBedrockAdapter:
+        name = "bedrock"
+
+        def __init__(self):
+            self.invocations = 0
+
+        def invoke(self, request):
+            self.invocations += 1
+            raise AssertionError("cloud adapter must not run without a budget")
+
+    adapter = UnexpectedBedrockAdapter()
+    monkeypatch.setattr(worker_module, "BedrockModelAdapter", lambda: adapter)
+
+    user = _ensure_user(db)
+    store = DbConsoleRuntimeStore()
+    worker = DbConsoleRuntimeWorker(store)
+    job_id = f"job-worker-cloud-budget-{cloud_token_budget}-{uuid.uuid4().hex}"
+    store.create_job(
+        db,
+        user_id=user.id,
+        job_id=job_id,
+        contract=ConsoleJobContract(
+            objective="Do not spend cloud tokens without an explicit budget.",
+            route_policy={
+                "provider": "bedrock",
+                "model": "anthropic.claude-test",
+                "allow_cloud_proxy": True,
+            },
+        ),
+    )
+
+    result = worker.run_once(
+        db,
+        user_id=user.id,
+        job_id=job_id,
+        options=ConsoleRuntimeRunOptions(
+            worker_id="worker-test",
+            dry_run=False,
+            complete=False,
+            include_capabilities=False,
+            live_execution_approved=True,
+            cloud_token_budget=cloud_token_budget,
+        ),
+    )
+
+    events = store.events_after(db, user_id=user.id, job_id=job_id)
+    event_types = [event.event_type for event in events]
+    budget_event = next(
+        event for event in events if event.event_type == "policy.cloud_budget_blocked"
+    )
+
+    assert adapter.invocations == 0
+    assert result["job"]["status"] == "blocked"
+    assert result["route_blocked"] is True
+    assert result["cloud_budget"]["reason"] == reason
+    assert (
+        budget_event.payload["cloud_budget"]["configured_total_tokens"]
+        == cloud_token_budget
+    )
+    assert "model.requested" not in event_types
+
+
+def test_db_console_runtime_worker_reserves_cloud_input_before_invocation(
+    db, monkeypatch
+):
+    class FakeBedrockAdapter:
+        name = "bedrock"
+
+        def __init__(self):
+            self.requests = []
+
+        def invoke(self, request):
+            self.requests.append(request)
+            return ModelResult(
+                provider="bedrock",
+                model=request.model,
+                text="bounded",
+                usage=ModelUsage(input_tokens=1, output_tokens=1),
+                metadata={
+                    "norllama_route": {
+                        "provider": "bedrock",
+                        "local": False,
+                        "cloud_proxy": True,
+                    },
+                    "norllama_receipt": {
+                        "route_receipt": {
+                            "selected_provider": "bedrock",
+                            "selected_model": request.model,
+                            "usage_bucket": "bedrock_amazon",
+                            "cloud_proxy": True,
+                        }
+                    },
+                },
+            )
+
+    adapter = FakeBedrockAdapter()
+    monkeypatch.setattr(worker_module, "BedrockModelAdapter", lambda: adapter)
+
+    user = _ensure_user(db)
+    store = DbConsoleRuntimeStore()
+    worker = DbConsoleRuntimeWorker(store)
+    job_id = f"job-worker-cloud-budget-cap-{uuid.uuid4().hex}"
+    store.create_job(
+        db,
+        user_id=user.id,
+        job_id=job_id,
+        contract=ConsoleJobContract(
+            objective="Bound this native Bedrock response.",
+            route_policy={
+                "provider": "bedrock",
+                "model": "anthropic.claude-test",
+                "allow_cloud_proxy": True,
+            },
+        ),
+    )
+
+    result = worker.run_once(
+        db,
+        user_id=user.id,
+        job_id=job_id,
+        options=ConsoleRuntimeRunOptions(
+            worker_id="worker-test",
+            dry_run=False,
+            complete=False,
+            include_capabilities=False,
+            live_execution_approved=True,
+            cloud_token_budget=2048,
+            max_output_tokens=4096,
+        ),
+    )
+
+    assert result["job"]["status"] == "checkpointed"
+    assert adapter.requests
+    budget = adapter.requests[0].metadata["cloud_budget"]
+    assert budget["blocked"] is False
+    assert budget["input_reserve_tokens"] > 0
+    assert adapter.requests[0].budget.max_output_tokens == budget["max_output_tokens"]
+    assert adapter.requests[0].budget.max_output_tokens < 4096
 
 
 def test_db_console_runtime_worker_fails_native_bedrock_without_fallback(
@@ -1460,6 +1611,7 @@ def test_db_console_runtime_worker_fails_native_bedrock_without_fallback(
             complete=False,
             include_capabilities=False,
             live_execution_approved=True,
+            cloud_token_budget=4096,
         ),
     )
 


### PR DESCRIPTION
## What changed

Adds a fail-closed cloud-token budget preflight for console-runtime Bedrock routes. A cloud request now requires an explicit positive budget, reserves the complete UTF-8 prompt payload plus 32 request-overhead tokens, and caps requested output to the remaining budget. Continuous runs pass their remaining cloud budget to each step. Durable policy and model events retain the resulting budget plan.

## Why

Cloud inference needed a hard worker-level spend boundary so a missing or undersized budget cannot invoke a provider. This supports local-first operation and prevents unbounded Bedrock use.

## Validation

- `make format`
- `make lint`
- `make test` (`1958 passed, 7 warnings`)
- Focused console-runtime worker tests (`66 passed, 4 warnings`)