### PR TITLE
Attribute Codex bridge prompt context

### DIFF
--- a/app/services/prompt_provider_facade.py
+++ b/app/services/prompt_provider_facade.py
@@ -811,6 +811,66 @@ def _message_context_chars(message: Mapping[str, Any]) -> int:
     return len(_json_dumps(content))
 
 
+def _message_context_breakdown(
+    messages: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Return content-free prompt sizing metadata for a message group."""
+
+    breakdown = {
+        "message_count": len(messages),
+        "chars": 0,
+        "tool_output_chars": 0,
+        "function_call_chars": 0,
+        "text_chars": 0,
+    }
+    for message in messages:
+        chars = _message_context_chars(message)
+        breakdown["chars"] += chars
+        item_type = _clean(message.get("type"))
+        if item_type == "function_call_output":
+            breakdown["tool_output_chars"] += chars
+        elif item_type == "function_call":
+            breakdown["function_call_chars"] += chars
+        else:
+            breakdown["text_chars"] += chars
+    return breakdown
+
+
+def _prompt_context_metadata(
+    *,
+    history_messages: list[dict[str, Any]],
+    tool_contract_messages: list[dict[str, Any]],
+    structured_output_messages: list[dict[str, Any]],
+    current_input_messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Describe prompt composition without retaining any prompt content."""
+
+    groups = {
+        "history": _message_context_breakdown(history_messages),
+        "tool_contract": _message_context_breakdown(tool_contract_messages),
+        "structured_output": _message_context_breakdown(structured_output_messages),
+        "current_input": _message_context_breakdown(current_input_messages),
+    }
+    all_messages = [
+        *history_messages,
+        *tool_contract_messages,
+        *structured_output_messages,
+        *current_input_messages,
+    ]
+    return {
+        "schema": "norman.responses-prompt-context.v1",
+        "groups": groups,
+        "total_message_count": len(all_messages),
+        "total_content_chars": sum(
+            _message_context_chars(message) for message in all_messages
+        ),
+        # The local adapter sends role labels and separators in addition to
+        # message content. This remains content-free but aligns with the
+        # prompt bytes sent to the local gateway.
+        "rendered_prompt_chars": len(norllama_gateway.messages_to_prompt(all_messages)),
+    }
+
+
 def _compact_replayed_text(text: str, *, limit: int) -> str:
     if len(text) <= limit:
         return text
@@ -3736,6 +3796,7 @@ class PreparedResponsesExecution:
     route_payload: dict[str, Any]
     route_envelope: dict[str, Any]
     messages: list[dict[str, Any]]
+    prompt_context: dict[str, Any]
     previous_messages: list[dict[str, Any]]
     function_calls: dict[str, str]
     function_call_items: dict[str, dict[str, Any]]
@@ -3785,16 +3846,24 @@ def _prepare_responses_execution(
         provider_payload,
         bridge_mode=bridge_mode,
     )
+    structured_output_messages = _structured_output_message(provider_payload)
+    current_input_messages = response_input_to_messages(
+        provider_payload,
+        known_tool_outputs=history.tool_outputs,
+        known_function_call_items=history.function_call_items,
+    )
     messages = [
         *history_messages,
         *tool_contract_messages,
-        *_structured_output_message(provider_payload),
-        *response_input_to_messages(
-            provider_payload,
-            known_tool_outputs=history.tool_outputs,
-            known_function_call_items=history.function_call_items,
-        ),
+        *structured_output_messages,
+        *current_input_messages,
     ]
+    prompt_context = _prompt_context_metadata(
+        history_messages=history_messages,
+        tool_contract_messages=tool_contract_messages,
+        structured_output_messages=structured_output_messages,
+        current_input_messages=current_input_messages,
+    )
     route_payload = {**provider_payload, "input": messages}
     route_envelope = provider_adapter_decision(
         provider="openai",
@@ -3807,6 +3876,7 @@ def _prepare_responses_execution(
         route_payload=route_payload,
         route_envelope=route_envelope,
         messages=messages,
+        prompt_context=prompt_context,
         previous_messages=history.messages,
         function_calls=function_calls,
         function_call_items=function_call_items,
@@ -3883,6 +3953,7 @@ def _responses_response_from_chat(
                     if prepared.history_replayed
                     else "unavailable"
                 ),
+                "prompt_context": prepared.prompt_context,
                 "tools_declared": len(_tools(provider_payload)),
                 "tool_calls_returned": len(tool_calls),
                 "tool_chain": tool_chain,

--- a/app/services/proxy_observability.py
+++ b/app/services/proxy_observability.py
@@ -18,6 +18,7 @@ DEFAULT_EVENT_LOG_PATH = Path("/var/lib/norman/state/proxy-events.jsonl")
 DEFAULT_EVENT_LOG_MAX_BYTES = 5 * 1024 * 1024
 DISABLED_EVENT_LOG_VALUES = frozenset({"0", "false", "none", "off", "disabled"})
 TOOL_CHAIN_SCHEMA = "norman.responses-tool-chain.v1"
+PROMPT_CONTEXT_SCHEMA = "norman.responses-prompt-context.v1"
 TOOL_CHAIN_TURN_TYPES = frozenset({"after_tool_result", "initial_or_text"})
 TOOL_CHAIN_OUTCOMES = frozenset(
     {
@@ -40,6 +41,19 @@ TOOL_CHAIN_WATCHDOG_STATES = frozenset(
 BRIDGE_MODES = frozenset({"transparent", "governed"})
 BRIDGE_TOOL_TRANSPORTS = frozenset({"local_text_adapter"})
 BRIDGE_STATE_RETENTIONS = frozenset({"ephemeral", "session"})
+PROMPT_CONTEXT_GROUPS = (
+    "history",
+    "tool_contract",
+    "structured_output",
+    "current_input",
+)
+PROMPT_CONTEXT_GROUP_FIELDS = (
+    "message_count",
+    "chars",
+    "tool_output_chars",
+    "function_call_chars",
+    "text_chars",
+)
 SAFE_TOOL_CHAIN_CALL_NAMES = frozenset({"tool_search"})
 LOCAL_TOOL_CHAIN_CALL_NAMES = {
     "apply_patch": "local_file_patch",
@@ -155,6 +169,38 @@ def _safe_identifier(value: Any, *, maximum: int = 192) -> str:
     return candidate[:maximum]
 
 
+def _safe_prompt_context_metadata(compatibility: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep numerical prompt sizing details without retaining model content."""
+
+    prompt_context = _mapping(compatibility.get("prompt_context"))
+    if _clean(prompt_context.get("schema")) != PROMPT_CONTEXT_SCHEMA:
+        return {}
+    raw_groups = _mapping(prompt_context.get("groups"))
+    groups: dict[str, dict[str, int]] = {}
+    for name in PROMPT_CONTEXT_GROUPS:
+        raw_group = _mapping(raw_groups.get(name))
+        groups[name] = {
+            field: _bounded_int(
+                raw_group.get(field),
+                maximum=10_000 if field == "message_count" else 4_000_000,
+            )
+            for field in PROMPT_CONTEXT_GROUP_FIELDS
+        }
+    return {
+        "schema": PROMPT_CONTEXT_SCHEMA,
+        "groups": groups,
+        "total_message_count": _bounded_int(
+            prompt_context.get("total_message_count"), maximum=10_000
+        ),
+        "total_content_chars": _bounded_int(
+            prompt_context.get("total_content_chars"), maximum=4_000_000
+        ),
+        "rendered_prompt_chars": _bounded_int(
+            prompt_context.get("rendered_prompt_chars"), maximum=4_000_000
+        ),
+    }
+
+
 def _safe_bridge_metadata(
     response: Mapping[str, Any],
     error: Mapping[str, Any],
@@ -201,6 +247,7 @@ def _safe_bridge_metadata(
                 "effective": _bounded_int(budget.get("effective")),
                 "maximum": _bounded_int(budget.get("maximum")),
             },
+            "prompt_context": _safe_prompt_context_metadata(compatibility),
             "fallback_reason": _safe_identifier(
                 fallback.get("local_failure_code"), maximum=96
             ),

--- a/scripts/codex_bridge_parity.py
+++ b/scripts/codex_bridge_parity.py
@@ -39,6 +39,7 @@ DEFAULT_TIMEOUT_SECONDS = 600
 DEFAULT_MIN_COMPLETED_PAIRS = 5
 DEFAULT_MAX_SCORE_REGRESSION = 5.0
 SCHEMA = "norman.codex-bridge-parity.v1"
+PROMPT_CONTEXT_SCHEMA = "norman.responses-prompt-context.v1"
 TOOL_ITEM_TYPES = frozenset(
     {
         "command_execution",
@@ -57,6 +58,19 @@ USAGE_KEYS = frozenset(
         "reasoning_output_tokens",
         "total_tokens",
     }
+)
+PROMPT_CONTEXT_GROUPS = (
+    "history",
+    "tool_contract",
+    "structured_output",
+    "current_input",
+)
+PROMPT_CONTEXT_GROUP_FIELDS = (
+    "message_count",
+    "chars",
+    "tool_output_chars",
+    "function_call_chars",
+    "text_chars",
 )
 
 
@@ -79,6 +93,7 @@ class RouteExecution:
     tool_events: int
     retry_events: int
     usage: dict[str, int]
+    prompt_context: dict[str, Any]
     short_stop: bool
 
 
@@ -154,10 +169,100 @@ def _usage_from_event(event: dict[str, Any]) -> dict[str, int]:
     return result
 
 
-def parse_event_metrics(events_path: Path) -> tuple[int, int, dict[str, int]]:
+def _prompt_context_from_source(source: object) -> dict[str, Any]:
+    if not isinstance(source, dict):
+        return {}
+    norman = source.get("norman")
+    if not isinstance(norman, dict):
+        return {}
+    compatibility = norman.get("responses_compatibility")
+    if not isinstance(compatibility, dict):
+        return {}
+    raw = compatibility.get("prompt_context")
+    if (
+        not isinstance(raw, dict)
+        or str(raw.get("schema") or "") != PROMPT_CONTEXT_SCHEMA
+    ):
+        return {}
+    raw_groups = raw.get("groups")
+    if not isinstance(raw_groups, dict):
+        return {}
+    groups: dict[str, dict[str, int]] = {}
+    for name in PROMPT_CONTEXT_GROUPS:
+        raw_group = raw_groups.get(name)
+        raw_group = raw_group if isinstance(raw_group, dict) else {}
+        groups[name] = {
+            field: _int(raw_group.get(field)) for field in PROMPT_CONTEXT_GROUP_FIELDS
+        }
+    return {
+        "schema": PROMPT_CONTEXT_SCHEMA,
+        "groups": groups,
+        "total_message_count": _int(raw.get("total_message_count")),
+        "total_content_chars": _int(raw.get("total_content_chars")),
+        "rendered_prompt_chars": _int(raw.get("rendered_prompt_chars")),
+    }
+
+
+def _prompt_context_from_event(event: dict[str, Any]) -> dict[str, Any]:
+    """Extract the facade's numeric prompt attribution from a Codex event."""
+
+    item = _event_item(event)
+    candidates: list[object] = [
+        event,
+        item,
+        event.get("response"),
+        item.get("response"),
+        event.get("data"),
+        item.get("data"),
+    ]
+    for candidate in candidates:
+        prompt_context = _prompt_context_from_source(candidate)
+        if prompt_context:
+            return prompt_context
+    return {}
+
+
+def _prompt_context_summary(
+    prompt_contexts: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    contexts = list(prompt_contexts)
+    if not contexts:
+        return {}
+    groups = {
+        name: {
+            field: sum(
+                _int((context.get("groups", {}).get(name, {}).get(field)))
+                for context in contexts
+            )
+            for field in PROMPT_CONTEXT_GROUP_FIELDS
+        }
+        for name in PROMPT_CONTEXT_GROUPS
+    }
+    rendered_chars = [
+        _int(context.get("rendered_prompt_chars")) for context in contexts
+    ]
+    return {
+        "schema": PROMPT_CONTEXT_SCHEMA,
+        "hop_count": len(contexts),
+        "groups": groups,
+        "total_message_count": sum(
+            _int(context.get("total_message_count")) for context in contexts
+        ),
+        "total_content_chars": sum(
+            _int(context.get("total_content_chars")) for context in contexts
+        ),
+        "rendered_prompt_chars_total": sum(rendered_chars),
+        "rendered_prompt_chars_max": max(rendered_chars),
+    }
+
+
+def parse_event_metrics(
+    events_path: Path,
+) -> tuple[int, int, dict[str, int], dict[str, Any]]:
     tool_ids: set[str] = set()
     retry_events = 0
     usage: dict[str, int] = {}
+    prompt_contexts: list[dict[str, Any]] = []
     for index, event in enumerate(_iter_jsonl(events_path)):
         item_type = _item_type(event)
         if item_type in TOOL_ITEM_TYPES:
@@ -167,7 +272,15 @@ def parse_event_metrics(events_path: Path) -> tuple[int, int, dict[str, int]]:
             retry_events += 1
         for key, value in _usage_from_event(event).items():
             usage[key] = max(usage.get(key, 0), value)
-    return len(tool_ids), retry_events, usage
+        prompt_context = _prompt_context_from_event(event)
+        if prompt_context:
+            prompt_contexts.append(prompt_context)
+    return (
+        len(tool_ids),
+        retry_events,
+        usage,
+        _prompt_context_summary(prompt_contexts),
+    )
 
 
 def resolve_native_codex_bin(value: str | None = None) -> Path:
@@ -308,7 +421,7 @@ def run_route_case(
         pass
     if status == "completed" and not answer:
         status = "empty_output"
-    tool_events, retry_events, usage = parse_event_metrics(events_path)
+    tool_events, retry_events, usage, prompt_context = parse_event_metrics(events_path)
     return RouteExecution(
         route=route.key,
         status=status,
@@ -320,6 +433,7 @@ def run_route_case(
         tool_events=tool_events,
         retry_events=retry_events,
         usage=usage,
+        prompt_context=prompt_context,
         short_stop=response_has_unfinished_promise(answer),
     )
 
@@ -371,6 +485,7 @@ def _execution_payload(
         "tool_events": execution.tool_events,
         "retry_events": execution.retry_events,
         "usage": execution.usage,
+        "prompt_context": execution.prompt_context,
         "short_stop": execution.short_stop,
         "score": _score_payload(score),
     }
@@ -408,6 +523,19 @@ def _duration_summary(case_rows: list[dict[str, Any]], route: str) -> dict[str, 
         "total_ms": sum(durations),
         "average_ms": round(sum(durations) / len(durations)) if durations else 0,
     }
+
+
+def _prompt_context_total(
+    case_rows: list[dict[str, Any]], route: str
+) -> dict[str, Any]:
+    contexts = [
+        execution.get("prompt_context", {})
+        for row in case_rows
+        if isinstance((execution := row[route]), dict)
+        and isinstance(execution.get("prompt_context"), dict)
+        and execution.get("prompt_context")
+    ]
+    return _prompt_context_summary(contexts)
 
 
 def build_summary(case_rows: list[dict[str, Any]]) -> dict[str, Any]:
@@ -487,6 +615,8 @@ def build_summary(case_rows: list[dict[str, Any]]) -> dict[str, Any]:
             key: _usage_total(case_rows, "transparent", key)
             for key in sorted(USAGE_KEYS)
         },
+        "native_prompt_context": _prompt_context_total(case_rows, "native"),
+        "transparent_prompt_context": _prompt_context_total(case_rows, "transparent"),
     }
 
 
@@ -540,6 +670,7 @@ def build_dry_run_rows(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
             "tool_events": 0,
             "retry_events": 0,
             "usage": {},
+            "prompt_context": {},
             "short_stop": False,
             "score": {},
         }
@@ -662,12 +793,31 @@ def render_markdown(report: dict[str, Any]) -> str:
             f"{summary['native_usage']['output_tokens']}, transparent "
             f"{summary['transparent_usage']['output_tokens']}"
         ),
-        "",
-        "## Cases",
-        "",
-        "| Case | Order | Native | Transparent | Score delta | Tools N/T |",
-        "| --- | --- | --- | --- | ---: | ---: |",
     ]
+    transparent_prompt_context = summary.get("transparent_prompt_context", {})
+    if transparent_prompt_context:
+        prompt_groups = transparent_prompt_context["groups"]
+        lines.append(
+            (
+                "- Transparent local prompt hops: "
+                f"{transparent_prompt_context['hop_count']}, "
+                f"{transparent_prompt_context['rendered_prompt_chars_total']} "
+                "rendered characters total "
+                f"({transparent_prompt_context['rendered_prompt_chars_max']} max); "
+                f"history {prompt_groups['history']['chars']}, "
+                f"tool contract {prompt_groups['tool_contract']['chars']}, "
+                f"current input {prompt_groups['current_input']['chars']}"
+            )
+        )
+    lines.extend(
+        (
+            "",
+            "## Cases",
+            "",
+            "| Case | Order | Native | Transparent | Score delta | Tools N/T |",
+            "| --- | --- | --- | --- | ---: | ---: |",
+        )
+    )
     for row in report["cases"]:
         native_score = _score_value(row["native"])
         transparent_score = _score_value(row["transparent"])

--- a/tests/test_codex_bridge_parity.py
+++ b/tests/test_codex_bridge_parity.py
@@ -38,6 +38,7 @@ def _execution(
         tool_events=tools,
         retry_events=0,
         usage={"output_tokens": 10},
+        prompt_context={},
         short_stop=module.response_has_unfinished_promise(answer),
     )
 
@@ -95,6 +96,36 @@ def test_event_parser_counts_unique_tool_calls_and_usage(tmp_path, monkeypatch) 
                     {
                         "type": "retrying",
                         "usage": {"output_tokens": 11, "input_tokens": 20},
+                        "response": {
+                            "id": "resp-bridge",
+                            "norman": {
+                                "responses_compatibility": {
+                                    "prompt_context": {
+                                        "schema": "norman.responses-prompt-context.v1",
+                                        "groups": {
+                                            "history": {
+                                                "message_count": 2,
+                                                "chars": 80,
+                                                "tool_output_chars": 60,
+                                                "function_call_chars": 10,
+                                                "text_chars": 10,
+                                            },
+                                            "tool_contract": {
+                                                "message_count": 1,
+                                                "chars": 120,
+                                                "tool_output_chars": 0,
+                                                "function_call_chars": 0,
+                                                "text_chars": 120,
+                                            },
+                                        },
+                                        "total_message_count": 3,
+                                        "total_content_chars": 200,
+                                        "rendered_prompt_chars": 220,
+                                        "private": "SECRET PROMPT",
+                                    }
+                                }
+                            },
+                        },
                     }
                 ),
             )
@@ -102,11 +133,52 @@ def test_event_parser_counts_unique_tool_calls_and_usage(tmp_path, monkeypatch) 
         encoding="utf-8",
     )
 
-    tool_events, retry_events, usage = module.parse_event_metrics(events)
+    tool_events, retry_events, usage, prompt_context = module.parse_event_metrics(
+        events
+    )
 
     assert tool_events == 1
     assert retry_events == 1
     assert usage == {"input_tokens": 20, "output_tokens": 11}
+    assert prompt_context == {
+        "schema": "norman.responses-prompt-context.v1",
+        "hop_count": 1,
+        "groups": {
+            "history": {
+                "message_count": 2,
+                "chars": 80,
+                "tool_output_chars": 60,
+                "function_call_chars": 10,
+                "text_chars": 10,
+            },
+            "tool_contract": {
+                "message_count": 1,
+                "chars": 120,
+                "tool_output_chars": 0,
+                "function_call_chars": 0,
+                "text_chars": 120,
+            },
+            "structured_output": {
+                "message_count": 0,
+                "chars": 0,
+                "tool_output_chars": 0,
+                "function_call_chars": 0,
+                "text_chars": 0,
+            },
+            "current_input": {
+                "message_count": 0,
+                "chars": 0,
+                "tool_output_chars": 0,
+                "function_call_chars": 0,
+                "text_chars": 0,
+            },
+        },
+        "total_message_count": 3,
+        "total_content_chars": 200,
+        "rendered_prompt_chars_total": 220,
+        "rendered_prompt_chars_max": 220,
+    }
+    assert "SECRET PROMPT" not in json.dumps(prompt_context)
 
 
 def test_report_redacts_prompt_and_answer_text(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_prompt_load_balancer.py
+++ b/tests/test_prompt_load_balancer.py
@@ -3960,6 +3960,17 @@ def test_openai_compat_responses_can_return_explicit_tool_call(monkeypatch):
     compat = response["norman"]["responses_compatibility"]
     assert compat["tools_declared"] == 1
     assert compat["tool_calls_returned"] == 1
+    prompt_context = compat["prompt_context"]
+    assert prompt_context["schema"] == "norman.responses-prompt-context.v1"
+    assert prompt_context["groups"]["history"]["message_count"] == 0
+    assert prompt_context["groups"]["tool_contract"]["message_count"] == 1
+    assert prompt_context["groups"]["current_input"]["message_count"] == 1
+    assert prompt_context["groups"]["current_input"]["chars"] == len("check the repo")
+    assert (
+        prompt_context["rendered_prompt_chars"] >= prompt_context["total_content_chars"]
+    )
+    assert "check the repo" not in json.dumps(prompt_context)
+    assert "Run a shell command." not in json.dumps(prompt_context)
     assert response["norman"]["route_receipt"]["schema"] == (
         "norman.norllama.route-receipt.v1"
     )
@@ -5548,6 +5559,14 @@ def test_openai_compat_responses_replays_typed_message_after_tool_output(monkeyp
         for message in tool_contracts
     ] == ["synthetic.status_lookup"]
     assert third_messages[-2]["type"] == "function_call_output"
+    prompt_context = final["norman"]["responses_compatibility"]["prompt_context"]
+    assert prompt_context["groups"]["history"]["message_count"] == 4
+    assert prompt_context["groups"]["tool_contract"]["message_count"] == 1
+    assert prompt_context["groups"]["current_input"]["message_count"] == 2
+    assert prompt_context["groups"]["history"]["tool_output_chars"] > 0
+    assert prompt_context["groups"]["current_input"]["tool_output_chars"] > 0
+    assert "synthetic health" not in json.dumps(prompt_context)
+    assert "status" not in json.dumps(prompt_context)
 
 
 def test_openai_compat_proxy_observability_records_success_without_prompt_leak(

--- a/tests/test_proxy_observability.py
+++ b/tests/test_proxy_observability.py
@@ -260,6 +260,30 @@ def test_bridge_receipt_is_sanitized_and_persisted(monkeypatch):
                 "tool_bridge_mode": "transparent",
                 "tool_transport": "local_text_adapter",
                 "state_retention": "ephemeral",
+                "prompt_context": {
+                    "schema": "norman.responses-prompt-context.v1",
+                    "groups": {
+                        "history": {
+                            "message_count": 2,
+                            "chars": 108,
+                            "tool_output_chars": 84,
+                            "function_call_chars": 10,
+                            "text_chars": 14,
+                            "private": "history content",
+                        },
+                        "tool_contract": {
+                            "message_count": 1,
+                            "chars": 248,
+                            "tool_output_chars": 0,
+                            "function_call_chars": 0,
+                            "text_chars": 248,
+                        },
+                    },
+                    "total_message_count": 3,
+                    "total_content_chars": 356,
+                    "rendered_prompt_chars": 382,
+                    "private": "prompt content",
+                },
             },
             "output_token_budget": {
                 "requested": 16384,
@@ -294,6 +318,42 @@ def test_bridge_receipt_is_sanitized_and_persisted(monkeypatch):
             "effective": 16384,
             "maximum": 32768,
         },
+        "prompt_context": {
+            "schema": "norman.responses-prompt-context.v1",
+            "groups": {
+                "history": {
+                    "message_count": 2,
+                    "chars": 108,
+                    "tool_output_chars": 84,
+                    "function_call_chars": 10,
+                    "text_chars": 14,
+                },
+                "tool_contract": {
+                    "message_count": 1,
+                    "chars": 248,
+                    "tool_output_chars": 0,
+                    "function_call_chars": 0,
+                    "text_chars": 248,
+                },
+                "structured_output": {
+                    "message_count": 0,
+                    "chars": 0,
+                    "tool_output_chars": 0,
+                    "function_call_chars": 0,
+                    "text_chars": 0,
+                },
+                "current_input": {
+                    "message_count": 0,
+                    "chars": 0,
+                    "tool_output_chars": 0,
+                    "function_call_chars": 0,
+                    "text_chars": 0,
+                },
+            },
+            "total_message_count": 3,
+            "total_content_chars": 356,
+            "rendered_prompt_chars": 382,
+        },
         "fallback_reason": "unknown",
     }
     summary = proxy_observability.proxy_observability_summary()
@@ -301,3 +361,5 @@ def test_bridge_receipt_is_sanitized_and_persisted(monkeypatch):
     assert summary["bridge_modes"] == {"transparent": 1}
     assert summary["bridge_fallback_count"] == 1
     assert "private reason with spaces" not in json.dumps(event, sort_keys=True)
+    assert "history content" not in json.dumps(event, sort_keys=True)
+    assert "prompt content" not in json.dumps(event, sort_keys=True)


### PR DESCRIPTION
## What changed

Adds content-free per-hop prompt attribution to the Responses facade and sanitized proxy receipts. The parity evaluator now records aggregate history, tool-contract, structured-output, and current-input character counts when the upstream stream exposes them.

## Why

The first post-compaction live parity run improved completion quality and reduced transparent latency, but cumulative local input tokens remained high. This change makes the actual repeated component observable without retaining prompts, tool arguments, tool outputs, or model responses.

## Validation

- `141 passed` across the facade, proxy-observability, and parity suites
- `ruff check` and Python compile checks passed

No behavioral prompt truncation is included in this diagnostics-only change.