### PR TITLE
Start regular Codex outside mapped work routes

### DIFF
--- a/scripts/codex_route.py
+++ b/scripts/codex_route.py
@@ -1084,7 +1084,7 @@ def route_payload(route: Route | None, launcher: str, cwd: Path) -> dict[str, ob
             "launcher": launcher,
             "checkout_root": str(root),
             "origin": origin,
-            "fallback": "regular-default" if launcher == "regular" else "work-bedrock",
+            "fallback": "regular-default",
         }
     payload = asdict(route)
     payload.update(
@@ -1660,18 +1660,6 @@ def exec_regular_fallback(arguments: list[str]) -> None:
     os.execve(real_codex, command, environment)
 
 
-def exec_work_fallback(reenter: str, arguments: list[str]) -> None:
-    if not reenter:
-        raise RuntimeError("Work fallback requires the original codex-work launcher.")
-    reentry_path = Path(reenter).expanduser().resolve()
-    if not reentry_path.is_file() or not os.access(reentry_path, os.X_OK):
-        raise RuntimeError(f"Work fallback launcher is not executable: {reentry_path}")
-    environment = os.environ.copy()
-    environment["CODEX_ROUTER_RESOLVED"] = "1"
-    environment["CODEX_REAL_BIN"] = str(resolve_real_codex())
-    os.execve(str(reentry_path), [str(reentry_path), *arguments], environment)
-
-
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Route Codex through the checkout's TUI Responses gateway."
@@ -1781,8 +1769,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             exec_regular_route(route, parsed.codex_args)
         return 0
 
-    if parsed.launcher == "work":
-        exec_work_fallback(parsed.reenter, parsed.codex_args)
+    if parsed.launcher == "work" and starts_session(parsed.codex_args):
+        print(
+            "codex-work: no mapped Norman work route for "
+            f"{cwd}; starting regular Codex.",
+            file=sys.stderr,
+        )
     exec_regular_fallback(parsed.codex_args)
     return 0
 

--- a/tests/test_codex_route.py
+++ b/tests/test_codex_route.py
@@ -121,7 +121,7 @@ def test_unmapped_checkout_has_the_expected_generic_fallback(route_module, monke
         "regular-default"
     )
     assert route_module.route_payload(None, "work", unknown_root)["fallback"] == (
-        "work-bedrock"
+        "regular-default"
     )
 
 
@@ -752,14 +752,29 @@ def test_every_route_generates_an_isolated_brokered_gateway_profile(
     assert profile_path.stat().st_mode & 0o777 == 0o600
 
 
-def test_regular_and_work_fallbacks_execute_the_expected_targets(
+def test_unmapped_work_session_uses_regular_codex_without_reentering_wrapper(
+    route_module, monkeypatch, capsys
+):
+    fallback_calls = []
+
+    monkeypatch.setattr(route_module, "resolve_route", lambda _cwd: None)
+    monkeypatch.setattr(
+        route_module,
+        "exec_regular_fallback",
+        lambda arguments: fallback_calls.append(arguments),
+    )
+
+    assert route_module.main(["--launcher", "work", "--reenter", "/missing", "--"]) == 0
+    assert fallback_calls == [[]]
+    assert "no mapped Norman work route" in capsys.readouterr().err
+
+
+def test_regular_fallback_executes_the_real_codex_binary(
     route_module, monkeypatch, tmp_path
 ):
     real_codex = tmp_path / "real-codex"
-    reentry = tmp_path / "codex-work"
-    for path in (real_codex, reentry):
-        path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
-        path.chmod(0o700)
+    real_codex.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    real_codex.chmod(0o700)
     captured = []
 
     monkeypatch.setattr(route_module, "resolve_real_codex", lambda: real_codex)
@@ -772,14 +787,9 @@ def test_regular_and_work_fallbacks_execute_the_expected_targets(
     )
 
     route_module.exec_regular_fallback(["--version"])
-    route_module.exec_work_fallback(str(reentry), ["--version"])
 
     assert captured[0][0] == str(real_codex)
     assert captured[0][1] == [str(real_codex), "--version"]
-    assert captured[1][0] == str(reentry)
-    assert captured[1][1] == [str(reentry), "--version"]
-    assert captured[1][2]["CODEX_ROUTER_RESOLVED"] == "1"
-    assert captured[1][2]["CODEX_REAL_BIN"] == str(real_codex)
 
 
 def test_mapped_route_verify_checks_models_then_local_capacity_once(


### PR DESCRIPTION
Fixes the silent codex-work exit from directories with no Norman specialty route, such as ~/code. The router previously re-entered the Control Plane work wrapper, which attempted an Ops MCP secret binding and exited under set -e without output. Unmapped sessions now emit a clear fallback notice and launch regular Codex directly; mapped routes are unchanged.\n\nValidated with 105 route tests, Ruff, formatting, diff checks, and an installed-wrapper smoke test from ~/code using a harmless real-Codex stand-in.