### PR TITLE
Accept native reasoning in tool-chain canary

### DIFF
--- a/scripts/tui_tool_chain_canary.py
+++ b/scripts/tui_tool_chain_canary.py
@@ -917,7 +917,7 @@ def _require_exact_function_call_item(
         or _clean(calls[0].get("name")) != name
         or any(
             not isinstance(item, Mapping)
-            or _clean(item.get("type")) not in {"function_call", "message"}
+            or _clean(item.get("type")) not in {"function_call", "message", "reasoning"}
             for item in output
         )
     ):

--- a/tests/test_tui_tool_chain_canary.py
+++ b/tests/test_tui_tool_chain_canary.py
@@ -229,6 +229,48 @@ def test_run_canary_allows_a_status_message_after_an_expected_function_call():
     assert receipt["turns"][0]["tool_names"] == ["tool_search"]
 
 
+def test_run_canary_allows_native_reasoning_before_an_expected_function_call():
+    requests = []
+    first = _tool_response("resp-search", "tool_search", "call-search")
+    first["output"].insert(
+        0,
+        {
+            "type": "reasoning",
+            "id": "rs-private",
+            "encrypted_content": "private-reasoning",
+        },
+    )
+    responses = iter(
+        [
+            first,
+            _tool_response(
+                "resp-synthetic",
+                "mcp__norman_canary.status_lookup",
+                "call-synthetic",
+            ),
+            {
+                "id": "resp-final",
+                "status": "completed",
+                "output": [{"type": "message"}],
+                "output_text": "Synthetic status is healthy.",
+            },
+        ]
+    )
+
+    receipt = canary.run_canary(
+        endpoint="http://127.0.0.1:8000/v1/responses",
+        token="private-token",
+        pressure_guard=lambda: {"admission": {"action": "accept_new_work"}},
+        request_fn=lambda *args: requests.append(args) or (200, next(responses)),
+    )
+
+    assert receipt["state"] == "passed"
+    assert len(requests) == 3
+    assert receipt["turns"][0]["output_count"] == 2
+    assert receipt["turns"][0]["tool_names"] == ["tool_search"]
+    assert "private-reasoning" not in json.dumps(receipt, sort_keys=True)
+
+
 def test_run_canary_streaming_exercises_native_sse_tool_calls():
     requests = []
     responses = iter(


### PR DESCRIPTION
## What changed

The scheduled tool-chain canary now accepts a native Responses `reasoning` output item alongside its one expected function call and ordinary status messages.

## Why

Terra emits native reasoning items in valid structured tool-call responses. The candidate correctly emitted `tool_search`, but the canary rejected the additional reasoning item as an unexpected output type.

## Validation

- `uv run --extra dev pytest -q tests/test_tui_tool_chain_canary.py` (25 passed)
- Ruff check and format check
- `git diff --check`