### PR TITLE
Fail TUI canary when Terra backend drifts

### DIFF
--- a/scripts/tui_tool_chain_canary.py
+++ b/scripts/tui_tool_chain_canary.py
@@ -26,6 +26,7 @@ DEFAULT_OUTPUT_JSON = Path(
 DEFAULT_PRESSURE_GUARD = Path(__file__).with_name("tui_host_pressure_guard.py")
 DEFAULT_PRESSURE_TARGET = "work-special"
 DEFAULT_TIMEOUT_SECONDS = 45.0
+EXPECTED_BACKEND_MODEL = "openai.gpt-5.6-terra"
 DEFAULT_OPS_MCP_ENDPOINT = "https://ops.openbrand.com/mcp"
 DEFAULT_OPS_MCP_KEY_SECRET = "control-plane/ops-mcp-canary-key"
 DEFAULT_OPS_MCP_KEY_HELPER = Path(__file__).with_name("norman_ops_mcp_canary_token.py")
@@ -818,6 +819,22 @@ def _safe_bridge_receipt(response: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _require_expected_backend_model(
+    response: Mapping[str, Any],
+    *,
+    expected_model: str,
+) -> None:
+    bridge = _safe_bridge_receipt(response)
+    if not bridge:
+        raise CanaryError("missing_backend_receipt")
+    effective_backend = _mapping(bridge.get("effective_backend"))
+    actual_model = _clean(effective_backend.get("model"))
+    if not actual_model or actual_model == "unknown":
+        raise CanaryError("missing_backend_receipt")
+    if actual_model != expected_model:
+        raise CanaryError("unexpected_backend_model")
+
+
 def _function_calls(response: Mapping[str, Any]) -> list[dict[str, Any]]:
     output = response.get("output")
     if not isinstance(output, list):
@@ -1055,6 +1072,7 @@ def run_canary(
     stream_request_fn: StreamRequestFn = _post_sse,
     ops_mcp: bool = False,
     ops_direct_smoke: OpsDirectSmokeFn | None = None,
+    expected_backend_model: str = "",
 ) -> dict[str, Any]:
     started_at = time.monotonic()
     receipt: dict[str, Any] = {
@@ -1069,6 +1087,9 @@ def run_canary(
         "elapsed_ms": 0.0,
         "turns": [],
     }
+    expected_backend_model = _safe_identifier(expected_backend_model)
+    if expected_backend_model:
+        receipt["expected_backend_model"] = expected_backend_model
     pressure_state = _mapping((pressure_guard or (lambda: {}))())
     admission = _mapping(pressure_state.get("admission"))
     action = _clean(admission.get("action"))
@@ -1108,6 +1129,11 @@ def run_canary(
         receipt["turns"].append(turn_receipt)
         if turn_receipt["bridge"]:
             receipt["bridge"] = turn_receipt["bridge"]
+        if expected_backend_model:
+            _require_expected_backend_model(
+                response,
+                expected_model=expected_backend_model,
+            )
         return response
 
     try:
@@ -1328,6 +1354,7 @@ def main(argv: list[str] | None = None) -> int:
         pressure_guard=pressure_guard,
         streaming=bool(args.stream or args.ops_mcp),
         ops_mcp=bool(args.ops_mcp),
+        expected_backend_model=EXPECTED_BACKEND_MODEL,
     )
     write_receipt(args.output_json, receipt)
     print(

--- a/tests/test_tui_tool_chain_canary.py
+++ b/tests/test_tui_tool_chain_canary.py
@@ -711,6 +711,62 @@ def test_canary_receipt_exposes_only_sanitized_bridge_metadata():
     assert "private" not in json.dumps(bridge, sort_keys=True)
 
 
+def test_run_canary_requires_the_expected_effective_backend_model():
+    response = _tool_response("resp-qwen", "tool_search", "call-search")
+    response["model"] = "qwen3-coder:30b-a3b-q4_K_M"
+    response["norman"].update(
+        {
+            "route": {
+                "selected_provider": "norllama",
+                "selected_model": "qwen3-coder:30b-a3b-q4_K_M",
+            },
+            "output_token_budget": {
+                "requested": 16384,
+                "effective": 16384,
+                "maximum": 32768,
+            },
+        }
+    )
+    response["norman"]["responses_compatibility"].update(
+        {
+            "tool_bridge_mode": "transparent",
+            "tool_transport": "local_text_adapter",
+            "state_retention": "session",
+        }
+    )
+
+    receipt = canary.run_canary(
+        endpoint="https://cp.kris.openbrand.com/v1/responses",
+        token="private-token",
+        pressure_guard=lambda: {},
+        request_fn=lambda *args: (200, response),
+        expected_backend_model=canary.EXPECTED_BACKEND_MODEL,
+    )
+
+    assert receipt["state"] == "failed"
+    assert receipt["failure_kind"] == "unexpected_backend_model"
+    assert receipt["expected_backend_model"] == canary.EXPECTED_BACKEND_MODEL
+    assert receipt["turns"][0]["bridge"]["effective_backend"]["model"] == (
+        "qwen3-coder:30b-a3b-q4_K_M"
+    )
+
+
+def test_run_canary_requires_a_backend_receipt_when_the_model_is_pinned():
+    receipt = canary.run_canary(
+        endpoint="https://cp.kris.openbrand.com/v1/responses",
+        token="private-token",
+        pressure_guard=lambda: {},
+        request_fn=lambda *args: (
+            200,
+            _tool_response("resp-unattributed", "tool_search", "call-search"),
+        ),
+        expected_backend_model=canary.EXPECTED_BACKEND_MODEL,
+    )
+
+    assert receipt["state"] == "failed"
+    assert receipt["failure_kind"] == "missing_backend_receipt"
+
+
 def test_run_canary_streaming_fails_when_raw_tool_json_reaches_output_text():
     receipt = canary.run_canary(
         endpoint="https://cp.kris.openbrand.com/v1/responses",


### PR DESCRIPTION
The deployed TUI tool-chain canary now requires every response to identify openai.gpt-5.6-terra as its effective backend.

An older installed canary script requested the legacy norman-code alias and could pass against local Qwen. The candidate validation caught that mismatch, but the canary did not fail closed.

Validation: 27 focused tests, Ruff, formatting, and diff checks. The release-local Terra canary already passed the native three-turn candidate chain.