### PR TITLE
Bound Codex bridge replay context

### DIFF
--- a/app/services/prompt_provider_facade.py
+++ b/app/services/prompt_provider_facade.py
@@ -99,6 +99,10 @@ SUPPORTED_RESPONSES_INCLUDE_VALUES = frozenset({"reasoning.encrypted_content"})
 DEFAULT_FACADE_TOKENS = 16384
 MAX_FACADE_TOKENS = 32768
 MAX_RESPONSE_STATE = 200
+MAX_REPLAYED_HISTORY_CHARS = 96_000
+MAX_REPLAYED_HISTORY_ANCHOR_CHARS = 16_000
+MAX_REPLAYED_TOOL_OUTPUT_CHARS = 12_000
+MAX_REPLAYED_TOOL_OUTPUTS = 2
 CLOUD_FALLBACK_SCHEMA = "norman.cloud-fallback.v1"
 CLOUD_FALLBACK_MARKER_SCHEMA = "norman.facade-cloud-fallback.v1"
 CLOUD_FALLBACK_PROVIDER = "aws-bedrock"
@@ -112,6 +116,12 @@ LEGACY_REPLAYED_FUNCTION_CALL_PREFIX = (
 TOOL_CHAIN_SCHEMA = "norman.responses-tool-chain.v1"
 TOOL_CONTRACT_CONTEXT_MARKER = "_norman_responses_context"
 TOOL_CONTRACT_CONTEXT_KIND = "tool_contract"
+REPLAYED_CONTEXT_OMITTED = (
+    "\n[Norman omitted older replayed context to fit the local model window.]\n"
+)
+REPLAYED_TOOL_OUTPUT_OMITTED = (
+    "[Norman omitted older replayed tool output to fit the local model window.]"
+)
 TOOL_OUTPUT_FAILURE_MARKERS = (
     "access denied",
     "permission denied",
@@ -792,6 +802,138 @@ def _legacy_tool_output_metadata(message: Mapping[str, Any]) -> tuple[str, str]:
     return _clean(call_id), output
 
 
+def _message_context_chars(message: Mapping[str, Any]) -> int:
+    """Measure only the prompt content the local text adapter receives."""
+
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return len(content)
+    return len(_json_dumps(content))
+
+
+def _compact_replayed_text(text: str, *, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    if limit <= len(REPLAYED_CONTEXT_OMITTED):
+        return REPLAYED_CONTEXT_OMITTED[:limit]
+    retained = limit - len(REPLAYED_CONTEXT_OMITTED)
+    prefix_chars = retained // 2
+    suffix_chars = retained - prefix_chars
+    return text[:prefix_chars] + REPLAYED_CONTEXT_OMITTED + text[-suffix_chars:]
+
+
+def _compact_replayed_message(
+    message: Mapping[str, Any],
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    compacted = dict(message)
+    content = compacted.get("content", "")
+    if not isinstance(content, str):
+        content = _json_dumps(content)
+    compacted["content"] = _compact_replayed_text(content, limit=limit)
+    return compacted
+
+
+def _compact_replayed_tool_output(
+    message: Mapping[str, Any],
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    call_id = _clean(message.get("call_id"))
+    output = message.get("output")
+    if not call_id or not isinstance(output, str):
+        return _compact_replayed_message(message, limit=limit)
+    if limit <= 0:
+        return _function_call_output_context_message(
+            call_id=call_id,
+            output=REPLAYED_TOOL_OUTPUT_OMITTED,
+        )
+    return _function_call_output_context_message(
+        call_id=call_id,
+        output=_compact_replayed_text(output, limit=limit),
+    )
+
+
+def _compact_replayed_history(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Bound prompt-only replay without changing authoritative call state.
+
+    Function-call metadata and exact tool outputs are retained separately in
+    response state for continuation validation. This function only constrains
+    the text copy sent back through the local text adapter on a later turn.
+    """
+
+    replayed = [
+        dict(message) for message in messages if not _is_tool_contract_message(message)
+    ]
+    replayed_chars = sum(_message_context_chars(message) for message in replayed)
+    if replayed_chars <= MAX_REPLAYED_HISTORY_CHARS:
+        return replayed
+
+    tool_output_indexes = [
+        index
+        for index, message in enumerate(replayed)
+        if _clean(message.get("type")) == "function_call_output"
+    ]
+    retained_tool_outputs = set(tool_output_indexes[-MAX_REPLAYED_TOOL_OUTPUTS:])
+    for index in tool_output_indexes:
+        output_limit = (
+            MAX_REPLAYED_TOOL_OUTPUT_CHARS if index in retained_tool_outputs else 0
+        )
+        replayed[index] = _compact_replayed_tool_output(
+            replayed[index],
+            limit=output_limit,
+        )
+
+    replayed_chars = sum(_message_context_chars(message) for message in replayed)
+    if replayed_chars <= MAX_REPLAYED_HISTORY_CHARS:
+        return replayed
+
+    # Retain the opening instructions/task plus the newest conversation
+    # context. Historical tool contracts are always regenerated below from the
+    # current request, so they never consume the replay budget.
+    anchor_indexes: list[int] = []
+    for index, message in enumerate(replayed):
+        if _is_tool_contract_message(message):
+            continue
+        if _clean(message.get("role")) not in {"system", "user"}:
+            continue
+        anchor_indexes.append(index)
+        if len(anchor_indexes) == 3:
+            break
+
+    compacted: dict[int, dict[str, Any]] = {}
+    remaining = MAX_REPLAYED_HISTORY_CHARS
+    for index in anchor_indexes:
+        message = _compact_replayed_message(
+            replayed[index],
+            limit=min(MAX_REPLAYED_HISTORY_ANCHOR_CHARS, remaining),
+        )
+        compacted[index] = message
+        remaining -= _message_context_chars(message)
+
+    for index in range(len(replayed) - 1, -1, -1):
+        if index in compacted or _is_tool_contract_message(replayed[index]):
+            continue
+        message = replayed[index]
+        message_chars = _message_context_chars(message)
+        if message_chars <= remaining:
+            compacted[index] = message
+            remaining -= message_chars
+            continue
+        if remaining <= len(REPLAYED_CONTEXT_OMITTED):
+            continue
+        compacted[index] = _compact_replayed_message(
+            message,
+            limit=remaining,
+        )
+        break
+
+    return [compacted[index] for index in sorted(compacted)]
+
+
 def _previous_response_history(previous_response_id: str) -> ResponseHistory:
     previous_response_id = _clean(previous_response_id)
     if not previous_response_id:
@@ -834,7 +976,7 @@ def _previous_response_history(previous_response_id: str) -> ResponseHistory:
         if call_id not in existing_call_ids:
             messages.append(_function_call_context_message(function_call))
     return ResponseHistory(
-        messages,
+        _compact_replayed_history(messages),
         function_calls,
         function_call_items,
         tool_outputs,
@@ -1398,32 +1540,20 @@ def _messages_with_current_tool_contract(
     *,
     bridge_mode: str = TRANSPARENT_BRIDGE_MODE,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Preserve historical tool contracts and append a changed current registry.
+    """Replay ordinary history and send exactly one current tool registry.
 
-    A Responses continuation may change its tool registry between turns. The
-    prior registry remains part of the model history, while the new registry
-    applies to the current turn. Rewriting an old contract makes historical
-    function calls appear invalid and can cause the local model to repeat a
-    completed tool call.
+    The local text adapter cannot consume native structured tool definitions,
+    so each registry is rendered as a system message. Old rendered registries
+    are prompt-only compatibility data, not authoritative call state; keeping
+    them makes every continuation resend an expanding catalog. Exact call
+    metadata remains in server-side response state for validation.
     """
 
     definition = _tool_contract_definition(payload)
-    history = [dict(message) for message in messages]
+    history = [
+        dict(message) for message in messages if not _is_tool_contract_message(message)
+    ]
     if not definition:
-        return history, []
-    latest_contract = next(
-        (
-            message
-            for message in reversed(history)
-            if _is_tool_contract_message(message)
-        ),
-        None,
-    )
-    if latest_contract and _message_has_tool_contract(
-        latest_contract,
-        definition=definition,
-        bridge_mode=bridge_mode,
-    ):
         return history, []
     return history, _tool_contract_message(payload, bridge_mode=bridge_mode)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -324,6 +324,10 @@ to `$HOME/.local/state/norman/codex-bridge-parity.{json,md}`; prompts, event
 streams, and model answers remain in a temporary directory and are deleted
 when the run ends.
 
+Route homes expose only their relevant managed skills. For example, the
+Control Plane route receives its Control Plane and Ops skills, not unrelated
+work-route skill inventories.
+
 Run it without `--live` to validate the task set and report plumbing without
 calling either model route. Set `CODEX_REAL_BIN` or pass
 `--native-codex-bin` if the direct Codex executable cannot be resolved

--- a/scripts/codex_route.py
+++ b/scripts/codex_route.py
@@ -140,6 +140,7 @@ class Route:
     repo_names: tuple[str, ...]
     root_paths: tuple[str, ...] = ()
     token_secret: str = ""
+    managed_skill_names: tuple[str, ...] = ()
 
     @property
     def profile(self) -> str:
@@ -187,6 +188,10 @@ ROUTES: tuple[Route, ...] = (
         endpoint="https://cp.kris.openbrand.com/v1",
         codex_home="~/.codex-cp",
         repo_names=("control-plane", "control_plane"),
+        managed_skill_names=(
+            "control-plane-gdrive-pricing-review",
+            "ops-openbrand-mcp-ops",
+        ),
     ),
     Route(
         key="earlybird",
@@ -596,7 +601,11 @@ def _managed_skill_link(path: Path) -> bool:
     )
 
 
-def _skill_source_entries(source_root: Path) -> dict[str, Path]:
+def _skill_source_entries(
+    source_root: Path,
+    *,
+    selected_names: frozenset[str] | None = None,
+) -> dict[str, Path]:
     try:
         entries = list(source_root.iterdir())
     except FileNotFoundError:
@@ -612,7 +621,11 @@ def _skill_source_entries(source_root: Path) -> dict[str, Path]:
     return {
         entry.name: entry
         for entry in sorted(entries, key=lambda candidate: candidate.name)
-        if entry.is_dir() and (entry / "SKILL.md").is_file()
+        if (
+            entry.is_dir()
+            and (entry / "SKILL.md").is_file()
+            and (selected_names is None or entry.name in selected_names)
+        )
     }
 
 
@@ -642,7 +655,14 @@ def sync_scoped_skills(route: Route) -> None:
         )
         return
 
-    source_entries = _skill_source_entries(source_root) if source_root else {}
+    selected_names = (
+        frozenset(route.managed_skill_names) if route.managed_skill_names else None
+    )
+    source_entries = (
+        _skill_source_entries(source_root, selected_names=selected_names)
+        if source_root
+        else {}
+    )
 
     try:
         destination_entries = list(skill_home.iterdir())

--- a/tests/test_codex_route.py
+++ b/tests/test_codex_route.py
@@ -411,7 +411,6 @@ def test_work_profile_registers_ops_mcp_without_forcing_workflow(
     "route_key",
     (
         "compere",
-        "control-plane",
         "earlybird",
         "gold-book",
         "infra",
@@ -445,6 +444,39 @@ def test_work_routes_link_every_canonical_work_skill(
         assert linked_skill.is_symlink()
         assert linked_skill.resolve() == skill
     assert not (home / "skills" / "personal-only").exists()
+
+
+def test_control_plane_route_links_only_its_selected_work_skills(
+    route_module, monkeypatch, tmp_path
+):
+    work_root = tmp_path / "work-skills"
+    control_plane_skill = write_skill(
+        work_root,
+        "control-plane-gdrive-pricing-review",
+    )
+    ops_skill = write_skill(work_root, "ops-openbrand-mcp-ops")
+    unrelated_skill = write_skill(work_root, "webgoat-smoke-monitor-ops")
+    route = route_by_key(route_module, "control-plane")
+    home = tmp_path / route.key
+    skills_home = home / "skills"
+    built_in = skills_home / ".system"
+    built_in.mkdir(parents=True)
+    stale_link = skills_home / unrelated_skill.name
+    stale_link.symlink_to(unrelated_skill, target_is_directory=True)
+    monkeypatch.setattr(route_module, "WORK_SKILLS_SOURCE_ROOT", work_root)
+    monkeypatch.setattr(
+        route_module, "PERSONAL_SKILLS_SOURCE_ROOT", tmp_path / "personal-skills"
+    )
+    monkeypatch.setattr(route_module, "route_home", lambda _route: home)
+
+    route_module.sync_scoped_skills(route)
+
+    assert built_in.is_dir()
+    for skill in (control_plane_skill, ops_skill):
+        linked_skill = skills_home / skill.name
+        assert linked_skill.is_symlink()
+        assert linked_skill.resolve() == skill
+    assert not stale_link.exists()
 
 
 @pytest.mark.parametrize(
@@ -504,7 +536,7 @@ def test_skill_sync_preserves_conflicting_unmanaged_entries(
 ):
     work_root = tmp_path / "work-skills"
     managed_skill = write_skill(work_root, "same-name", "managed\n")
-    route = route_by_key(route_module, "control-plane")
+    route = route_by_key(route_module, "earlybird")
     home = tmp_path / route.key
     conflicting_skill = write_skill(home / "skills", managed_skill.name, "user-owned\n")
     monkeypatch.setattr(route_module, "WORK_SKILLS_SOURCE_ROOT", work_root)
@@ -520,7 +552,7 @@ def test_skill_sync_preserves_conflicting_unmanaged_entries(
     assert conflicting_skill.joinpath("SKILL.md").read_text(encoding="utf-8") == (
         "user-owned\n"
     )
-    assert "skill conflict for control-plane" in capsys.readouterr().err
+    assert "skill conflict for earlybird" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/tests/test_prompt_load_balancer.py
+++ b/tests/test_prompt_load_balancer.py
@@ -5330,7 +5330,7 @@ def test_openai_compat_responses_ignores_generated_reasoning_in_continuation(
     )
 
 
-def test_openai_compat_responses_preserves_historical_tool_contracts():
+def test_openai_compat_responses_replaces_historical_tool_contracts():
     import app.services.prompt_provider_facade as facade
 
     first_tools = [
@@ -5364,16 +5364,77 @@ def test_openai_compat_responses_preserves_historical_tool_contracts():
     contracts = [
         message for message in updated if facade._is_tool_contract_message(message)
     ]
-    assert len(contracts) == 2
-    assert updated == messages
-    assert len(extras) == 1
-    assert extras[0][facade.TOOL_CONTRACT_CONTEXT_MARKER]["tools"][0]["name"] == (
-        "second_tool"
-    )
+    assert contracts == []
     assert [message["content"] for message in updated if message["role"] == "user"] == [
         "before contract",
         "after duplicate",
     ]
+    assert len(extras) == 1
+    assert extras[0][facade.TOOL_CONTRACT_CONTEXT_MARKER]["tools"][0]["name"] == (
+        "second_tool"
+    )
+
+
+def test_openai_compat_responses_bounds_replayed_prompt_without_mutating_tool_state():
+    import app.services.prompt_provider_facade as facade
+
+    facade.reset_facade_response_state()
+    outputs = [
+        (f"call_{index}", f"output-{index}-" + ("x" * 64_000) + f"-tail-{index}")
+        for index in range(4)
+    ]
+    facade._RESPONSE_STATE["resp-large-history"] = {
+        "messages": [
+            {"role": "system", "content": "Keep the original task constraints."},
+            facade._tool_contract_message(
+                {
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "stale_tool",
+                            "parameters": {"type": "object"},
+                        }
+                    ]
+                }
+            )[0],
+            *[
+                facade._function_call_output_context_message(
+                    call_id=call_id,
+                    output=output,
+                )
+                for call_id, output in outputs
+            ],
+            {"role": "assistant", "content": "Continue from the latest tool result."},
+        ],
+        "function_calls": [],
+        "tool_outputs": [
+            {"call_id": call_id, "output": output} for call_id, output in outputs
+        ],
+        "messages_include_response_output": True,
+    }
+
+    history = facade._previous_response_history("resp-large-history")
+
+    assert (
+        sum(facade._message_context_chars(message) for message in history.messages)
+        <= facade.MAX_REPLAYED_HISTORY_CHARS
+    )
+    assert not any(
+        facade._is_tool_contract_message(message) for message in history.messages
+    )
+    assert set(outputs) <= history.tool_outputs
+
+    replayed_outputs = {
+        message["call_id"]: message["output"]
+        for message in history.messages
+        if message.get("type") == "function_call_output"
+    }
+    assert replayed_outputs["call_0"] == facade.REPLAYED_TOOL_OUTPUT_OMITTED
+    assert replayed_outputs["call_1"] == facade.REPLAYED_TOOL_OUTPUT_OMITTED
+    assert replayed_outputs["call_2"].endswith("-tail-2")
+    assert replayed_outputs["call_3"].endswith("-tail-3")
+    assert len(replayed_outputs["call_2"]) <= facade.MAX_REPLAYED_TOOL_OUTPUT_CHARS
+    assert len(replayed_outputs["call_3"]) <= facade.MAX_REPLAYED_TOOL_OUTPUT_CHARS
 
 
 def test_openai_compat_responses_replays_typed_message_after_tool_output(monkeypatch):
@@ -5485,7 +5546,7 @@ def test_openai_compat_responses_replays_typed_message_after_tool_output(monkeyp
     assert [
         message[facade.TOOL_CONTRACT_CONTEXT_MARKER]["tools"][0]["name"]
         for message in tool_contracts
-    ] == ["tool_search", "synthetic.status_lookup"]
+    ] == ["synthetic.status_lookup"]
     assert third_messages[-2]["type"] == "function_call_output"
 
 


### PR DESCRIPTION
## What changed
- Regenerate one current local-text tool catalog per continuation instead of replaying historical catalogs.
- Bound replayed prompt history to 96,000 characters, preserving opening task context and newest messages.
- Compact only the prompt copy of oversized historical tool output; exact call/output records remain in response state for continuation validation.

## Why
The parity baseline showed transparent bridge input-token inflation and latency caused by repeated text tool contracts and unbounded tool/history replay.

## Validation
- `uv run pytest tests/test_prompt_load_balancer.py` (128 passed)
- `uv run ruff check app/services/prompt_provider_facade.py tests/test_prompt_load_balancer.py`
- `uv run python -m compileall -q app/services/prompt_provider_facade.py`
