### PR TITLE
Preserve native Terra Responses tools

### DIFF
--- a/app/services/console_runtime/adapters/bedrock.py
+++ b/app/services/console_runtime/adapters/bedrock.py
@@ -615,6 +615,7 @@ class BedrockModelAdapter:
             system=request.system,
             max_tokens=request.budget.max_output_tokens,
             temperature=_temperature(request, route_policy),
+            responses_options=request.responses_options,
             region=bedrock_region(route_policy),
             timeout_seconds=timeout_seconds,
         )

--- a/app/services/console_runtime/types.py
+++ b/app/services/console_runtime/types.py
@@ -569,6 +569,7 @@ class ModelRequest:
     temperature: float | None = None
     budget: ModelBudget = field(default_factory=ModelBudget)
     metadata: Dict[str, Any] = field(default_factory=dict)
+    responses_options: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         self.messages = [dict(message) for message in self.messages or []]
@@ -576,6 +577,7 @@ class ModelRequest:
         self.route_key = str(self.route_key or "").strip()
         self.system = str(self.system or "")
         self.metadata = _clean_dict(self.metadata)
+        self.responses_options = _clean_dict(self.responses_options)
 
     def as_dict(self) -> Dict[str, Any]:
         return asdict(self)

--- a/app/services/norllama/bedrock.py
+++ b/app/services/norllama/bedrock.py
@@ -845,6 +845,43 @@ def bedrock_mantle_responses_input(
             }
         )
     for message in messages or []:
+        item_type = _clean(message.get("type")).lower()
+        if item_type == "function_call":
+            call_id = _clean(message.get("call_id"))
+            name = _clean(message.get("name"))
+            if not call_id or not name:
+                raise ValueError(
+                    "Bedrock Mantle function_call input requires call_id and name"
+                )
+            arguments = message.get("arguments", "")
+            if isinstance(arguments, (Mapping, list)):
+                arguments = json.dumps(arguments, sort_keys=True, separators=(",", ":"))
+            converted.append(
+                {
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": str(arguments or ""),
+                }
+            )
+            continue
+        if item_type == "function_call_output":
+            call_id = _clean(message.get("call_id"))
+            if not call_id:
+                raise ValueError(
+                    "Bedrock Mantle function_call_output input requires call_id"
+                )
+            output = message.get("output", "")
+            if isinstance(output, (Mapping, list)):
+                output = json.dumps(output, sort_keys=True, separators=(",", ":"))
+            converted.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": str(output or ""),
+                }
+            )
+            continue
         role = _clean(message.get("role")).lower()
         text = _content_text(message.get("content"))
         if not text:
@@ -873,6 +910,33 @@ def bedrock_mantle_responses_input(
     return converted
 
 
+def _mantle_responses_options(
+    responses_options: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Allow the native Responses fields supported by Bedrock Mantle."""
+
+    options = responses_options or {}
+    payload: dict[str, Any] = {}
+    tools = options.get("tools")
+    if isinstance(tools, list):
+        payload["tools"] = [dict(tool) for tool in tools if isinstance(tool, Mapping)]
+    tool_choice = options.get("tool_choice")
+    if isinstance(tool_choice, (str, Mapping)):
+        payload["tool_choice"] = (
+            dict(tool_choice) if isinstance(tool_choice, Mapping) else tool_choice
+        )
+    if isinstance(options.get("parallel_tool_calls"), bool):
+        payload["parallel_tool_calls"] = options["parallel_tool_calls"]
+    for field in ("reasoning", "text"):
+        value = options.get(field)
+        if isinstance(value, Mapping):
+            payload[field] = dict(value)
+    include = options.get("include")
+    if isinstance(include, list):
+        payload["include"] = [str(value) for value in include if str(value).strip()]
+    return payload
+
+
 def build_bedrock_mantle_responses_request(
     *,
     model: str,
@@ -880,11 +944,12 @@ def build_bedrock_mantle_responses_request(
     system: str = "",
     max_tokens: int = 1024,
     temperature: float | None = None,
+    responses_options: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     clean_model = _clean(model)
     if not clean_model:
         raise ValueError("Bedrock Mantle route is missing a model")
-    return {
+    payload = {
         "model": clean_model,
         "input": bedrock_mantle_responses_input(messages, system=system),
         # Mantle currently rejects lower values and does not accept temperature.
@@ -893,6 +958,8 @@ def build_bedrock_mantle_responses_request(
             _positive_int(max_tokens, 1024),
         ),
     }
+    payload.update(_mantle_responses_options(responses_options))
+    return payload
 
 
 def invoke_bedrock_mantle_responses(
@@ -903,6 +970,7 @@ def invoke_bedrock_mantle_responses(
     system: str = "",
     max_tokens: int = 1024,
     temperature: float | None = None,
+    responses_options: Mapping[str, Any] | None = None,
     region: str = "",
     timeout_seconds: float = 0,
 ) -> dict[str, Any]:
@@ -912,6 +980,7 @@ def invoke_bedrock_mantle_responses(
         system=system,
         max_tokens=max_tokens,
         temperature=temperature,
+        responses_options=responses_options,
     )
     request = urllib_request.Request(
         bedrock_mantle_responses_url(region),

--- a/app/services/prompt_provider_facade.py
+++ b/app/services/prompt_provider_facade.py
@@ -935,7 +935,11 @@ def _compact_replayed_history(
     return [compacted[index] for index in sorted(compacted)]
 
 
-def _previous_response_history(previous_response_id: str) -> ResponseHistory:
+def _previous_response_history(
+    previous_response_id: str,
+    *,
+    compact: bool = True,
+) -> ResponseHistory:
     previous_response_id = _clean(previous_response_id)
     if not previous_response_id:
         return ResponseHistory([], {}, {}, set(), False)
@@ -977,7 +981,7 @@ def _previous_response_history(previous_response_id: str) -> ResponseHistory:
         if call_id not in existing_call_ids:
             messages.append(_function_call_context_message(function_call))
     return ResponseHistory(
-        _compact_replayed_history(messages),
+        _compact_replayed_history(messages) if compact else messages,
         function_calls,
         function_call_items,
         tool_outputs,
@@ -1088,13 +1092,18 @@ def _gateway_attribution(
 
 
 def _choice_text(payload: Mapping[str, Any]) -> str:
-    choices = payload.get("choices") if isinstance(payload.get("choices"), list) else []
-    if not choices:
-        return ""
-    first = choices[0] if isinstance(choices[0], dict) else {}
-    message = first.get("message") if isinstance(first.get("message"), dict) else {}
+    message = _choice_message(payload)
     content = message.get("content")
     return content if isinstance(content, str) else _clean(content)
+
+
+def _choice_message(payload: Mapping[str, Any]) -> dict[str, Any]:
+    choices = payload.get("choices") if isinstance(payload.get("choices"), list) else []
+    if not choices:
+        return {}
+    first = choices[0] if isinstance(choices[0], dict) else {}
+    message = first.get("message")
+    return dict(message) if isinstance(message, Mapping) else {}
 
 
 def _norman_options(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -1669,6 +1678,15 @@ def _requested_model(payload: Mapping[str, Any]) -> str:
     return _clean(payload.get("model"))
 
 
+def _uses_native_mantle_responses(payload: Mapping[str, Any]) -> bool:
+    """Keep the Terra route on its native Bedrock Responses protocol."""
+
+    return _requested_model(payload).lower() in {
+        "gpt-5.6-terra",
+        "openai.gpt-5.6-terra",
+    }
+
+
 def _responses_bridge_mode(payload: Mapping[str, Any]) -> str:
     """Select the explicit tool-bridge behavior for a Responses request."""
 
@@ -1804,6 +1822,52 @@ def _responses_include_advisory(payload: Mapping[str, Any]) -> list[str]:
             param="include",
         )
     return list(include)
+
+
+def _native_mantle_responses_options(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Keep native Responses options structured for the Terra Mantle route."""
+
+    options: dict[str, Any] = {}
+    tools = _tools(payload)
+    if tools:
+        options["tools"] = tools
+    tool_choice = payload.get("tool_choice")
+    if isinstance(tool_choice, (str, Mapping)):
+        options["tool_choice"] = (
+            dict(tool_choice) if isinstance(tool_choice, Mapping) else tool_choice
+        )
+    if isinstance(payload.get("parallel_tool_calls"), bool):
+        options["parallel_tool_calls"] = payload["parallel_tool_calls"]
+    reasoning = _responses_reasoning_advisory(payload)
+    if reasoning:
+        options["reasoning"] = reasoning
+    text = _mapping(payload.get("text"))
+    if text:
+        options["text"] = text
+    include = _responses_include_advisory(payload)
+    if include:
+        options["include"] = include
+    return options
+
+
+def _native_mantle_function_call_items(raw: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Extract native Responses function calls without parsing assistant text."""
+
+    output = raw.get("output")
+    if not isinstance(output, list):
+        return []
+    calls: list[dict[str, Any]] = []
+    for item in output:
+        if not isinstance(item, Mapping):
+            continue
+        if _clean(item.get("type")) != "function_call":
+            continue
+        function_call = _function_call_item(item)
+        if function_call:
+            calls.append(function_call)
+    return calls
 
 
 def _responses_client_metadata_ignored(payload: Mapping[str, Any]) -> bool:
@@ -3202,6 +3266,7 @@ def _explicit_cloud_selection_request(
     invocation: AuthorizedChatInvocation,
     messages: list[dict[str, Any]],
     provider_payload: Mapping[str, Any],
+    native_responses_transport: bool = False,
 ) -> ModelRequest:
     try:
         timeout_seconds = int(
@@ -3232,8 +3297,14 @@ def _explicit_cloud_selection_request(
                 _explicit_cloud_selection_marker(plan=plan)
             ),
             "codex_reasoning_advisory": invocation.reasoning_advisory,
+            "norman_native_mantle_responses_transport": native_responses_transport,
             **invocation.trusted_context,
         },
+        responses_options=(
+            _native_mantle_responses_options(provider_payload)
+            if native_responses_transport
+            else {}
+        ),
     )
 
 
@@ -3270,6 +3341,7 @@ def _execute_explicit_cloud_selection(
     route_envelope: Mapping[str, Any],
     messages: list[dict[str, Any]],
     invocation: AuthorizedChatInvocation,
+    native_responses_transport: bool = False,
 ) -> dict[str, Any]:
     """Run a user-selected cloud model without probing local capacity."""
 
@@ -3280,6 +3352,7 @@ def _execute_explicit_cloud_selection(
                 invocation=invocation,
                 messages=messages,
                 provider_payload=provider_payload,
+                native_responses_transport=native_responses_transport,
             )
         )
     except Exception as exc:
@@ -3302,7 +3375,12 @@ def _execute_explicit_cloud_selection(
             invocation=invocation,
             code="explicit_cloud_selection_not_authorized",
         )
-    if not result.text:
+    native_function_calls = (
+        _native_mantle_function_call_items(result.raw)
+        if native_responses_transport
+        else []
+    )
+    if not result.text and not native_function_calls:
         raise _explicit_cloud_selection_error(
             plan=plan,
             invocation=invocation,
@@ -3322,8 +3400,12 @@ def _execute_explicit_cloud_selection(
         "choices": [
             {
                 "index": 0,
-                "message": {"role": "assistant", "content": result.text},
-                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": result.text,
+                    "_norman_native_function_call_items": native_function_calls,
+                },
+                "finish_reason": "tool_calls" if native_function_calls else "stop",
             }
         ],
         "usage": usage,
@@ -3554,6 +3636,7 @@ def _execute_authorized_chat(
     route_envelope: Mapping[str, Any],
     messages: list[dict[str, Any]],
     request_id: str,
+    native_responses_transport: bool = False,
 ) -> dict[str, Any]:
     explicit_cloud_plan = _explicit_cloud_selection_plan(
         provider_payload=provider_payload,
@@ -3572,6 +3655,7 @@ def _execute_authorized_chat(
             route_envelope=route_envelope,
             messages=messages,
             invocation=invocation,
+            native_responses_transport=native_responses_transport,
         )
 
     invocation = _prepare_authorized_chat_invocation(
@@ -3667,6 +3751,7 @@ def _resolve_tool_continuation_response(
         route_envelope=prepared.route_envelope,
         messages=_tool_continuation_repair_messages(prepared.messages),
         request_id=f"{request_id}-tool-continuation-repair",
+        native_responses_transport=prepared.native_responses_transport,
     )
     if _repeats_successful_tool_call(
         _choice_text(repaired),
@@ -3752,6 +3837,7 @@ class PreparedResponsesExecution:
     client_metadata_ignored: bool
     store_requested: bool
     bridge_mode: str
+    native_responses_transport: bool
 
 
 def _prepare_responses_execution(
@@ -3766,10 +3852,12 @@ def _prepare_responses_execution(
     client_metadata_ignored = _responses_client_metadata_ignored(provider_payload)
     store_requested = _responses_store_requested(provider_payload)
     bridge_mode = _responses_bridge_mode(provider_payload)
+    native_responses_transport = _uses_native_mantle_responses(provider_payload)
     provider_payload.pop("client_metadata", None)
     provider_payload.pop("store", None)
     history = _previous_response_history(
-        _clean(provider_payload.get("previous_response_id"))
+        _clean(provider_payload.get("previous_response_id")),
+        compact=not native_responses_transport,
     )
     function_call_items = _validate_response_tool_continuation(
         provider_payload,
@@ -3787,21 +3875,29 @@ def _prepare_responses_execution(
         function_call_items=function_call_items,
         known_tool_outputs=tool_outputs,
     )
-    history_messages, tool_contract_messages = _messages_with_current_tool_contract(
-        history.messages,
+    input_messages = response_input_to_messages(
         provider_payload,
-        bridge_mode=bridge_mode,
+        known_tool_outputs=history.tool_outputs,
+        known_function_call_items=history.function_call_items,
     )
-    messages = [
-        *history_messages,
-        *tool_contract_messages,
-        *_structured_output_message(provider_payload),
-        *response_input_to_messages(
+    if native_responses_transport:
+        # Mantle's Responses endpoint accepts the structured tool registry,
+        # output format, reasoning configuration, and tool-call history
+        # directly. Do not flatten them into the local text-adapter prompt.
+        _structured_output_message(provider_payload)
+        messages = [*history.messages, *input_messages]
+    else:
+        history_messages, tool_contract_messages = _messages_with_current_tool_contract(
+            history.messages,
             provider_payload,
-            known_tool_outputs=history.tool_outputs,
-            known_function_call_items=history.function_call_items,
-        ),
-    ]
+            bridge_mode=bridge_mode,
+        )
+        messages = [
+            *history_messages,
+            *tool_contract_messages,
+            *_structured_output_message(provider_payload),
+            *input_messages,
+        ]
     route_payload = {**provider_payload, "input": messages}
     route_envelope = provider_adapter_decision(
         provider="openai",
@@ -3823,6 +3919,7 @@ def _prepare_responses_execution(
         client_metadata_ignored=client_metadata_ignored,
         store_requested=store_requested,
         bridge_mode=bridge_mode,
+        native_responses_transport=native_responses_transport,
     )
 
 
@@ -3842,12 +3939,23 @@ def _responses_response_from_chat(
     chat_response = dict(chat_response)
     text = _choice_text(chat_response)
     tools = _tools(provider_payload)
-    preamble, tool_calls = _response_tool_calls(
-        text,
-        provider_payload=provider_payload,
-        normalized_output=normalized_output,
+    native_function_calls = _messages(
+        _choice_message(chat_response).get("_norman_native_function_call_items")
     )
-    visible_text = preamble if tool_calls else text
+    if prepared.native_responses_transport:
+        tool_calls = [
+            function_call
+            for item in native_function_calls
+            if (function_call := _function_call_item(item))
+        ]
+        visible_text = text
+    else:
+        preamble, tool_calls = _response_tool_calls(
+            text,
+            provider_payload=provider_payload,
+            normalized_output=normalized_output,
+        )
+        visible_text = preamble if tool_calls else text
     output_items = _response_output_items(
         text=visible_text,
         tool_calls=tool_calls,
@@ -3894,12 +4002,19 @@ def _responses_response_from_chat(
                 "tool_calls_returned": len(tool_calls),
                 "tool_chain": tool_chain,
                 "tool_call_mode": (
-                    "adapter_json_envelope"
+                    "native_responses"
+                    if prepared.native_responses_transport
+                    and (_tool_names(tools) or tool_calls)
+                    else "adapter_json_envelope"
                     if _tool_names(tools) or tool_calls
                     else "none"
                 ),
                 "tool_bridge_mode": prepared.bridge_mode,
-                "tool_transport": "local_text_adapter",
+                "tool_transport": (
+                    "bedrock_mantle_responses"
+                    if prepared.native_responses_transport
+                    else "local_text_adapter"
+                ),
                 "structured_output_requested": bool(
                     _mapping(provider_payload.get("text")).get("format")
                 ),
@@ -4173,6 +4288,9 @@ class FacadeResponsesStream:
                     route_envelope=self.prepared.route_envelope,
                     messages=self.prepared.messages,
                     invocation=self.invocation,
+                    native_responses_transport=(
+                        self.prepared.native_responses_transport
+                    ),
                 ),
                 progress_event=lambda state, elapsed_ms: {
                     "type": "explicit_cloud_selection",
@@ -4325,6 +4443,7 @@ def execute_openai_responses_facade(
         route_envelope=prepared.route_envelope,
         messages=prepared.messages,
         request_id=facade_request_id,
+        native_responses_transport=prepared.native_responses_transport,
     )
     (
         chat_response,

--- a/tests/test_console_runtime_bedrock_adapter.py
+++ b/tests/test_console_runtime_bedrock_adapter.py
@@ -668,6 +668,59 @@ def test_bedrock_mantle_request_uses_supported_parameters():
     assert "temperature" not in payload
 
 
+def test_bedrock_mantle_request_preserves_native_responses_options_and_tools():
+    payload = bedrock_module.build_bedrock_mantle_responses_request(
+        model="openai.gpt-5.6-terra",
+        messages=[
+            {
+                "type": "function_call",
+                "call_id": "call-repository-status",
+                "name": "repository_status",
+                "arguments": {"path": "."},
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call-repository-status",
+                "output": {"branch": "main"},
+            },
+        ],
+        responses_options={
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "repository_status",
+                    "parameters": {"type": "object"},
+                }
+            ],
+            "tool_choice": "required",
+            "parallel_tool_calls": False,
+            "reasoning": {"effort": "high"},
+            "text": {"format": {"type": "json_object"}},
+            "include": ["reasoning.encrypted_content"],
+        },
+    )
+
+    assert payload["input"] == [
+        {
+            "type": "function_call",
+            "call_id": "call-repository-status",
+            "name": "repository_status",
+            "arguments": '{"path":"."}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call-repository-status",
+            "output": '{"branch":"main"}',
+        },
+    ]
+    assert payload["tools"][0]["name"] == "repository_status"
+    assert payload["tool_choice"] == "required"
+    assert payload["parallel_tool_calls"] is False
+    assert payload["reasoning"] == {"effort": "high"}
+    assert payload["text"] == {"format": {"type": "json_object"}}
+    assert payload["include"] == ["reasoning.encrypted_content"]
+
+
 def test_bedrock_adapter_sanitizes_mantle_provider_failure(monkeypatch):
     monkeypatch.setenv("NORMAN_KEYS_URL", "http://keys.norman.test")
     monkeypatch.delenv("NORMAN_SECRET_CMD", raising=False)

--- a/tests/test_prompt_load_balancer.py
+++ b/tests/test_prompt_load_balancer.py
@@ -664,6 +664,7 @@ def _mock_bedrock_result(
     *,
     model: str = "openai.gpt-5.6-terra",
     metadata: dict | None = None,
+    raw: dict | None = None,
 ) -> ModelResult:
     return ModelResult(
         provider="bedrock",
@@ -671,6 +672,7 @@ def _mock_bedrock_result(
         text=text,
         usage=ModelUsage(input_tokens=7, output_tokens=3, total_tokens=10),
         metadata=metadata or {},
+        raw=raw or {},
     )
 
 
@@ -678,6 +680,7 @@ def _install_bedrock_stub(
     monkeypatch,
     *,
     result: ModelResult | None = None,
+    results: list[ModelResult] | None = None,
     error: Exception | None = None,
     delay_seconds: float = 0.0,
 ):
@@ -708,6 +711,7 @@ def _install_bedrock_stub(
         raising=False,
     )
     calls = []
+    pending_results = list(results or [])
 
     class StubBedrockModelAdapter:
         def invoke(self, request):
@@ -716,6 +720,8 @@ def _install_bedrock_stub(
                 time.sleep(delay_seconds)
             if error is not None:
                 raise error
+            if pending_results:
+                return pending_results.pop(0)
             return result or _mock_bedrock_result()
 
     monkeypatch.setattr(
@@ -989,6 +995,127 @@ def test_openai_compat_responses_routes_explicit_cloud_model_for_tui(
     assert len(bedrock_calls) == 1
 
 
+def test_openai_compat_responses_preserves_native_terra_tools_and_continuation(
+    test_app, monkeypatch
+):
+    from app.services.prompt_provider_facade import norllama_gateway
+
+    headers = _proxy_headers(monkeypatch)
+    local_calls = []
+    monkeypatch.setattr(
+        norllama_gateway,
+        "invoke_text_chat",
+        lambda **kwargs: local_calls.append(kwargs) or _mock_local_chat([], ""),
+    )
+    tool = {
+        "type": "function",
+        "name": "repository_status",
+        "description": "Read the repository status.",
+        "parameters": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    }
+    bedrock_calls = _install_bedrock_stub(
+        monkeypatch,
+        results=[
+            _mock_bedrock_result(
+                "",
+                raw={
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "id": "fc-repository-status",
+                            "call_id": "call-repository-status",
+                            "name": "repository_status",
+                            "arguments": '{"path":"."}',
+                        }
+                    ]
+                },
+            ),
+            _mock_bedrock_result("Repository is clean."),
+        ],
+    )
+
+    first = test_app.post(
+        "/v1/responses",
+        headers=headers,
+        json={
+            "model": "openai.gpt-5.6-terra",
+            "input": "Check the repository.",
+            "tools": [tool],
+            "tool_choice": "required",
+            "parallel_tool_calls": False,
+            "reasoning": {"effort": "high"},
+        },
+    )
+
+    assert first.status_code == 200
+    first_payload = first.json()
+    assert first_payload["output"][0] == {
+        "type": "function_call",
+        "id": "fc-repository-status",
+        "call_id": "call-repository-status",
+        "name": "repository_status",
+        "arguments": '{"path":"."}',
+    }
+    assert (
+        first_payload["norman"]["responses_compatibility"]["tool_transport"]
+        == "bedrock_mantle_responses"
+    )
+    first_request = bedrock_calls[0]
+    assert first_request.responses_options == {
+        "tools": [tool],
+        "tool_choice": "required",
+        "parallel_tool_calls": False,
+        "reasoning": {"effort": "high"},
+    }
+    assert not any(
+        "Tool contract" in str(message.get("content", ""))
+        for message in first_request.messages
+    )
+
+    second = test_app.post(
+        "/v1/responses",
+        headers=headers,
+        json={
+            "model": "openai.gpt-5.6-terra",
+            "previous_response_id": first_payload["id"],
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call-repository-status",
+                    "output": '{"branch":"main","dirty":false}',
+                }
+            ],
+            "tools": [tool],
+            "reasoning": {"effort": "high"},
+        },
+    )
+
+    assert second.status_code == 200
+    second_payload = second.json()
+    assert second_payload["output_text"] == "Repository is clean."
+    second_request = bedrock_calls[1]
+    function_call = next(
+        message
+        for message in second_request.messages
+        if message.get("type") == "function_call"
+    )
+    assert function_call["call_id"] == "call-repository-status"
+    assert function_call["name"] == "repository_status"
+    assert function_call["arguments"] == '{"path":"."}'
+    function_call_output = next(
+        message
+        for message in second_request.messages
+        if message.get("type") == "function_call_output"
+    )
+    assert function_call_output["call_id"] == "call-repository-status"
+    assert function_call_output["output"] == '{"branch":"main","dirty":false}'
+    assert local_calls == []
+
+
 def test_openai_compat_responses_streams_explicit_cloud_model_for_tui(
     test_app, monkeypatch
 ):
@@ -1013,6 +1140,91 @@ def test_openai_compat_responses_streams_explicit_cloud_model_for_tui(
     assert "cloud ok" in response.text
     assert local_calls == []
     assert len(bedrock_calls) == 1
+
+
+def test_openai_compat_responses_streams_native_terra_function_call(
+    test_app, monkeypatch
+):
+    from app.services.prompt_provider_facade import norllama_gateway
+
+    headers = _proxy_headers(monkeypatch)
+    local_calls = []
+    monkeypatch.setattr(
+        norllama_gateway,
+        "invoke_text_chat_stream",
+        lambda **kwargs: local_calls.append(kwargs),
+    )
+    tool = {
+        "type": "function",
+        "name": "repository_status",
+        "description": "Read the repository status.",
+        "parameters": {"type": "object"},
+    }
+    bedrock_calls = _install_bedrock_stub(
+        monkeypatch,
+        result=_mock_bedrock_result(
+            "",
+            raw={
+                "output": [
+                    {
+                        "type": "function_call",
+                        "id": "fc-repository-status",
+                        "call_id": "call-repository-status",
+                        "name": "repository_status",
+                        "arguments": '{"path":"."}',
+                    }
+                ]
+            },
+        ),
+    )
+
+    response = test_app.post(
+        "/v1/responses",
+        headers=headers,
+        json={
+            "model": "openai.gpt-5.6-terra",
+            "input": "Check the repository.",
+            "stream": True,
+            "tools": [tool],
+            "tool_choice": "required",
+            "reasoning": {"effort": "high"},
+        },
+    )
+
+    assert response.status_code == 200
+    payloads = [
+        json.loads(data)
+        for event, data in _response_sse_events(response.text)
+        if event and data != "[DONE]"
+    ]
+    completed = next(
+        payload["response"]
+        for payload in payloads
+        if payload["type"] == "response.completed"
+    )
+
+    assert not any(
+        payload["type"] == "response.output_text.delta" for payload in payloads
+    )
+    assert completed["output"] == [
+        {
+            "type": "function_call",
+            "id": "fc-repository-status",
+            "call_id": "call-repository-status",
+            "name": "repository_status",
+            "arguments": '{"path":"."}',
+        }
+    ]
+    assert (
+        completed["norman"]["responses_compatibility"]["tool_transport"]
+        == "bedrock_mantle_responses"
+    )
+    assert bedrock_calls[0].responses_options == {
+        "tools": [tool],
+        "tool_choice": "required",
+        "reasoning": {"effort": "high"},
+    }
+    assert local_calls == []
 
 
 def test_openai_compat_chat_completions_routes_explicit_cloud_model_for_tui(


### PR DESCRIPTION
Root cause:
Routed Control Plane Terra sessions were translated through the legacy local text-tool adapter. That flattened native tool definitions, tool outputs, and reasoning before Bedrock received the request, causing the fresh Terra parity run to complete but short-stop without repository tool calls.

Change:
- Preserve structured Responses tools, tool outputs, reasoning, and output options on the explicit Terra Bedrock path.
- Preserve typed tool-call history across Terra continuations.
- Keep the text-envelope adapter unchanged for explicit legacy local routes.
- Add non-streaming and SSE native Terra tool-chain regressions.

Validation:
- 2727 passed under CPython 3.14.7.
- Focused Bedrock/facade suite: 152 passed.
- Ruff, format, and diff checks pass.

Production is unchanged pending CI, isolated candidate validation, the public three-turn canary, and a new direct-Terra versus routed-Terra parity run.