### PR TITLE
Normalize streamed Terra tool envelopes

### DIFF
--- a/app/services/prompt_provider_facade.py
+++ b/app/services/prompt_provider_facade.py
@@ -1207,11 +1207,13 @@ def _tool_chain_context(
 def _trailing_json_tool_call_envelope(
     text: str,
 ) -> tuple[str, list[dict[str, Any]]]:
-    """Split an optional prose preamble from a final JSON tool envelope.
+    """Split a JSON tool envelope from adjacent assistant prose.
 
     Some local models announce an action before emitting the tool JSON. The
-    envelope is only meaningful when it is a complete, standalone final object
-    so ordinary JSON answers remain assistant text.
+    envelope is meaningful when it is a complete, standalone final object or
+    the first meaningful object in the response. The latter shape occurs when
+    a provider emits the tool call and a short status sentence in one turn.
+    Ordinary JSON answers remain assistant text.
     """
 
     if not text:
@@ -1245,6 +1247,9 @@ def _trailing_json_tool_call_envelope(
             preamble = text[:start]
             return (preamble if preamble.strip() else ""), calls
         start = text.rfind("{", 0, start)
+    leading_envelope = _leading_json_tool_call_envelope(text)
+    if leading_envelope is not None:
+        return leading_envelope
     return text, []
 
 
@@ -1258,6 +1263,26 @@ def _trailing_fenced_json_tool_call_envelope(text: str) -> tuple[str, str] | Non
     if match is None:
         return None
     return match.group(1), match.group(2)
+
+
+def _leading_json_tool_call_envelope(
+    text: str,
+) -> tuple[str, list[dict[str, Any]]] | None:
+    """Return prose following a complete initial JSON tool-call envelope."""
+
+    leading_characters = len(text) - len(text.lstrip())
+    candidate = text[leading_characters:]
+    if not candidate.startswith("{"):
+        return None
+    try:
+        payload, end = json.JSONDecoder().raw_decode(candidate)
+    except (TypeError, ValueError):
+        return None
+    calls = _tool_calls_from_envelope_payload(payload)
+    if not calls:
+        return None
+    trailing_text = candidate[end:]
+    return (trailing_text if trailing_text.strip() else ""), calls
 
 
 def _tool_calls_from_envelope_payload(payload: Any) -> list[dict[str, Any]]:
@@ -2093,18 +2118,21 @@ def _response_tool_calls(
         raw_calls = [dict(call) for call in normalized_output.raw_tool_calls]
     else:
         preamble, raw_calls = _trailing_json_tool_call_envelope(text)
-    return (
-        preamble,
-        _extract_tool_calls(
-            text,
-            tools=tools,
-            # Some Codex TUI request forms keep their executable tool registry
-            # client-side and omit a top-level Responses tools list. The TUI still
-            # validates the returned call before it can execute anything.
-            allow_implicit_tools="tools" not in provider_payload,
-            raw_calls=raw_calls,
-        ),
+    tool_calls = _extract_tool_calls(
+        text,
+        tools=tools,
+        # Some Codex TUI request forms keep their executable tool registry
+        # client-side and omit a top-level Responses tools list. The TUI still
+        # validates the returned call before it can execute anything.
+        allow_implicit_tools="tools" not in provider_payload,
+        raw_calls=raw_calls,
     )
+    # The stream normalizer intentionally does not know the caller's tool
+    # registry. If a tool-shaped JSON object names an undeclared tool, preserve
+    # it as regular assistant text instead of silently dropping the envelope.
+    if raw_calls and not tool_calls:
+        return text, []
+    return preamble, tool_calls
 
 
 def _repeats_successful_tool_call(

--- a/tests/test_prompt_load_balancer.py
+++ b/tests/test_prompt_load_balancer.py
@@ -1294,6 +1294,127 @@ def test_openai_compat_responses_stream_keeps_tool_envelopes_out_of_text(
     assert response.closed is True
 
 
+def test_openai_compat_responses_stream_splits_tool_envelope_from_status_text(
+    test_app, monkeypatch
+):
+    response = _MockNativeStreamResponse(
+        [
+            json.dumps({"model": "qwen3-coder:30b", "response": "{"}),
+            json.dumps(
+                {
+                    "model": "qwen3-coder:30b",
+                    "response": (
+                        '"tool_call":{"name":"ticket_search",'
+                        '"arguments":{"query":"P0"}}}'
+                    ),
+                }
+            ),
+            json.dumps(
+                {
+                    "model": "qwen3-coder:30b",
+                    "response": "\nWaiting for the search result before proceeding.",
+                }
+            ),
+            json.dumps(
+                {
+                    "model": "qwen3-coder:30b",
+                    "done": True,
+                    "prompt_eval_count": 4,
+                    "eval_count": 2,
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        norllama_gateway,
+        "invoke_text_chat_stream",
+        lambda **kwargs: norllama_gateway.NorllamaTextStream(
+            response,
+            model=kwargs["model"],
+        ),
+    )
+
+    result = test_app.post(
+        "/v1/responses",
+        headers=_proxy_headers(monkeypatch),
+        json={
+            "model": "norman-code",
+            "input": "Find the highest priority ticket.",
+            "stream": True,
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "ticket_search",
+                    "description": "Search Jira tickets.",
+                    "parameters": {"type": "object"},
+                }
+            ],
+        },
+    )
+
+    assert result.status_code == 200
+    events = _response_sse_events(result.text)
+    payloads = [
+        json.loads(data) for event, data in events if event and data != "[DONE]"
+    ]
+    output_text_deltas = [
+        payload["delta"]
+        for payload in payloads
+        if payload["type"] == "response.output_text.delta"
+    ]
+    output_items = [
+        payload["item"]
+        for payload in payloads
+        if payload["type"] == "response.output_item.added"
+    ]
+    completed = next(
+        payload["response"]
+        for payload in payloads
+        if payload["type"] == "response.completed"
+    )
+
+    assert output_text_deltas == ["\nWaiting for the search result before proceeding."]
+    assert all('"tool_call"' not in delta for delta in output_text_deltas)
+    assert [item["type"] for item in output_items] == ["message", "function_call"]
+    assert output_items[1]["name"] == "ticket_search"
+    assert completed["output_text"] == output_text_deltas[0]
+    assert [item["type"] for item in completed["output"]] == [
+        "message",
+        "function_call",
+    ]
+    assert response.closed is True
+
+
+def test_leading_undeclared_tool_envelope_remains_text_after_normalization():
+    import app.services.prompt_provider_facade as facade
+
+    text = (
+        '{"tool_call":{"name":"undeclared_search","arguments":{"query":"P0"}}}'
+        "\nWaiting for the result."
+    )
+    normalizer = facade.ResponsesStreamNormalizer()
+    assert normalizer.feed(text) == []
+    normalized = normalizer.finalize()
+
+    response_text, tool_calls = facade._response_tool_calls(
+        normalized.raw_text,
+        provider_payload={
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "ticket_search",
+                    "parameters": {"type": "object"},
+                }
+            ]
+        },
+        normalized_output=normalized,
+    )
+
+    assert normalized.raw_tool_calls[0]["name"] == "undeclared_search"
+    assert response_text == text
+    assert tool_calls == []
+
+
 def test_openai_compat_responses_stream_keeps_native_function_call_out_of_text(
     test_app, monkeypatch
 ):


### PR DESCRIPTION
Fixes streamed Responses tool calls when Terra emits a valid leading tool envelope followed by short status prose in the same response. The facade now emits the declared tool call natively and preserves only the trailing prose as text; undeclared tool-shaped JSON remains ordinary text.\n\nValidation: 130 facade tests, 23 tool-chain-canary tests, Ruff, formatting, and diff checks.