### PR TITLE
Expose sanitized Mantle validation parameter

### DIFF
--- a/app/services/norllama/bedrock.py
+++ b/app/services/norllama/bedrock.py
@@ -25,6 +25,7 @@ BedrockSessionFactory = Callable[..., Any]
 BedrockConfigFactory = Callable[..., Any]
 BEDROCK_MANTLE_MIN_MAX_OUTPUT_TOKENS = 16
 _SAFE_PROVIDER_ERROR_IDENTIFIER = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
+_SAFE_PROVIDER_ERROR_PARAM = re.compile(r"^[A-Za-z0-9_.:\[\]/-]{1,160}$")
 
 
 @dataclass(frozen=True, repr=False)
@@ -89,11 +90,13 @@ class BedrockMantleResponsesError(RuntimeError):
         http_status: int = 0,
         provider_error_type: str = "",
         provider_error_code: str = "",
+        provider_error_param: str = "",
     ) -> None:
         super().__init__(message)
         self.http_status = _nonnegative_int(http_status)
         self.provider_error_type = provider_error_type
         self.provider_error_code = provider_error_code
+        self.provider_error_param = provider_error_param
 
     def safe_metadata(self) -> dict[str, int | str]:
         return {
@@ -102,6 +105,7 @@ class BedrockMantleResponsesError(RuntimeError):
                 "http_status": self.http_status,
                 "provider_error_type": self.provider_error_type,
                 "provider_error_code": self.provider_error_code,
+                "provider_error_param": self.provider_error_param,
             }.items()
             if value
         }
@@ -118,23 +122,33 @@ def _safe_provider_error_identifier(value: Any) -> str:
     return ""
 
 
+def _safe_provider_error_param(value: Any) -> str:
+    """Keep only a schema-field pointer, never provider-supplied values or prose."""
+
+    candidate = _clean(value)
+    if _SAFE_PROVIDER_ERROR_PARAM.fullmatch(candidate):
+        return candidate
+    return ""
+
+
 def _mantle_http_error_metadata(
     error: urllib_error.HTTPError,
-) -> tuple[str, str]:
-    """Read only allowlisted error identifiers from a Mantle HTTP error."""
+) -> tuple[str, str, str]:
+    """Read only allowlisted error identifiers and a schema pointer."""
 
     try:
         body = error.read().decode("utf-8", errors="replace")
         parsed = json.loads(body) if body else {}
     except (OSError, UnicodeError, json.JSONDecodeError):
-        return "", ""
+        return "", "", ""
     if not isinstance(parsed, Mapping):
-        return "", ""
+        return "", "", ""
     details = parsed.get("error")
     details = details if isinstance(details, Mapping) else parsed
     return (
         _safe_provider_error_identifier(details.get("type")),
         _safe_provider_error_identifier(details.get("code")),
+        _safe_provider_error_param(details.get("param")),
     )
 
 
@@ -1072,12 +1086,17 @@ def invoke_bedrock_mantle_responses(
         ) as response:
             raw_response = response.read().decode("utf-8", errors="replace")
     except urllib_error.HTTPError as exc:
-        provider_error_type, provider_error_code = _mantle_http_error_metadata(exc)
+        (
+            provider_error_type,
+            provider_error_code,
+            provider_error_param,
+        ) = _mantle_http_error_metadata(exc)
         raise BedrockMantleResponsesError(
             f"Bedrock Mantle Responses request failed with HTTP {exc.code}",
             http_status=exc.code,
             provider_error_type=provider_error_type,
             provider_error_code=provider_error_code,
+            provider_error_param=provider_error_param,
         ) from exc
     except (OSError, TimeoutError, urllib_error.URLError) as exc:
         raise RuntimeError("Bedrock Mantle Responses request failed") from exc

--- a/app/services/prompt_provider_facade.py
+++ b/app/services/prompt_provider_facade.py
@@ -3398,7 +3398,7 @@ def _execute_explicit_cloud_selection(
         logger.warning(
             "Norman explicit cloud selection failed request_id=%s provider=%s "
             "model=%s exception_class=%s http_status=%s "
-            "provider_error_type=%s provider_error_code=%s",
+            "provider_error_type=%s provider_error_code=%s provider_error_param=%s",
             invocation.invocation_id,
             plan.provider,
             plan.model,
@@ -3406,6 +3406,7 @@ def _execute_explicit_cloud_selection(
             safe_error_metadata.get("http_status", ""),
             safe_error_metadata.get("provider_error_type", ""),
             safe_error_metadata.get("provider_error_code", ""),
+            safe_error_metadata.get("provider_error_param", ""),
         )
         raise _explicit_cloud_selection_error(
             plan=plan,

--- a/tests/test_console_runtime_bedrock_adapter.py
+++ b/tests/test_console_runtime_bedrock_adapter.py
@@ -745,6 +745,7 @@ def test_bedrock_adapter_sanitizes_mantle_provider_failure(monkeypatch):
         "error": {
             "type": "invalid_request_error",
             "code": "invalid_function_call_output",
+            "param": "input[3].content[0].call_id",
             "message": "upstream message with token=must-not-leak",
         }
     }
@@ -782,7 +783,17 @@ def test_bedrock_adapter_sanitizes_mantle_provider_failure(monkeypatch):
         "http_status": 429,
         "provider_error_type": "invalid_request_error",
         "provider_error_code": "invalid_function_call_output",
+        "provider_error_param": "input[3].content[0].call_id",
     }
+
+
+def test_bedrock_adapter_rejects_unsafe_mantle_error_param():
+    assert (
+        bedrock_module._safe_provider_error_param(
+            'input[3].content[0].call_id="secret"'
+        )
+        == ""
+    )
 
 
 def test_bedrock_adapter_blocks_forged_explicit_cloud_marker_before_credentials(


### PR DESCRIPTION
Adds a strictly allowlisted provider field pointer to Mantle validation diagnostics. Free-form provider messages, prompts, tool arguments, and values remain excluded.

This is needed to identify the rejected native Terra continuation field in the isolated candidate without exposing request content.

Validated locally: 21 focused tests, Ruff, formatter, and diff check.