### PR TITLE
Expose sanitized Mantle continuation errors

### DIFF
--- a/app/services/norllama/bedrock.py
+++ b/app/services/norllama/bedrock.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import socket
 import subprocess
@@ -23,6 +24,7 @@ BedrockClientFactory = Callable[..., Any]
 BedrockSessionFactory = Callable[..., Any]
 BedrockConfigFactory = Callable[..., Any]
 BEDROCK_MANTLE_MIN_MAX_OUTPUT_TOKENS = 16
+_SAFE_PROVIDER_ERROR_IDENTIFIER = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
 
 
 @dataclass(frozen=True, repr=False)
@@ -77,8 +79,63 @@ class BedrockMantleApiKey:
         }
 
 
+class BedrockMantleResponsesError(RuntimeError):
+    """A Mantle failure with strictly sanitized provider metadata."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        http_status: int = 0,
+        provider_error_type: str = "",
+        provider_error_code: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.http_status = _nonnegative_int(http_status)
+        self.provider_error_type = provider_error_type
+        self.provider_error_code = provider_error_code
+
+    def safe_metadata(self) -> dict[str, int | str]:
+        return {
+            key: value
+            for key, value in {
+                "http_status": self.http_status,
+                "provider_error_type": self.provider_error_type,
+                "provider_error_code": self.provider_error_code,
+            }.items()
+            if value
+        }
+
+
 def _clean(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _safe_provider_error_identifier(value: Any) -> str:
+    candidate = _clean(value)
+    if _SAFE_PROVIDER_ERROR_IDENTIFIER.fullmatch(candidate):
+        return candidate
+    return ""
+
+
+def _mantle_http_error_metadata(
+    error: urllib_error.HTTPError,
+) -> tuple[str, str]:
+    """Read only allowlisted error identifiers from a Mantle HTTP error."""
+
+    try:
+        body = error.read().decode("utf-8", errors="replace")
+        parsed = json.loads(body) if body else {}
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return "", ""
+    if not isinstance(parsed, Mapping):
+        return "", ""
+    details = parsed.get("error")
+    details = details if isinstance(details, Mapping) else parsed
+    return (
+        _safe_provider_error_identifier(details.get("type")),
+        _safe_provider_error_identifier(details.get("code")),
+    )
 
 
 def _first_env(*names: str) -> str:
@@ -1015,8 +1072,12 @@ def invoke_bedrock_mantle_responses(
         ) as response:
             raw_response = response.read().decode("utf-8", errors="replace")
     except urllib_error.HTTPError as exc:
-        raise RuntimeError(
-            f"Bedrock Mantle Responses request failed with HTTP {exc.code}"
+        provider_error_type, provider_error_code = _mantle_http_error_metadata(exc)
+        raise BedrockMantleResponsesError(
+            f"Bedrock Mantle Responses request failed with HTTP {exc.code}",
+            http_status=exc.code,
+            provider_error_type=provider_error_type,
+            provider_error_code=provider_error_code,
         ) from exc
     except (OSError, TimeoutError, urllib_error.URLError) as exc:
         raise RuntimeError("Bedrock Mantle Responses request failed") from exc

--- a/app/services/prompt_provider_facade.py
+++ b/app/services/prompt_provider_facade.py
@@ -3388,13 +3388,24 @@ def _execute_explicit_cloud_selection(
             )
         )
     except Exception as exc:
+        safe_error_metadata = getattr(exc, "safe_metadata", None)
+        safe_error_metadata = (
+            safe_error_metadata() if callable(safe_error_metadata) else {}
+        )
+        safe_error_metadata = (
+            safe_error_metadata if isinstance(safe_error_metadata, Mapping) else {}
+        )
         logger.warning(
             "Norman explicit cloud selection failed request_id=%s provider=%s "
-            "model=%s exception_class=%s",
+            "model=%s exception_class=%s http_status=%s "
+            "provider_error_type=%s provider_error_code=%s",
             invocation.invocation_id,
             plan.provider,
             plan.model,
             type(exc).__name__,
+            safe_error_metadata.get("http_status", ""),
+            safe_error_metadata.get("provider_error_type", ""),
+            safe_error_metadata.get("provider_error_code", ""),
         )
         raise _explicit_cloud_selection_error(
             plan=plan,

--- a/tests/test_console_runtime_bedrock_adapter.py
+++ b/tests/test_console_runtime_bedrock_adapter.py
@@ -741,7 +741,13 @@ def test_bedrock_adapter_sanitizes_mantle_provider_failure(monkeypatch):
     monkeypatch.setenv("NORMAN_KEYS_URL", "http://keys.norman.test")
     monkeypatch.delenv("NORMAN_SECRET_CMD", raising=False)
     mantle_key = "test-mantle-api-key"
-    provider_body = "upstream message with token=must-not-leak"
+    provider_body = {
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_function_call_output",
+            "message": "upstream message with token=must-not-leak",
+        }
+    }
 
     class Response:
         def __enter__(self):
@@ -761,17 +767,22 @@ def test_bedrock_adapter_sanitizes_mantle_provider_failure(monkeypatch):
             429,
             "provider response",
             hdrs=None,
-            fp=io.BytesIO(provider_body.encode()),
+            fp=io.BytesIO(json.dumps(provider_body).encode()),
         )
 
     monkeypatch.setattr(bedrock_module.urllib_request, "urlopen", fake_urlopen)
 
-    with pytest.raises(RuntimeError) as error:
+    with pytest.raises(bedrock_module.BedrockMantleResponsesError) as error:
         BedrockModelAdapter().invoke(_explicit_cloud_selection_request())
 
     assert str(error.value) == "Bedrock Mantle Responses request failed with HTTP 429"
     assert mantle_key not in str(error.value)
-    assert provider_body not in str(error.value)
+    assert provider_body["error"]["message"] not in str(error.value)
+    assert error.value.safe_metadata() == {
+        "http_status": 429,
+        "provider_error_type": "invalid_request_error",
+        "provider_error_code": "invalid_function_call_output",
+    }
 
 
 def test_bedrock_adapter_blocks_forged_explicit_cloud_marker_before_credentials(


### PR DESCRIPTION
Adds privacy-safe HTTP status and allowlisted provider type/code attribution for Bedrock Mantle Responses failures. This is required to diagnose the isolated Terra native function-result continuation failure without logging prompts, tool arguments, results, or provider messages.\n\nValidated: focused Bedrock/native adapter tests (20 passed), Ruff, formatting, diff check.