### PR TITLE
Extract sanitized Mantle validation field

### DIFF
--- a/app/services/norllama/bedrock.py
+++ b/app/services/norllama/bedrock.py
@@ -26,6 +26,12 @@ BedrockConfigFactory = Callable[..., Any]
 BEDROCK_MANTLE_MIN_MAX_OUTPUT_TOKENS = 16
 _SAFE_PROVIDER_ERROR_IDENTIFIER = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
 _SAFE_PROVIDER_ERROR_PARAM = re.compile(r"^[A-Za-z0-9_.:\[\]/-]{1,160}$")
+_PROVIDER_ERROR_MESSAGE_PARAM = re.compile(
+    r"(?<![A-Za-z0-9_.:\[\]/-])"
+    r"((?:input|tools|reasoning|tool_choice|parallel_tool_calls|text|include)"
+    r"(?:\[[0-9]+\]|\.[A-Za-z_][A-Za-z0-9_]*)*)"
+    r"(?![A-Za-z0-9_.\[\]/-])"
+)
 
 
 @dataclass(frozen=True, repr=False)
@@ -131,6 +137,13 @@ def _safe_provider_error_param(value: Any) -> str:
     return ""
 
 
+def _provider_error_param_from_message(value: Any) -> str:
+    """Extract only a recognized schema path from an otherwise discarded message."""
+
+    match = _PROVIDER_ERROR_MESSAGE_PARAM.search(_clean(value))
+    return _safe_provider_error_param(match.group(1)) if match else ""
+
+
 def _mantle_http_error_metadata(
     error: urllib_error.HTTPError,
 ) -> tuple[str, str, str]:
@@ -145,10 +158,15 @@ def _mantle_http_error_metadata(
         return "", "", ""
     details = parsed.get("error")
     details = details if isinstance(details, Mapping) else parsed
+    provider_error_param = _safe_provider_error_param(details.get("param"))
+    if not provider_error_param:
+        provider_error_param = _provider_error_param_from_message(
+            details.get("message")
+        )
     return (
         _safe_provider_error_identifier(details.get("type")),
         _safe_provider_error_identifier(details.get("code")),
-        _safe_provider_error_param(details.get("param")),
+        provider_error_param,
     )
 
 

--- a/tests/test_console_runtime_bedrock_adapter.py
+++ b/tests/test_console_runtime_bedrock_adapter.py
@@ -796,6 +796,18 @@ def test_bedrock_adapter_rejects_unsafe_mantle_error_param():
     )
 
 
+def test_bedrock_adapter_extracts_only_schema_path_from_mantle_error_message():
+    assert (
+        bedrock_module._provider_error_param_from_message(
+            'Invalid value at input[3].content[0].call_id: "secret"'
+        )
+        == "input[3].content[0].call_id"
+    )
+    assert (
+        bedrock_module._provider_error_param_from_message("token=must-not-leak") == ""
+    )
+
+
 def test_bedrock_adapter_blocks_forged_explicit_cloud_marker_before_credentials(
     monkeypatch,
 ):


### PR DESCRIPTION
## What changed

Extract a strict allowlisted schema field path from Mantle validation messages when the provider omits its structured `error.param` field.

## Privacy

The bridge retains only recognized structural paths such as `input[3].type`. It discards provider messages, prompt text, tool arguments, tool output, and values.

## Why

The isolated native-Terra candidate succeeds on the first structured tool turn but receives a 400 validation error on the function-result continuation. The field pointer is required to repair the exact invalid item without guessing.

## Validation

- 22 focused Bedrock/facade tests passed
- Ruff, formatting, and `git diff --check` passed