### PR TITLE
Make Control Plane Codex Apps opt-in

### DIFF
--- a/scripts/codex_route.py
+++ b/scripts/codex_route.py
@@ -140,6 +140,7 @@ class Route:
     root_paths: tuple[str, ...] = ()
     token_secret: str = ""
     managed_skill_names: tuple[str, ...] = ()
+    default_disabled_features: tuple[str, ...] = ()
 
     @property
     def profile(self) -> str:
@@ -191,6 +192,7 @@ ROUTES: tuple[Route, ...] = (
             "control-plane-gdrive-pricing-review",
             "ops-openbrand-mcp-ops",
         ),
+        default_disabled_features=("apps",),
     ),
     Route(
         key="earlybird",
@@ -318,6 +320,8 @@ OPTIONS_WITH_VALUE = frozenset(
         "--config",
         "--cd",
         "--color",
+        "--disable",
+        "--enable",
         "--model",
         "--profile",
         "--profile-v2",
@@ -428,6 +432,20 @@ def explicit_models(arguments: Sequence[str]) -> list[str]:
 
 def has_explicit_model(arguments: Sequence[str]) -> bool:
     return bool(explicit_models(arguments))
+
+
+def explicit_feature_toggles(arguments: Sequence[str]) -> set[str]:
+    features: set[str] = set()
+    for index, argument in enumerate(arguments):
+        if argument in {"--enable", "--disable"}:
+            value = _value_after(arguments, index)
+            if value:
+                features.add(value.strip().lower())
+        elif argument.startswith(("--enable=", "--disable=")):
+            value = argument.split("=", 1)[1].strip().lower()
+            if value:
+                features.add(value)
+    return features
 
 
 def config_overrides(arguments: Sequence[str]) -> list[str]:
@@ -1593,9 +1611,15 @@ def exec_work_route(route: Route, arguments: list[str]) -> None:
     environment["CODEX_REAL_BIN"] = str(resolve_real_codex())
     environment["NORMAN_TUI_NO_DIRECT_VAULT"] = "1"
     command = [environment["CODEX_REAL_BIN"]]
-    if not has_explicit_profile(arguments) and starts_session(arguments):
+    session_start = starts_session(arguments)
+    explicit_features = explicit_feature_toggles(arguments)
+    if session_start:
+        for feature in route.default_disabled_features:
+            if feature.lower() not in explicit_features:
+                command.extend(("--disable", feature))
+    if not has_explicit_profile(arguments) and session_start:
         command.extend(("--profile", route.profile))
-    if not has_explicit_model(arguments) and starts_session(arguments):
+    if not has_explicit_model(arguments) and session_start:
         command.extend(("-m", DEFAULT_ROUTER_MODEL))
     command.extend(arguments)
     os.execve(command[0], command, environment)

--- a/tests/test_codex_route.py
+++ b/tests/test_codex_route.py
@@ -177,6 +177,62 @@ def test_explicit_gateway_profile_and_model_are_not_overridden(
     assert captured["environment"]["NORMAN_TUI_NO_DIRECT_VAULT"] == "1"
 
 
+def test_control_plane_work_sessions_disable_apps_unless_explicitly_enabled(
+    route_module, monkeypatch, tmp_path
+):
+    route = route_by_key(route_module, "control-plane")
+    real_codex = tmp_path / "codex"
+    real_codex.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    real_codex.chmod(0o700)
+    captured = []
+
+    monkeypatch.setenv("CODEX_WORK_OPS_BINDING_LOADED", "1")
+    monkeypatch.setattr(route_module, "write_gateway_profile", lambda _route: tmp_path)
+    monkeypatch.setattr(route_module, "resolve_real_codex", lambda: real_codex)
+    monkeypatch.setattr(route_module, "verify_managed_tui_secret_policy", lambda: None)
+    monkeypatch.setattr(
+        route_module.os,
+        "execve",
+        lambda executable, arguments, environment: captured.append(
+            (executable, arguments, environment)
+        ),
+    )
+
+    route_module.exec_work_route(route, ["exec", "inspect the repository"])
+    route_module.exec_work_route(
+        route,
+        ["--enable", "apps", "exec", "inspect the repository"],
+    )
+
+    assert captured[0][1] == [
+        str(real_codex),
+        "--disable",
+        "apps",
+        "--profile",
+        route.profile,
+        "-m",
+        route_module.DEFAULT_ROUTER_MODEL,
+        "exec",
+        "inspect the repository",
+    ]
+    assert captured[1][1] == [
+        str(real_codex),
+        "--profile",
+        route.profile,
+        "-m",
+        route_module.DEFAULT_ROUTER_MODEL,
+        "--enable",
+        "apps",
+        "exec",
+        "inspect the repository",
+    ]
+
+
+def test_feature_toggles_do_not_confuse_route_command_detection(route_module):
+    assert route_module.command_name(["--disable", "apps", "exec", "status"]) == "exec"
+    assert route_module.starts_session(["--enable=apps", "exec", "status"])
+
+
 def test_route_environment_hides_raw_secret_configuration_from_every_tui(
     route_module, monkeypatch
 ):


### PR DESCRIPTION
Control Plane codex-work sessions now start with Codex Apps disabled unless the caller explicitly selects --enable apps.

Why: a controlled routed-Terra A/B reduced input from 121,869 to 31,383 tokens for the same read-only task when Apps were disabled, while completion remained normal and repository tool events increased from one to two. The two scoped Control Plane skills and Ops MCP binding remain available.

Validation: full Python 3.14 suite (2,735 passed before rebase); focused route suite (104 passed on the rebased head); Ruff, formatter, and diff checks.