### PR TITLE
Accept Terra status text after tool calls

### DIFF
--- a/scripts/tui_tool_chain_canary.py
+++ b/scripts/tui_tool_chain_canary.py
@@ -913,9 +913,13 @@ def _require_exact_function_call_item(
     calls = _function_calls(response)
     if (
         not isinstance(output, list)
-        or len(output) != 1
         or len(calls) != 1
         or _clean(calls[0].get("name")) != name
+        or any(
+            not isinstance(item, Mapping)
+            or _clean(item.get("type")) not in {"function_call", "message"}
+            for item in output
+        )
     ):
         raise CanaryError("unexpected_function_call")
     call_id = _clean(calls[0].get("call_id"))

--- a/tests/test_tui_tool_chain_canary.py
+++ b/tests/test_tui_tool_chain_canary.py
@@ -195,6 +195,40 @@ def test_run_canary_exercises_the_three_turn_synthetic_tool_chain():
     assert "undeclared_tool" not in serialized
 
 
+def test_run_canary_allows_a_status_message_after_an_expected_function_call():
+    requests = []
+    first = _tool_response("resp-search", "tool_search", "call-search")
+    first["output"].append({"type": "message", "content": "Searching."})
+    responses = iter(
+        [
+            first,
+            _tool_response(
+                "resp-synthetic",
+                "mcp__norman_canary.status_lookup",
+                "call-synthetic",
+            ),
+            {
+                "id": "resp-final",
+                "status": "completed",
+                "output": [{"type": "message"}],
+                "output_text": "Synthetic status is healthy.",
+            },
+        ]
+    )
+
+    receipt = canary.run_canary(
+        endpoint="http://127.0.0.1:8000/v1/responses",
+        token="private-token",
+        pressure_guard=lambda: {"admission": {"action": "accept_new_work"}},
+        request_fn=lambda *args: requests.append(args) or (200, next(responses)),
+    )
+
+    assert receipt["state"] == "passed"
+    assert len(requests) == 3
+    assert receipt["turns"][0]["output_count"] == 2
+    assert receipt["turns"][0]["tool_names"] == ["tool_search"]
+
+
 def test_run_canary_streaming_exercises_native_sse_tool_calls():
     requests = []
     responses = iter(


### PR DESCRIPTION
Terra can return one expected native function call plus a short status message in the same Responses output. The synthetic tool-chain canary now accepts that valid shape while still rejecting extra function calls, undeclared tools, and unsupported output items.\n\nValidation: 154 facade/canary tests, Ruff, formatting, and diff checks.